### PR TITLE
feat(streaming): add size limit functionality for recording sessions

### DIFF
--- a/src/main/kotlin/github/rikacelery/Main.kt
+++ b/src/main/kotlin/github/rikacelery/Main.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.internal.synchronized
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.apache.commons.cli.*
@@ -119,6 +120,7 @@ fun main(vararg args: String): Unit = runBlocking {
         val url = match.groupValues[2]
         val quality = extract(match.groupValues[3], "q:(\\S+)".toRegex(), "720p")
         val timeLimit = extract(match.groupValues[3], "limit:(\\d+)".toRegex(), "0")
+        val sizeLimit = extract(match.groupValues[3], "size:(\\S+)".toRegex(), "0")
         val autopay = extract(match.groupValues[3], "(autopay)".toRegex(), "") == "autopay"
         rootLogger.info("loads: ${if (active) "[active]" else "[      ]"} quality:$quality limit:$timeLimit${if (autopay) " autopay " else " "}url:$url")
         async {
@@ -129,8 +131,9 @@ fun main(vararg args: String): Unit = runBlocking {
                 return@async null
             }
             if (timeLimit.toLong() > 0) {
-                room.limit = timeLimit.toLong().seconds
+                room.timeLimit = timeLimit.toLong().seconds
             }
+            room.sizeLimit = Json.decodeFromString(SizeStrSerializer,"\"$sizeLimit\"")
             room.autoPay = autopay
             rootLogger.info("Got new room {}.", room)
             room to active
@@ -195,6 +198,7 @@ fun main(vararg args: String): Unit = runBlocking {
                 val active = call.request.queryParameters["active"].toBoolean()
                 val slug = call.request.queryParameters["slug"]
                 val limit = call.request.queryParameters["limit"]?.toLongOrNull() ?: 0L
+                val sizeLimit = call.request.queryParameters["size"]?.toLongOrNull() ?: 0L
                 if (slug == null) {
                     call.respond(HttpStatusCode.NotAcceptable, "slug not provided.")
                     return@get
@@ -215,8 +219,9 @@ fun main(vararg args: String): Unit = runBlocking {
                     return@get
                 }
                 if (limit > 0) {
-                    room.limit = limit.seconds
+                    room.timeLimit = limit.seconds
                 }
+                room.sizeLimit = sizeLimit
                 println(room)
                 scheduler.add(room, active)
                 saveJobFile(jobFile, scheduler)
@@ -326,7 +331,33 @@ fun main(vararg args: String): Unit = runBlocking {
                     call.respond(HttpStatusCode.NotAcceptable, "Room $slug not found.")
                     return@get
                 }
-                room.limit = if (limit == 0L) Duration.INFINITE else limit.seconds
+                room.timeLimit = if (limit == 0L) Duration.INFINITE else limit.seconds
+                saveJobFile(jobFile, scheduler)
+                call.respond(room)
+            }
+            get("/sizelimit") {
+                val slug = call.request.queryParameters["slug"]
+                if (slug == null) {
+                    call.respond(HttpStatusCode.NotAcceptable, "slug not provided.")
+                    return@get
+                }
+                val sizelimit = call.request.queryParameters["size"]
+                if (sizelimit == null) {
+                    call.respond(HttpStatusCode.NotAcceptable, "size not provided.")
+                    return@get
+                }
+                val sizeLong = try {
+                    Json.decodeFromString(SizeStrSerializer, JsonPrimitive(sizelimit).toString())
+                } catch (e: Exception) {
+                    call.respond(HttpStatusCode.NotAcceptable, "size not valid.")
+                    throw e
+                }
+                val room = scheduler.sessions.keys.find { it.room.name.equals(slug, true) }?.room
+                if (room == null) {
+                    call.respond(HttpStatusCode.NotAcceptable, "Room $slug not found.")
+                    return@get
+                }
+                room.sizeLimit = sizeLong
                 saveJobFile(jobFile, scheduler)
                 call.respond(room)
             }
@@ -351,7 +382,7 @@ fun main(vararg args: String): Unit = runBlocking {
                             state.room.name,
                             state.room.id.toString(),
                             state.room.quality,
-                            if (state.room.limit.isFinite()) state.room.limit.inWholeSeconds.toString() else "0",
+                            if (state.room.timeLimit.isFinite()) state.room.timeLimit.inWholeSeconds.toString() else "0",
                         )
                     }
                 }.awaitAll()
@@ -426,10 +457,6 @@ fun main(vararg args: String): Unit = runBlocking {
                 engine?.stop()
             }
             get("/stop-server") {
-                if(scheduler.gracefulStop) {
-                    call.respond(HttpStatusCode.NotAcceptable, "Already graceful stopping.")
-                    return@get
-                }
 //                sc.cancel()
                 val sessions = scheduler.sessions.filter { it.value.isActive }
                 val latch = AtomicInteger(sessions.size)
@@ -487,7 +514,8 @@ private fun saveJobFile(jobFile: File, scheduler: Scheduler) {
     synchronized(jobFile) {
         jobFile.writeText(scheduler.sessions.keys.joinToString("\n") {
             "${if (it.listen) "" else "#"}https://$HOST/${it.room.name} q:${it.room.quality} " +
-                    (if (it.room.limit.isFinite()) " limit:${it.room.limit.inWholeSeconds} " else " ") +
+                    (if (it.room.timeLimit.isFinite()) " limit:${it.room.timeLimit.inWholeSeconds} " else " ") +
+                    (if (it.room.sizeLimit!=0L) " size:${Json.encodeToString(SizeStrSerializer,it.room.sizeLimit).removeSurrounding("")} " else " ") +
                     (if (it.room.autoPay) " autopay " else " ")
         })
     }

--- a/src/main/kotlin/github/rikacelery/Room.kt
+++ b/src/main/kotlin/github/rikacelery/Room.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlin.time.Duration
@@ -16,10 +17,15 @@ data class Room(
     var quality: String,
     //config
     @Serializable(with = DurationMillisSerializer::class)
-    var limit: Duration = Duration.INFINITE,
+    var timeLimit: Duration = Duration.INFINITE,
+    @Serializable(with = SizeStrSerializer::class)
+//    1000 -> KB
+//    1G200M -> 1200000000
+//    120000000 -> 120M
+    var sizeLimit: Long = 0,
     val lastSeen: String? = null,
     var autoPay: Boolean = false,
-    )
+)
 
 object DurationMillisSerializer : KSerializer<Duration> {
     override val descriptor = PrimitiveSerialDescriptor("DurationMillis", PrimitiveKind.LONG)
@@ -35,5 +41,183 @@ object DurationMillisSerializer : KSerializer<Duration> {
     override fun deserialize(decoder: Decoder): Duration {
         val millis = decoder.decodeLong()
         return if (millis == 0L) Duration.INFINITE else millis.milliseconds
+    }
+}
+
+object SizeStrSerializer : KSerializer<Long> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("SizeStr", PrimitiveKind.STRING)
+
+    // 定义单位映射
+    // 包含二进制 (1024) 和 十进制 (1000) 以便反序列化时兼容
+    // 注意：'B' 和 'Bi' 都代表字节基数，但为了输出统一，我们主要使用带 'i' 的二进制单位作为标准输出
+    private val binaryUnits = listOf(
+        Triple('T', "Ti", (1L shl 40)), // 1024^4
+        Triple('G', "Gi", (1L shl 30)), // 1024^3
+        Triple('M', "Mi", (1L shl 20)), // 1024^2
+        Triple('K', "Ki", (1L shl 10)), // 1024^1
+        Triple('B', "Bi", 1L)    // 1024^0
+    )
+
+    // 十进制单位用于兼容解析 (如用户输入 "1G" 而不是 "1Gi")
+    private val decimalUnits = listOf(
+        'T' to 1_000_000_000_000L,
+        'G' to 1_000_000_000L,
+        'M' to 1_000_000L,
+        'K' to 1_000L,
+        'B' to 1L
+    )
+
+    // 构建解析用的 Map：支持 "Ti", "Gi", "T", "G" 等所有后缀
+    private val parseUnitMap: Map<String, Long> = buildMap {
+        // 添加二进制单位 (Ti, Gi...)
+        for ((short, longName, value) in binaryUnits) {
+            put(longName, value) // "Ti" -> value
+            if (short != 'B') {
+                put(short.toString(), value) // "T" -> value (兼容写法，视为二进制或近似)
+            } else {
+                put("B", value) // "B" -> 1
+            }
+        }
+        // 注意：如果用户输入 "1G"，上面已经映射为 1024^3。
+        // 如果严格需要区分 "1G"(1000) 和 "1Gi"(1024)，我们需要更复杂的解析逻辑。
+        // 通常在实际工程中，不带 'i' 的单位常被混用。
+        // 为了严格满足你之前 "1G200M -> 1200000000" (十进制) 的需求，
+        // 我们需要在解析时优先匹配长后缀 ("Gi"), 如果只有短后缀 ("G")，
+        // 这里存在歧义。
+
+        // 【修正策略】：
+        // 为了同时满足你之前的十进制例子和现在的二进制需求：
+        // 1. 显式带 'i' 的 (Ti, Gi...) -> 1024 进制
+        // 2. 不带 'i' 的 (T, G, M, K, B) -> 1000 进制 (保留你之前的行为)
+        // 3. 纯数字 -> Bytes
+
+        clear() // 清空重建
+
+        // 1. 注册二进制 (高优先级，因为后缀更长)
+        binaryUnits.forEach { (_, longName, value) ->
+            put(longName, value)
+        }
+
+        // 2. 注册十进制 (短后缀)
+        // 注意：'B' 和 'Bi' 冲突处理。如果输入 "100Bi" 走上面，"100B" 走下面。
+        decimalUnits.forEach { (char, value) ->
+            val key = char.toString()
+            // 只有当该key没有被二进制占用时才放入，或者强制覆盖？
+            // "B" 在二进制里也是 1，在十进制里也是 1，没冲突。
+            // "K" vs "Ki": 不同。
+            put(key, value)
+        }
+    }
+
+    private val serializeUnits = listOf(
+        "Ti" to (1L shl 40),
+        "Gi" to (1L shl 30),
+        "Mi" to (1L shl 20),
+        "Ki" to (1L shl 10),
+        "Bi" to 1L
+    )
+
+    override fun serialize(encoder: Encoder, value: Long) {
+        if (value <= 0) {
+            encoder.encodeString("0Bi")
+            return
+        }
+
+        val result1 = run{
+            var remaining = value
+            val result = StringBuilder()
+
+            for ((unitName, divisor) in serializeUnits) {
+                if (remaining >= divisor) {
+                    val count = remaining / divisor
+                    result.append(count).append(unitName)
+                    remaining %= divisor
+                }
+            }
+            result
+        }.toString()
+        val result2 = run{
+            var remaining = value
+            val result = StringBuilder()
+
+            for ((unitName, divisor) in decimalUnits) {
+                if (remaining >= divisor) {
+                    val count = remaining / divisor
+                    result.append(count).append(unitName)
+                    remaining %= divisor
+                }
+            }
+            result
+        }.toString()
+
+        encoder.encodeString(if (result1.length<result2.length) result1 else result2)
+    }
+
+    override fun deserialize(decoder: Decoder): Long {
+        val input = decoder.decodeString().trim()
+        // 统一转为大写处理，但要注意 "i" 是小写，所以转大写后 "Gi" -> "GI"
+        // 我们的 Map 需要适配大小写不敏感，或者输入规范大小写。
+        // 为了健壮性，我们在解析时做大小写归一化。
+
+        val normalizedInput = input.uppercase() // "1Gi" -> "1GI", "1G" -> "1G"
+
+        // 重新构建一个全大写的查找表用于解析
+        val upperCaseUnitMap = parseUnitMap.mapKeys { it.key.uppercase() }
+
+        // 1. 尝试纯数字
+        return input.toLongOrNull() ?: parseComplexSize(normalizedInput, upperCaseUnitMap)
+    }
+
+    private fun parseComplexSize(input: String, unitMap: Map<String, Long>): Long {
+        var totalBytes = 0L
+        var currentNumber = ""
+
+        // 由于输入可能包含 "GI" (来自 Gi) 或 "G"，我们需要贪心匹配最长的单位后缀
+        // 但简单的逐字符扫描很难处理双字符单位。
+        // 策略：遍历字符串，如果是数字则累积；如果是字母，则尝试匹配单位。
+
+        val keys = unitMap.keys.sortedByDescending { it.length } // 优先匹配长的 "GI" 而不是 "G"
+
+        var i = 0
+        while (i < input.length) {
+            val char = input[i]
+
+            if (char.isDigit()) {
+                currentNumber += char
+                i++
+            } else if (char.isLetter()) {
+                // 尝试从当前位置匹配一个单位
+                var matched = false
+                for (key in keys) {
+                    if (input.startsWith(key, i)) {
+                        if (currentNumber.isEmpty()) {
+                            throw IllegalArgumentException("Missing number before unit '$key' at pos $i in $input")
+                        }
+                        val value = currentNumber.toLongOrNull()
+                            ?: throw IllegalArgumentException("Invalid number '$currentNumber'")
+
+                        totalBytes += value * unitMap[key]!!
+                        currentNumber = ""
+                        i += key.length
+                        matched = true
+                        break
+                    }
+                }
+
+                if (!matched) {
+                    throw IllegalArgumentException("Unknown unit starting at character '${input[i]}' in $input")
+                }
+            } else if (char.isWhitespace()) {
+                i++ // 跳过空格
+            } else {
+                throw IllegalArgumentException("Invalid character '$char' in $input")
+            }
+        }
+
+        if (currentNumber.isNotEmpty()) {
+            throw IllegalArgumentException("Trailing number without unit: $currentNumber")
+        }
+
+        return totalBytes
     }
 }

--- a/src/main/kotlin/github/rikacelery/utils/Writer.kt
+++ b/src/main/kotlin/github/rikacelery/utils/Writer.kt
@@ -11,6 +11,7 @@ class Writer(private val name: String, private val destFolder: String, private v
     private lateinit var bufferedWriter: BufferedOutputStream
     private lateinit var timeStarted: Date
     private var isInit = false
+    private var total = 0L
     private val ext = "mp4"
 
 
@@ -18,6 +19,7 @@ class Writer(private val name: String, private val destFolder: String, private v
         timeStarted = Date()
         file = File(tmpfolder, "${name}-${formatedStartTime()}-init.${ext}")
         bufferedWriter = file.outputStream().buffered()
+        total = 0L
         isInit = true
         if (File(tmpfolder).exists().not()) {
             File(tmpfolder).mkdirs()
@@ -39,9 +41,11 @@ class Writer(private val name: String, private val destFolder: String, private v
         }
     }
 
-    fun append(data: ByteArray) {
+    fun append(data: ByteArray): Long {
         if (!isInit) throw Exception("Writer not initialized yet.")
         bufferedWriter.write(data)
+        total+=data.size
+        return total
     }
 
     fun appendEvent(data: JsonObject) {
@@ -66,7 +70,10 @@ class Writer(private val name: String, private val destFolder: String, private v
     }
 
     fun dispose() {
+        if (!isInit) return
+        isInit = false
         bufferedWriter.close()
         file.delete()
+        file.parentFile.resolve(file.nameWithoutExtension + ".event").delete()
     }
 }

--- a/src/main/kotlin/github/rikacelery/v2/Session.kt
+++ b/src/main/kotlin/github/rikacelery/v2/Session.kt
@@ -65,6 +65,7 @@ class Session(
         private val logger = LoggerFactory.getLogger(Session::class.java)
     }
 
+    private var shouldStop = false
     private val scope =
         CoroutineScope(dispatcher + SupervisorJob() + CoroutineExceptionHandler { coroutineContext, throwable ->
             logger.error("Exception in {}", coroutineContext, throwable)
@@ -252,9 +253,9 @@ class Session(
 //        roomid_480p_h265_SEGMENTID_XXXXXXXXXXX_timestamp.mp4 transcended stream
 //        roomid_SEGMENTID_XXXXXXXXXXX_timestamp.mp4 raw stream
         val parts = url.substringAfterLast("/").split("_")
-        if (parts.size==6)
+        if (parts.size == 6)
             return parts[3].toIntOrNull()
-        else if (parts.size==4)
+        else if (parts.size == 4)
             return parts[1].toIntOrNull()
         return null
     }
@@ -272,14 +273,14 @@ class Session(
             room.quality,
             status
         )
-
-        val writer = Writer(room.name, dest, tmp).apply { init() }
-        writerReference.set(writer)
+        shouldStop = false
+        writerReference.set(Writer(room.name, dest, tmp).apply { init() })
         val counter = createDiscontinuityCounter()
         metric = Metric.newMetric(room.id, room.name)
 
         try {
             generatorJob = scope.launch {
+                var lastInitSegment = byteArrayOf()
                 segmentGenerator()
                     .map { event ->
                         if (event is Event.CmdFinish) {
@@ -345,14 +346,16 @@ class Session(
                             result.first::class.simpleName,
                             result.first.url()
                         )
+                        val writer = writerReference.get()
+                        if (writer == null) return@collect
                         when (result.first) {
                             is Event.WSEvent -> {
-                                writerReference.get()!!.appendEvent((result.first as Event.WSEvent).data)
+                                writer.appendEvent((result.first as Event.WSEvent).data)
                             }
 
                             is Event.CmdFinish -> {
                                 try {
-                                    val file = writerReference.get()!!.done()
+                                    val file = writer.done()
                                     requireNotNull(file)
                                     scope.launch(NonCancellable) {
                                         runCatching {
@@ -378,8 +381,42 @@ class Session(
                                 metric.doneIncrement()
                                 if (bytes.isSuccess) {
                                     val data = bytes.getOrThrow()
+                                    if (result.first is Event.LiveSegmentInit)
+                                        lastInitSegment = data
                                     metric.bytesWriteIncrement(data.size.toLong())
-                                    writerReference.get()?.append(data)
+                                    writerReference.get()?.let { writer ->
+                                        val total = writer.append(data)
+                                        if (room.sizeLimit != 0L && total >= room.sizeLimit) {
+                                            try {
+                                                val file = writer.done()
+                                                requireNotNull(file)
+                                                scope.launch(NonCancellable) {
+                                                    runCatching {
+                                                        PostProcessor.process(
+                                                            file.first,
+                                                            ProcessorCtx(
+                                                                room,
+                                                                file.second,
+                                                                Date(),
+                                                                file.third,
+                                                                currentQuality
+                                                            )
+                                                        )
+                                                    }.onFailure {
+                                                        logger.error("[{}] Postprocess failed", room.name, it)
+                                                    }
+                                                }
+
+                                            } catch (e: Exception) {
+                                                logger.error("[${room.name}] Failed to postprocess", e)
+                                            } finally {
+                                                writer.init()
+                                                writer.append(lastInitSegment)
+                                                metric.reset()
+                                            }
+
+                                        }
+                                    }
                                 } else {
                                     metric.failedIncrement()
                                 }
@@ -467,7 +504,7 @@ class Session(
                 send(Event.WSEvent(it))
             }
         }
-        while (currentCoroutineContext().isActive) {
+        while (currentCoroutineContext().isActive && !shouldStop) {
             retry++
             try {
                 val lines = withTimeout(5_000) {
@@ -547,7 +584,10 @@ class Session(
                 }
                 for (url in segmentUrls) {
                     // record time limit
-                    if (System.currentTimeMillis() - startTime > room.limit.inWholeMilliseconds && !cache.contains(url)) {
+                    if (System.currentTimeMillis() - startTime > room.timeLimit.inWholeMilliseconds && !cache.contains(
+                            url
+                        )
+                    ) {
                         send(Event.CmdFinish())
                         // reset state
                         initSent = false

--- a/src/main/resources/vue.html
+++ b/src/main/resources/vue.html
@@ -165,7 +165,12 @@
                 <div class="relative flex items-center">
                     <i class="fa-regular fa-clock absolute left-3 text-slate-400"></i>
                     <input v-model.number="timeLimit" type="number" min="0" placeholder="Limit"
-                        class="pl-9 pr-2 py-1.5 text-sm bg-white border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 w-24 transition-all">
+                           class="pl-9 pr-2 py-1.5 text-sm bg-white border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 w-24 transition-all">
+                </div>
+                <div class="relative flex items-center">
+                    <i class="fa-regular fa-clock absolute left-3 text-slate-400"></i>
+                    <input v-model="sizeLimit" type="text"  placeholder="Size"
+                           class="pl-9 pr-2 py-1.5 text-sm bg-white border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 w-24 transition-all">
                 </div>
 
                 <select v-model="addQuality"
@@ -223,6 +228,11 @@
                                 @click="sortToggle('Limit')">
                                 Time Limit <i class="fa-solid ml-1"
                                     :class="!sort['Limit'] ? 'fa-sort text-slate-300' : (sort['Limit'] === 1 ? 'fa-sort-down text-indigo-500' : 'fa-sort-up text-indigo-500')"></i>
+                            </th>
+                            <th class="px-4 py-3 cursor-pointer hover:bg-slate-100 transition-colors select-none"
+                                @click="sortToggle('SizeLimit')">
+                                Size Limit <i class="fa-solid ml-1"
+                                    :class="!sort['SizeLimit'] ? 'fa-sort text-slate-300' : (sort['SizeLimit'] === 1 ? 'fa-sort-down text-indigo-500' : 'fa-sort-up text-indigo-500')"></i>
                             </th>
                             <th class="px-4 py-3 cursor-pointer hover:bg-slate-100 transition-colors select-none"
                                 @click="sortToggle('Status')">
@@ -287,13 +297,27 @@
                             </td>
                             <td class="px-4 py-3">
                                 <div class="flex items-center gap-2">
-                                    <span class="text-slate-500 text-right">{{room.limit}}</span>
+                                    <span class="text-slate-500 text-right">{{room.timeLimit}}</span>
                                     <i class="fa-solid fa-arrow-right-long text-slate-300 text-xs"></i>
                                     <input v-model.number="editLimits[room.name]" type="number" min="0"
                                         :style="{ width: Math.max(6, String(editLimits[room.name] || '').length + 3) + 'ch' }"
                                         class="px-2 py-1 text-xs border border-slate-200 rounded bg-white focus:outline-none focus:border-indigo-500"
                                         placeholder="New">
                                     <button @click="setLimit(room.name)" title="Apply Limit"
+                                        class="text-emerald-600 hover:text-emerald-800 transition-colors p-1">
+                                        <i class="fa-solid fa-check"></i>
+                                    </button>
+                                </div>
+                            </td>
+                            <td class="px-4 py-3">
+                                <div class="flex items-center gap-2">
+                                    <span class="text-slate-500 text-right">{{room.sizeLimit}}</span>
+                                    <i class="fa-solid fa-arrow-right-long text-slate-300 text-xs"></i>
+                                    <input v-model="editSizeLimits[room.name]" type="text"
+                                        :style="{ width: Math.max(6, String(editSizeLimits[room.name] || '').length + 3) + 'ch' }"
+                                        class="px-2 py-1 text-xs border border-slate-200 rounded bg-white focus:outline-none focus:border-indigo-500"
+                                        placeholder="New">
+                                    <button @click="setSizeLimit(room.name)" title="Apply Limit"
                                         class="text-emerald-600 hover:text-emerald-800 transition-colors p-1">
                                         <i class="fa-solid fa-check"></i>
                                     </button>
@@ -419,6 +443,7 @@
                     sort: { "Room": 1, "Status": 1 },
                     roomInfo: {},
                     editLimits: {}, // Cache for limits inputs to prevent overlap with polling
+                    editSizeLimits: {}, // Cache for size limits inputs to prevent overlap with polling
                     allUrls: [],
                     snapshotcache: {},
                 }
@@ -511,6 +536,18 @@
                     }
                     try {
                         const r1 = await fetch(`${HOST}/limit?slug=${roomName}&limit=${newLimit}`);
+                        this.showToast(await r1.text());
+                        this.editLimits[roomName] = null; // Clear input after success
+                    } catch (e) { this.showToast("Network Error", "error"); }
+                },
+                async setSizeLimit(roomName) {
+                    const newLimit = this.editSizeLimits[roomName];
+                    if (newLimit === undefined || newLimit === null || newLimit < 0) {
+                        this.showToast(`Invalid limit value`, "error");
+                        return;
+                    }
+                    try {
+                        const r1 = await fetch(`${HOST}/sizelimit?slug=${roomName}&size=${newLimit}`);
                         this.showToast(await r1.text());
                         this.editLimits[roomName] = null; // Clear input after success
                     } catch (e) { this.showToast("Network Error", "error"); }


### PR DESCRIPTION
- Add sizeLimit parameter parsing from URL and API requests
- Implement SizeStrSerializer for handling size units (KB, MB, GB, etc.)
- Integrate size limit checking during stream recording process
- Add size limit display and editing in the web UI
- Create new /sizelimit endpoint for updating room size limits
- Modify Room model to include sizeLimit property alongside timeLimit
- Update Writer utility to track and enforce size-based recording limits
- Add size limit validation and error handling throughout the pipeline
- Include size limit in job file persistence and API responses
- Add stop condition based on size limit in addition to time limit
- close #36 