### PR TITLE
feat(v3): parse master playlist for quality selection, add "highest" …

### DIFF
--- a/extension/popup.js
+++ b/extension/popup.js
@@ -136,7 +136,7 @@ let pathname = tab.url
   ]));
 
   // quality rows
-  const qRow1 = ["raw", "1080p60", "720p60", "720p"];
+  const qRow1 = ["highest", "1080p60", "720p60", "720p"];
   const qRow2 = ["480p", "240p", "160p"];
   for (const qs of [qRow1, qRow2]) {
     main.appendChild(mkRow(qs.map(q =>

--- a/extension/xhrec-panel.user.js
+++ b/extension/xhrec-panel.user.js
@@ -178,8 +178,8 @@
     actRemove, actActivate, actDeactivate,
   ]));
 
-  panel.appendChild(mkRow(["Q:raw", "Q:1080p60", "Q:720p60", "Q:720p"], [
-    () => actQuality("raw"), () => actQuality("1080p60"),
+  panel.appendChild(mkRow(["Q:highest", "Q:1080p60", "Q:720p60", "Q:720p"], [
+    () => actQuality("highest"), () => actQuality("1080p60"),
     () => actQuality("720p60"), () => actQuality("720p"),
   ]));
   panel.appendChild(mkRow(["Q:540p","Q:480p", "Q:240p", "Q:160p"], [

--- a/src/main/kotlin/github/rikacelery/v3/bootstrap/Bootstrap.kt
+++ b/src/main/kotlin/github/rikacelery/v3/bootstrap/Bootstrap.kt
@@ -131,7 +131,7 @@ class Bootstrap(
         obj["output"]?.jsonPrimitive?.content?.let { File(it) } ?: fallback
 
     data class ListConfLine(
-        val url: String, val quality: String = "720p",
+        val url: String, val quality: String = "highest",
         val timeLimit: Long = 0, val sizeLimit: Long = 0, val autoPay: Boolean = false, val pkey: String = "",
         val armed: Boolean
     )
@@ -180,7 +180,7 @@ class Bootstrap(
         val parts = line.trim().split(" ")
         if (parts.isEmpty()) return null
         val url = parts[0]
-        var quality = "720p"
+        var quality = "highest"
         var timeLimit = 0L
         var sizeLimit = 0L
         var autoPay = false

--- a/src/main/kotlin/github/rikacelery/v3/components/ConfigComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/ConfigComponent.kt
@@ -82,6 +82,11 @@ class ConfigComponent(
     private suspend fun handleQuery(env: CommandEnvelope) {
         val ack = when (env.command) {
             is GetDecryptKey -> ConfigResponse(persistedDecryptKeys[env.command.keyName])
+            is MatchDecryptKeys -> {
+                val found = env.command.keys.firstOrNull { persistedDecryptKeys.containsKey(it) }
+                if (found != null) DecryptKeyMatch(found, persistedDecryptKeys[found]!!)
+                else DecryptKeyMatch("", "")
+            }
             else -> return
         }
         eventBus.publish(CommandAck(env.id, ack))

--- a/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
@@ -79,7 +79,7 @@ class HttpServerComponent(
                 get("/add") {
                     val name = call.request.queryParameters["name"] ?: ""
                     if (name.isBlank()) return@get call.respondText("Missing name", status = HttpStatusCode.BadRequest)
-                    val quality = call.request.queryParameters["quality"] ?: "720p"
+                    val quality = call.request.queryParameters["quality"] ?: "highest"
                     val active = call.request.queryParameters["active"]?.toBooleanStrictOrNull() ?: false
                     val limit = call.request.queryParameters["limit"]?.toLongOrNull() ?: 0L
                     val autopay = call.request.queryParameters["autopay"]?.toBooleanStrictOrNull() ?: false
@@ -213,7 +213,7 @@ class HttpServerComponent(
                         "Missing id",
                         status = HttpStatusCode.BadRequest
                     )
-                    val q = call.request.queryParameters["q"] ?: "720p"
+                    val q = call.request.queryParameters["q"] ?: "highest"
                     requestBus.request<OkResponse>(SetRoomQuality(id, q))
                     persistConfig()
                     call.respondText("Quality set to $q")
@@ -320,6 +320,7 @@ class HttpServerComponent(
                                             else -> s?.state?.name ?: ""
                                         })
                                         put("active", s?.state == SessionState.Recording)
+                                        put("quality", s?.quality ?: "")
                                     })
                                     put("listening", s != null || isArmed)
                                     put("room", buildJsonObject {

--- a/src/main/kotlin/github/rikacelery/v3/components/LiveEventSource.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/LiveEventSource.kt
@@ -2,13 +2,15 @@ package github.rikacelery.v3.components
 
 import github.rikacelery.v3.core.Actor
 import github.rikacelery.v3.core.EventBus
-import github.rikacelery.v3.events.*
+import github.rikacelery.v3.events.LiveMessage
+import github.rikacelery.v3.events.RecordingStarted
+import github.rikacelery.v3.events.RecordingStopped
+import github.rikacelery.v3.events.RoomStatusChanged
 import io.ktor.client.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.websocket.*
 import kotlinx.coroutines.*
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import java.util.concurrent.ConcurrentHashMap
@@ -93,7 +95,7 @@ class LiveEventSource(
                 throw e
             } catch (e: Exception) {
                 wsSession = null
-                logger.error("WS error: ${e.message}, reconnecting in ${backoff.inWholeMilliseconds}ms")
+//                logger.error("WS error: ${e.message}, reconnecting in ${backoff.inWholeMilliseconds}ms")
                 delay(backoff)
                 backoff = minOf(backoff.inWholeSeconds * 2, 30).seconds
             }
@@ -154,16 +156,6 @@ class LiveEventSource(
                     logger.debug("WS event: type={}, roomId={}, status={}", type, roomId, status)
                     roomStatuses[roomId] = status
                     eventBus.publish(RoomStatusChanged(roomId, oldStatus, status))
-
-                    if (type == "streamChanged") {
-                        val qualities = bc?.get("qualities")?.jsonArray?.mapNotNull {
-                            it.jsonObject["id"]?.jsonPrimitive?.content
-                        } ?: emptyList()
-                        if (qualities.isNotEmpty()) {
-                            logger.debug("WS qualities: roomId={}, qualities={}", roomId, qualities)
-                            eventBus.publish(QualitiesAvailable(roomId, qualities))
-                        }
-                    }
                 }
 
                 // Forward ALL events to the event log (matching v2 behavior)

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -10,6 +10,7 @@ import github.rikacelery.v3.data.StreamStart
 import github.rikacelery.v3.data.User
 import github.rikacelery.v3.events.*
 import github.rikacelery.v3.m3u8.M3u8Parser
+import github.rikacelery.v3.m3u8.MasterPlaylist
 import github.rikacelery.v3.utils.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
@@ -51,7 +52,8 @@ data class RoomSession(
     var totalBytes: Long = 0,
     var timeLimit: Duration = Duration.INFINITE,
     var sizeLimitBytes: Long = 0,
-    var pollingJob: Job? = null
+    var pollingJob: Job? = null,
+    var masterPlaylist: MasterPlaylist? = null
 )
 
 class CircleCache(private val capacity: Int) {
@@ -136,9 +138,11 @@ class SessionComponent(
                             rs.initUrl?.let { rs.circleCache.remove(it) }
                         }
                     }
+
                     SessionState.Fetching -> {
                         stopSession(msg.roomId)
                     }
+
                     else -> {} // Armed, Closing, Idle — nothing to do
                 }
             }
@@ -183,10 +187,7 @@ class SessionComponent(
             }
         }
         val resolvedPkey = pkey.ifBlank { streamAuthKey }
-        val qualities = apiClient.roomQualities(name)
-        val selectedQuality = selectQuality(qualities, quality)
-        logger.info("Session starting: roomId={}, name={}, quality={}", roomId, name, selectedQuality)
-        val rs = RoomSession(roomId, name, selectedQuality, selectedQuality, pkey = resolvedPkey)
+        val rs = RoomSession(roomId, name, quality, quality, pkey = resolvedPkey)
         sessions[roomId] = rs
         rs.token = token.takeIf { !it.isNullOrEmpty() }
         val config = requestBus.request<RoomConfigResponse>(GetRoomConfig(roomId))
@@ -195,8 +196,14 @@ class SessionComponent(
         rs.state = SessionState.Fetching
         rs.startTime = Instant.now()
         dataChannel.send(StreamStart(roomId, name, rs.startTime))
+        rs.masterPlaylist = fetchAndCacheMasterPlaylist(rs)
+        val availableNames = rs.masterPlaylist!!.variants.map { it.name }
+        val selected = selectQuality(availableNames, rs.quality)
+        rs.quality = selected
+        rs.targetquality = selected
+        logger.info("Session starting: roomId={}, name={}, quality={}", roomId, name, rs.quality)
+        rs.playlistUrl = resolveVariantUrl(rs)
         rs.pollingJob = scope.launch { pollingLoop(rs) }
-        rs.playlistUrl = buildPlaylistUrl(roomId, rs.quality, rs.pkey, rs.token)
         eventBus.publish(RecordingStarted(roomId, rs.quality))
     }
 
@@ -254,7 +261,7 @@ class SessionComponent(
                         event.qualities
                     )
                     rs.quality = newQuality
-                    rs.playlistUrl = buildPlaylistUrl(event.roomId, newQuality, rs.pkey, rs.token)
+                    rs.playlistUrl = resolveVariantUrl(rs)
                 } else {
 //                    logger.debug(
 //                        "Quality unchanged for {}: {} (available: {})", rs.roomName, rs.quality, event.qualities
@@ -294,10 +301,9 @@ class SessionComponent(
     }
 
     private fun selectQuality(available: List<String>, requested: String): String {
-        if (requested == "raw") return "raw"
+        if (requested == "highest") return "highest"
         val clean = available.filterNot { it.contains("blurred") }
-        if (clean.isEmpty()) return "raw"
-        if (requested == available[0]) return "raw"
+        if (clean.isEmpty()) return requested
         if (requested in available) return requested
         val reqParts = requested.split("p").filterNot(String::isEmpty)
         val final = clean.minByOrNull { q ->
@@ -310,7 +316,6 @@ class SessionComponent(
                 abs((qParts[0].toIntOrNull() ?: 0) - (reqParts[0].toIntOrNull() ?: 0))
             }
         } ?: requested
-        if (final == available[0]) return "raw"
         return final
     }
 
@@ -323,12 +328,13 @@ class SessionComponent(
 
     private suspend fun pollQualityForRoom(rs: RoomSession) {
         try {
-            val qualities = apiClient.roomQualities(rs.roomName)
-            if (qualities.isNotEmpty()) {
-                eventBus.publish(QualitiesAvailable(rs.roomId, qualities))
+            val master = fetchAndCacheMasterPlaylist(rs)
+            val availableNames = master.variants.map { it.name }
+            if (availableNames.isNotEmpty()) {
+                eventBus.publish(QualitiesAvailable(rs.roomId, availableNames))
             }
         } catch (_: Exception) {
-            // quality polling is best-effort; ignore transient errors
+            // master playlist polling is best-effort; ignore transient errors
         }
     }
 
@@ -395,22 +401,37 @@ class SessionComponent(
         return null
     }
 
-    private fun buildPlaylistUrl(roomId: Long, quality: String, pkey: String, token: String? = null): String =
-        buildUrl {
-            protocol = URLProtocol.HTTPS
-            host = "media-hls.doppiocdn.org"
-            encodedPath = if (quality != "raw" && quality.isNotBlank()) "b-hls-%d/%d/%d_%s.m3u8".format(
-                22, roomId, roomId, quality
-            ) else "b-hls-%d/%d/%d.m3u8".format(
-                22, roomId, roomId
-            )
-            parameters["psch"] = "v2"
-            parameters["pkey"] = pkey
-            parameters["preferredVideoCodec"] = "H265"
-            if (token != null) {
-                parameters["aclAuth"] = token
-            }
-        }.toString()
+    private fun buildMasterUrl(roomId: Long): String =
+        "https://edge-hls.doppiocdn.org/hls/$roomId/master/${roomId}_auto.m3u8"
+
+    private suspend fun fetchAndCacheMasterPlaylist(rs: RoomSession): MasterPlaylist {
+        val client = ClientManager.getProxiedClient("master_${rs.roomId}")
+        val url = buildMasterUrl(rs.roomId)
+        val response = withRetry(3) { client.get(url) }
+        val text = response.bodyAsText()
+        val master = m3u8Parser.parseMaster(text)
+        rs.masterPlaylist = master
+        val keyIds = master.pschKeys.map { it.substringAfter(":") }
+        val match = requestBus.request<DecryptKeyMatch>(MatchDecryptKeys(keyIds))
+        require(match.decryptKey.isNotEmpty()) {
+            "[${rs.roomName}] No PSCH key from master playlist matched in persistedDecryptKeys. keys=$keyIds"
+        }
+        rs.pkey = match.keyName
+        return master
+    }
+
+    private fun resolveVariantUrl(rs: RoomSession): String {
+        val mp = rs.masterPlaylist!!
+        val variant = if (rs.quality == "highest") {
+            mp.variants.maxByOrNull { it.bandwidth }
+        } else {
+            val availableNames = mp.variants.map { it.name }
+            val matched = selectQuality(availableNames, rs.quality)
+            mp.variants.find { it.name == matched }
+        }
+        val baseUrl = variant?.url ?: mp.variants.maxByOrNull { it.bandwidth }!!.url
+        return "$baseUrl?psch=v2&pkey=${rs.pkey}"
+    }
 
     private fun createDiscontinuityCounter(): suspend (List<Int>) -> Int {
         var lastMax: Int? = null
@@ -528,10 +549,20 @@ class SessionComponent(
                         if (configureSession(rs.roomId, rs.roomName) == null) {
                             logger.info("[STOP] [{}] Room off or non-public after timeout", rs.roomName)
                             rs.state = SessionState.Closing
-                            downloader.tell(DoCutPoint(CutPoint(rs.roomId, rs.segmentIndex - 1, rs.roomName, Instant.now(), EndReason.UserStop)))
+                            downloader.tell(
+                                DoCutPoint(
+                                    CutPoint(
+                                        rs.roomId,
+                                        rs.segmentIndex - 1,
+                                        rs.roomName,
+                                        Instant.now(),
+                                        EndReason.UserStop
+                                    )
+                                )
+                            )
                             break
                         }
-                        rs.playlistUrl = buildPlaylistUrl(rs.roomId, rs.quality, rs.pkey, rs.token)
+                        rs.playlistUrl = resolveVariantUrl(rs)
                         continue
                     }
                     throw e
@@ -540,22 +571,52 @@ class SessionComponent(
                         val token = configureSession(rs.roomId, rs.roomName)
                         if (token != null) {
                             rs.token = token.takeIf { it.isNotEmpty() }
-                            rs.playlistUrl = buildPlaylistUrl(rs.roomId, rs.quality, rs.pkey, rs.token)
+                            rs.playlistUrl = resolveVariantUrl(rs)
                             continue
                         }
                         logger.info("[STOP] [{}] Room off or non-public (403)", rs.roomName)
                         rs.state = SessionState.Closing
-                        downloader.tell(DoCutPoint(CutPoint(rs.roomId, rs.segmentIndex - 1, rs.roomName, Instant.now(), EndReason.UserStop)))
+                        downloader.tell(
+                            DoCutPoint(
+                                CutPoint(
+                                    rs.roomId,
+                                    rs.segmentIndex - 1,
+                                    rs.roomName,
+                                    Instant.now(),
+                                    EndReason.UserStop
+                                )
+                            )
+                        )
                         break
                     } else if (e.response.status == HttpStatusCode.NotFound) {
                         logger.info("[STOP] [{}] Stream url returns 404", rs.roomName)
                         rs.state = SessionState.Closing
-                        downloader.tell(DoCutPoint(CutPoint(rs.roomId, rs.segmentIndex - 1, rs.roomName, Instant.now(), EndReason.UserStop)))
+                        downloader.tell(
+                            DoCutPoint(
+                                CutPoint(
+                                    rs.roomId,
+                                    rs.segmentIndex - 1,
+                                    rs.roomName,
+                                    Instant.now(),
+                                    EndReason.UserStop
+                                )
+                            )
+                        )
                         break
                     } else {
                         logger.error("Polling error room ${rs.roomId}: ${e.message}")
                         rs.state = SessionState.Closing
-                        downloader.tell(DoCutPoint(CutPoint(rs.roomId, rs.segmentIndex - 1, rs.roomName, Instant.now(), EndReason.UserStop)))
+                        downloader.tell(
+                            DoCutPoint(
+                                CutPoint(
+                                    rs.roomId,
+                                    rs.segmentIndex - 1,
+                                    rs.roomName,
+                                    Instant.now(),
+                                    EndReason.UserStop
+                                )
+                            )
+                        )
                         break
                     }
                 } catch (e: Exception) {
@@ -563,7 +624,12 @@ class SessionComponent(
                     if (configureSession(rs.roomId, rs.roomName) == null) {
                         logger.info("[STOP] [{}] Room off or non-public", rs.roomName)
                     }
-                    rs.playlistUrl = buildPlaylistUrl(rs.roomId, rs.quality, rs.pkey, rs.token)
+                    try {
+                        rs.masterPlaylist = fetchAndCacheMasterPlaylist(rs)
+                        rs.playlistUrl = resolveVariantUrl(rs)
+                    } catch (_: Exception) {
+                        continue
+                    }
                 }
             }
         } finally {

--- a/src/main/kotlin/github/rikacelery/v3/events/Commands.kt
+++ b/src/main/kotlin/github/rikacelery/v3/events/Commands.kt
@@ -22,6 +22,7 @@ data class RemoveRoom(val roomId: Long) : Request
 // ── Config commands ──
 
 data class GetDecryptKey(val keyName: String) : Request
+data class MatchDecryptKeys(val keys: List<String>) : Request
 // ── Scheduler commands ──
 
 data class StartRecordingCmd(val roomId: Long) : Request
@@ -71,5 +72,6 @@ data class RoomConfigResponse(
     val pkey: String = ""
 ) : Response
 data class ConfigResponse(val value: Any?) : Response
+data class DecryptKeyMatch(val keyName: String, val decryptKey: String) : Response
 object OkResponse : Response
 data class ErrorResponse(val message: String) : Response

--- a/src/main/kotlin/github/rikacelery/v3/m3u8/M3u8Parser.kt
+++ b/src/main/kotlin/github/rikacelery/v3/m3u8/M3u8Parser.kt
@@ -63,9 +63,70 @@ object M3u8Parser {
         }
         return null
     }
+
+    fun parseMaster(m3u8Text: String): MasterPlaylist {
+        val lines = m3u8Text.lines()
+        val pschKeys = mutableListOf<String>()
+        val variants = mutableListOf<VariantStream>()
+
+        var i = 0
+        while (i < lines.size) {
+            val line = lines[i].trim()
+            when {
+                line.startsWith("#EXT-X-MOUFLON:PSCH:") -> {
+                    pschKeys.add(line.substringAfter("PSCH:"))
+                }
+                line.startsWith("#EXT-X-STREAM-INF:") -> {
+                    val attrs = parseAttributes(line.substringAfter("#EXT-X-STREAM-INF:"))
+                    i++
+                    while (i < lines.size && (lines[i].isBlank() || lines[i].trimStart().startsWith("#"))) {
+                        i++
+                    }
+                    val url = if (i < lines.size) lines[i].trim() else ""
+                    variants.add(VariantStream(
+                        name = buildQualityName(attrs["RESOLUTION"] ?: "", attrs["FRAME-RATE"] ?: ""),
+                        resolution = attrs["RESOLUTION"] ?: "",
+                        bandwidth = attrs["BANDWIDTH"]?.toLongOrNull() ?: 0L,
+                        url = url
+                    ))
+                }
+            }
+            i++
+        }
+        return MasterPlaylist(variants, pschKeys)
+    }
+
+    private fun parseAttributes(attrStr: String): Map<String, String> {
+        val result = mutableMapOf<String, String>()
+        val regex = Regex("""([A-Z-]+)=("[^"]*"|[^,]+)""")
+        regex.findAll(attrStr).forEach { match ->
+            val key = match.groupValues[1]
+            val value = match.groupValues[2].removeSurrounding("\"")
+            result[key] = value
+        }
+        return result
+    }
+
+    private fun buildQualityName(resolution: String, frameRate: String): String {
+        val height = resolution.split("x").lastOrNull()?.toIntOrNull() ?: return ""
+        val fps = frameRate.split(".").firstOrNull()?.toIntOrNull() ?: 30
+        return if (fps != 30) "${height}p$fps" else "${height}p"
+    }
 }
 
 data class ParsedPlaylist(
     val initUrl: String?,
     val segments: List<Segment>
+)
+
+data class VariantStream(
+    val name: String,
+    val resolution: String,
+    val bandwidth: Long,
+    val url: String
+)
+
+data class MasterPlaylist(
+    val variants: List<VariantStream>,
+    val pschKeys: List<String>
 )

--- a/src/main/kotlin/github/rikacelery/v3/utils/ClientManager.kt
+++ b/src/main/kotlin/github/rikacelery/v3/utils/ClientManager.kt
@@ -4,8 +4,8 @@ import io.ktor.client.*
 import io.ktor.client.engine.okhttp.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.plugins.logging.*
 import io.ktor.client.plugins.websocket.*
-import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import okhttp3.ConnectionPool
@@ -64,6 +64,14 @@ object ClientManager {
 
     private fun HttpClientConfig<OkHttpConfig>.configureClient() {
         expectSuccess = true
+        install(Logging){
+            logger = object : Logger {
+                override fun log(message: String) {
+                    this@ClientManager.logger.trace(message)
+                }
+            }
+            level = LogLevel.INFO
+        }
         install(HttpRequestRetry) {
             retryOnException(maxRetries = 3, retryOnTimeout = true)
             constantDelay(300)

--- a/src/main/resources/vue.html
+++ b/src/main/resources/vue.html
@@ -73,7 +73,6 @@
         .thumb-container video {}
         .thumb-placeholder {
             position: relative;
-            width: 64px; height: 40px;
             background: #1a1a2e;
             border-radius: 4px;
             display: flex; align-items: center; justify-content: center;
@@ -177,6 +176,9 @@
         html.dark .bg-red-600\/90 { background: #dc2626; }
         html.dark .thumb-placeholder { background: #0f172a; }
         html.dark .bg-slate-50\/90 { background: #1e293b; }
+        html.dark .text-indigo-600 { color: #a5b4fc; }
+        html.dark .bg-emerald-50 { background: #064e3b; }
+        html.dark .border-emerald-200 { border-color: #047857; }
     </style>
 </head>
 
@@ -227,7 +229,7 @@
 
                 <select v-model="addQuality"
                     class="py-1.5 px-3 text-sm bg-white border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 cursor-pointer">
-                    <option v-for="q in ['160p','240p','480p','720p','720p60','1080p','1080p60','2560p60','raw']"
+                    <option v-for="q in ['highest','160p','240p','480p','720p','720p60','1080p','1080p60','2560p60']"
                         :key="q" :value="q">{{q}}</option>
                 </select>
 
@@ -244,6 +246,11 @@
                         class="w-8 h-8 flex items-center justify-center rounded bg-slate-100 text-slate-600 hover:bg-slate-200 hover:text-slate-800 transition-colors dark-toggle-btn">
                         <i class="fa-solid" :class="darkMode ? 'fa-sun' : 'fa-moon'"></i>
                     </button>
+                    <div class="flex items-center gap-1 bg-slate-100 rounded px-2 h-8" title="Preview size">
+                        <i class="fa-solid fa-image text-slate-400 text-xs"></i>
+                        <input type="range" min="40" max="240" v-model.number="previewHeight"
+                            class="w-24 h-1 accent-indigo-500 cursor-pointer">
+                    </div>
                     <button @click="poweroff()" title="Power Off Server"
                         class="w-8 h-8 flex items-center justify-center rounded bg-red-100 text-red-700 hover:bg-red-600 hover:text-white transition-colors ml-2">
                         <i class="fa-solid fa-power-off text-sm"></i>
@@ -263,84 +270,75 @@
                     <thead
                         class="bg-slate-50 text-slate-600 font-semibold border-b border-slate-200 uppercase text-xs tracking-wider text-nowrap">
                         <tr>
-                            <th class="px-4 py-3 cursor-pointer hover:bg-slate-100 transition-colors select-none"
+                            <th class="px-2 py-2 cursor-pointer hover:bg-slate-100 transition-colors select-none"
                                 @click="sortToggle('Room')">
-                                Room <i class="fa-solid ml-1"
-                                    :class="!sort['Room'] ? 'fa-sort text-slate-300' : (sort['Room'] === 1 ? 'fa-sort-down text-indigo-500' : 'fa-sort-up text-indigo-500')"></i>
+                                Room
                             </th>
-                            <th class="px-4 py-3 text-center">Room</th>
-                            <th class="px-4 py-3 text-center">Preview</th>
-                            <th class="px-4 py-3 cursor-pointer hover:bg-slate-100 transition-colors select-none"
+                            <th class="px-1 py-2 text-center text-[10px]">Room</th>
+                            <th class="px-1 py-2 text-center text-[10px]">Preview</th>
+                            <th class="px-1 py-2 cursor-pointer hover:bg-slate-100 transition-colors select-none text-[10px]"
                                 @click="sortToggle('ID')">
-                                ID <i class="fa-solid ml-1"
-                                    :class="!sort['ID'] ? 'fa-sort text-slate-300' : (sort['ID'] === 1 ? 'fa-sort-down text-indigo-500' : 'fa-sort-up text-indigo-500')"></i>
+                                ID
                             </th>
-                            <th class="px-4 py-3 cursor-pointer hover:bg-slate-100 transition-colors select-none"
+                            <th class="px-1 py-2 cursor-pointer hover:bg-slate-100 transition-colors select-none text-center text-[10px]"
                                 @click="sortToggle('Quality')">
-                                Quality <i class="fa-solid ml-1"
-                                    :class="!sort['Quality'] ? 'fa-sort text-slate-300' : (sort['Quality'] === 1 ? 'fa-sort-down text-indigo-500' : 'fa-sort-up text-indigo-500')"></i>
+                                Quality
                             </th>
-                            <th class="px-4 py-3 cursor-pointer hover:bg-slate-100 transition-colors select-none"
+                            <th class="px-1 py-2 cursor-pointer hover:bg-slate-100 transition-colors select-none text-center"
                                 @click="sortToggle('Limit')">
-                                Time Limit <i class="fa-solid ml-1"
-                                    :class="!sort['Limit'] ? 'fa-sort text-slate-300' : (sort['Limit'] === 1 ? 'fa-sort-down text-indigo-500' : 'fa-sort-up text-indigo-500')"></i>
+                                <div class="flex flex-col text-[10px] leading-tight">
+                                    <span>Time</span>
+                                    <span>Size</span>
+                                </div>
                             </th>
-                            <th class="px-4 py-3 cursor-pointer hover:bg-slate-100 transition-colors select-none"
-                                @click="sortToggle('SizeLimit')">
-                                Size Limit <i class="fa-solid ml-1"
-                                    :class="!sort['SizeLimit'] ? 'fa-sort text-slate-300' : (sort['SizeLimit'] === 1 ? 'fa-sort-down text-indigo-500' : 'fa-sort-up text-indigo-500')"></i>
-                            </th>
-                            <th class="px-4 py-3 cursor-pointer hover:bg-slate-100 transition-colors select-none"
+                            <th class="px-1 py-2 cursor-pointer hover:bg-slate-100 transition-colors select-none text-center text-[10px]"
                                 @click="sortToggle('Status')">
-                                Status <i class="fa-solid ml-1"
-                                    :class="!sort['Status'] ? 'fa-sort text-slate-300' : (sort['Status'] === 1 ? 'fa-sort-down text-indigo-500' : 'fa-sort-up text-indigo-500')"></i>
+                                Status
                             </th>
-                            <th class="px-4 py-3 cursor-pointer hover:bg-slate-100 transition-colors select-none text-center"
+                            <th class="px-1 py-2 cursor-pointer hover:bg-slate-100 transition-colors select-none text-center text-[10px]"
                                 @click="sortToggle('AutoPay')">
-                                AutoPay <i class="fa-solid ml-1"
-                                    :class="!sort['AutoPay'] ? 'fa-sort text-slate-300' : (sort['AutoPay'] === 1 ? 'fa-sort-down text-indigo-500' : 'fa-sort-up text-indigo-500')"></i>
+                                AutoPay
                             </th>
-                            <th class="px-4 py-3">Segments</th>
-                            <th class="px-4 py-3 cursor-pointer hover:bg-slate-100 transition-colors select-none text-right"
+                            <th class="px-1 py-2 text-[10px] text-center">Segments</th>
+                            <th class="px-1 py-2 cursor-pointer hover:bg-slate-100 transition-colors select-none text-right text-[10px]"
                                 @click="sortToggle('Size')">
-                                <span class="">File Size</span> <span
-                                    class="text-slate-400 font-normal">({{formatBytes(totalSize)}})</span>
-                                <i class="fa-solid ml-1"
-                                    :class="!sort['Size'] ? 'fa-sort text-slate-300' : (sort['Size'] === 1 ? 'fa-sort-down text-indigo-500' : 'fa-sort-up text-indigo-500')"></i>
+                                Size
                             </th>
-                            <th class="px-4 py-3 text-center">Actions</th>
+                            <th class="px-1 py-2 text-center text-[10px]">Actions</th>
                         </tr>
                     </thead>
                     <tbody class="divide-y divide-slate-100">
                         <tr v-if="roomDisplay.length === 0">
-                            <td colspan="10" class="px-4 py-12 text-center text-slate-400">
+                            <td colspan="9" class="px-4 py-12 text-center text-slate-400">
                                 <i class="fa-solid fa-inbox text-3xl mb-2"></i>
                                 <p>No rooms found. Add a room to start recording.</p>
                             </td>
                         </tr>
                         <tr v-for="room in roomDisplay" :key="room.name"
                             class="hover:bg-slate-50 transition-colors group">
-                            <td class="px-4 py-3 font-medium text-indigo-600">
+                            <td class="px-2 py-1 font-medium text-indigo-600 text-xs">
                                 <a :href="`https://xhamsterlive.com/${room.name}`" target="_blank"
-                                    class="hover:underline flex items-center gap-1">
+                                    class="hover:underline flex items-center gap-0.5">
                                     {{room.name}} <i
-                                        class="fa-solid fa-arrow-up-right-from-square text-[0.65rem] text-slate-400"></i>
+                                        class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] text-slate-400"></i>
                                 </a>
                             </td>
-                            <td class="px-4 py-2 text-center">
+                            <td class="px-1 py-1 text-center text-[10px] text-slate-500">
                                 {{room.roomStatus}}
                             </td>
-                            <td class="px-4 py-2 text-center">
+                            <td class="px-1 py-1 text-center">
                                 <div class="thumb-container">
                                     <template v-if="room.sessionStatus==='Recording'">
                                         <div v-if="!activeVideos[room.id]" class="thumb-placeholder border border-slate-200"
+                                            :style="{ height: previewHeight + 'px', width: (previewHeight * 1.6) + 'px' }"
                                             @click="activateVideo(room.id)">
                                             <i class="fa-solid fa-play"></i>
                                         </div>
                                         <video v-else
                                             :src="'/mse/live?id=' + room.id"
                                             muted autoplay playsinline
-                                            class="h-10 w-16 object-cover rounded shadow-sm border border-slate-200"
+                                            :style="{ height: previewHeight + 'px', width: (previewHeight * 1.6) + 'px' }"
+                                            class="object-cover rounded shadow-sm border border-slate-200"
                                             @click="deactivateVideo(room.id)">
                                         </video>
                                         <img v-if="snapshotcache[room.name]?.url"
@@ -348,92 +346,97 @@
                                             class="thumb-preview" />
                                     </template>
                                     <div v-else
-                                        class="h-10 w-16 bg-slate-100 rounded border border-slate-200 flex items-center justify-center text-slate-300 text-xs">
+                                        :style="{ height: previewHeight + 'px', width: (previewHeight * 1.6) + 'px' }"
+                                        class="bg-slate-100 rounded border border-slate-200 flex items-center justify-center text-slate-300 text-xs">
                                         N/A</div>
                                 </div>
                             </td>
-                            <td class="px-4 py-3 text-slate-500 font-mono text-xs">{{room.id || '-'}}</td>
-                            <td class="px-4 py-3">
-                                <select @change="ev => setQuality(ev.target.value, room.id)" :value="room.quality"
-                                    class="text-xs py-1 px-2 border border-slate-200 rounded bg-white focus:outline-none focus:border-indigo-500">
-                                    <option
-                                        v-for="q in ['160p','240p','480p','720p','720p60','540p','960p','1080p','1080p60','2560p60','raw']"
-                                        :key="q">{{q}}</option>
-                                </select>
-                            </td>
-                            <td class="px-4 py-3">
-                                <div class="flex items-center gap-2">
-                                    <span class="text-slate-500 text-right">{{room.timeLimit > 0 ? (room.timeLimit / 1000) : 0}}</span>
-                                    <i class="fa-solid fa-arrow-right-long text-slate-300 text-xs"></i>
-                                    <input v-model.number="editLimits[room.id]" type="number" min="0"
-                                        :style="{ width: Math.max(6, String(editLimits[room.id] || '').length + 3) + 'ch' }"
-                                        class="px-2 py-1 text-xs border border-slate-200 rounded bg-white focus:outline-none focus:border-indigo-500"
-                                        placeholder="New">
-                                    <button @click="setLimit(room.id)" title="Apply Limit"
-                                        class="text-emerald-600 hover:text-emerald-800 transition-colors p-1">
-                                        <i class="fa-solid fa-check"></i>
-                                    </button>
+                            <td class="px-1 py-1 text-slate-400 font-mono text-[10px] text-center">{{room.id || '-'}}</td>
+                            <td class="px-2 py-1">
+                                <div class="flex flex-col items-center gap-0.5">
+                                    <select @change="ev => setQuality(ev.target.value, room.id)" :value="room.quality"
+                                        class="text-[10px] py-0.5 px-1 border border-slate-200 rounded bg-white focus:outline-none focus:border-indigo-500 w-16">
+                                        <option
+                                            v-for="q in ['highest','160p','240p','480p','720p','720p60','540p','960p','1080p','1080p60','2560p60']"
+                                            :key="q">{{q}}</option>
+                                    </select>
+                                    <span v-if="room.sessionStatus==='Recording' && room.sessionQuality"
+                                        class="text-[10px] font-mono text-emerald-600 bg-emerald-50 px-1 rounded border border-emerald-200"
+                                        :title="'实际录制清晰度: ' + room.sessionQuality">
+                                        ⏺{{room.sessionQuality}}
+                                    </span>
                                 </div>
                             </td>
-                            <td class="px-4 py-3">
-                                <div class="flex items-center gap-2">
-                                    <span class="text-slate-500 text-right">{{room.sizeLimitBytes > 0 ? formatBytes(room.sizeLimitBytes) : 0}}</span>
-                                    <i class="fa-solid fa-arrow-right-long text-slate-300 text-xs"></i>
-                                    <input v-model="editSizeLimits[room.id]" type="text"
-                                        :style="{ width: Math.max(6, String(editSizeLimits[room.id] || '').length + 3) + 'ch' }"
-                                        class="px-2 py-1 text-xs border border-slate-200 rounded bg-white focus:outline-none focus:border-indigo-500"
-                                        placeholder="New">
-                                    <button @click="setSizeLimit(room.id)" title="Apply Limit"
-                                        class="text-emerald-600 hover:text-emerald-800 transition-colors p-1">
-                                        <i class="fa-solid fa-check"></i>
-                                    </button>
+                            <td class="px-2 py-1">
+                                <div class="flex flex-col gap-0.5 text-[10px]">
+                                    <div class="flex items-center gap-1">
+                                        <span class="text-slate-500 text-right whitespace-nowrap">{{room.timeLimit > 0 ? (room.timeLimit / 1000) : 0}}s</span>
+                                        <input v-model.number="editLimits[room.id]" type="number" min="0"
+                                            class="w-12 px-1 py-0.5 text-[10px] border border-slate-200 rounded bg-white focus:outline-none focus:border-indigo-500"
+                                            placeholder="new">
+                                        <button @click="setLimit(room.id)" title="Set Time"
+                                            class="text-emerald-600 hover:text-emerald-800 p-0.5 leading-none">
+                                            <i class="fa-solid fa-check text-[10px]"></i>
+                                        </button>
+                                    </div>
+                                    <div class="flex items-center gap-1">
+                                        <span class="text-slate-500 text-right whitespace-nowrap">{{room.sizeLimitBytes > 0 ? formatBytes(room.sizeLimitBytes) : '0'}}</span>
+                                        <i class="fa-solid fa-arrow-right-long text-slate-300 text-[8px]"></i>
+                                        <input v-model="editSizeLimits[room.id]" type="text"
+                                            class="w-12 px-1 py-0.5 text-[10px] border border-slate-200 rounded bg-white focus:outline-none focus:border-indigo-500"
+                                            placeholder="new">
+                                        <button @click="setSizeLimit(room.id)" title="Set Size"
+                                            class="text-emerald-600 hover:text-emerald-800 p-0.5 leading-none">
+                                            <i class="fa-solid fa-check text-[10px]"></i>
+                                        </button>
+                                    </div>
                                 </div>
                             </td>
-                            <td class="px-4 py-3">
+                            <td class="px-1 py-1 text-center">
                                 <span v-if="room.sessionStatus==='Recording'"
-                                    class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-red-100 text-red-700">
-                                    <span class="w-2 h-2 rounded-full bg-red-500 status-recording"></span> Recording
+                                    class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-red-100 text-red-700">
+                                    <span class="w-1.5 h-1.5 rounded-full bg-red-500 status-recording"></span>REC
                                 </span>
                                 <span v-else-if="room.sessionStatus==='Listening'"
-                                    class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-700">
-                                    <i class="fa-solid fa-hourglass-half fa-spin-pulse"></i> Listening
+                                    class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-blue-100 text-blue-700">
+                                    <i class="fa-solid fa-hourglass-half fa-spin-pulse text-[10px]"></i>ARM
                                 </span>
                                 <span v-else-if="room.sessionStatus===''"
-                                    class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-slate-100 text-slate-500">
-                                    <i class="fa-solid fa-video-slash"></i> Offline
+                                    class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-slate-100 text-slate-500">
+                                    <i class="fa-solid fa-video-slash text-[10px]"></i>OFF
                                 </span>
                                 <span v-else
-                                    class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-700">
+                                    class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-gray-100 text-gray-700">
                                     {{room.sessionStatus}}
                                 </span>
                             </td>
-                            <td class="px-4 py-3 text-center">
+                            <td class="px-1 py-1 text-center">
                                 <label class="relative inline-flex items-center cursor-pointer">
                                     <input type="checkbox" v-model="room.autoPay"
                                         @change="setAutoPay($event.target.checked, room.id)" class="sr-only peer">
                                     <div
-                                        class="w-9 h-5 bg-slate-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-indigo-600">
+                                        class="w-7 h-4 bg-slate-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-indigo-600">
                                     </div>
                                 </label>
                             </td>
-                            <td class="px-4 py-3">
-                                <div v-if="room.sessionStatus==='Recording'" class="flex items-center gap-3 text-xs font-mono">
-                                    <span class="text-emerald-600 flex items-center gap-1" title="Running"><i
-                                            :class="[{'animate-bounce':room.running},'fa-download','fa-solid']"></i>{{room.running
+                            <td class="px-1 py-1">
+                                <div v-if="room.sessionStatus==='Recording'" class="flex items-center gap-1 text-[10px] font-mono">
+                                    <span class="text-emerald-600 flex items-center gap-0.5" title="Running"><i
+                                            :class="[{'animate-bounce':room.running},'fa-download','fa-solid','text-[9px]']"></i>{{room.running
                                         || 0}}</span>
-                                    <span class="text-blue-600 flex items-center gap-1" title="Success"><i
-                                            class="fa-solid fa-check"></i>{{room.success || 0}}</span>
-                                    <span class="text-red-600 flex items-center gap-1" title="Failed"><i
-                                            class="fa-solid fa-xmark"></i>{{room.failed || 0}}</span>
-                                    <span class="text-yellow-600 flex items-center gap-1" title="Missing"><i
-                                            class="fa-solid fa-question"></i>{{room.segMissing || 0}}</span>
+                                    <span class="text-blue-600 flex items-center gap-0.5" title="Success"><i
+                                            class="fa-solid fa-check text-[9px]"></i>{{room.success || 0}}</span>
+                                    <span class="text-red-600 flex items-center gap-0.5" title="Failed"><i
+                                            class="fa-solid fa-xmark text-[9px]"></i>{{room.failed || 0}}</span>
+                                    <span class="text-yellow-600 flex items-center gap-0.5" title="Missing"><i
+                                            class="fa-solid fa-question text-[9px]"></i>{{room.segMissing || 0}}</span>
                                 </div>
-                                <span v-else class="text-slate-300 text-xs">-</span>
+                                <span v-else class="text-slate-300 text-[10px]">-</span>
                             </td>
-                            <td class="px-4 py-3 text-right font-mono text-xs text-slate-600">
+                            <td class="px-1 py-1 text-right font-mono text-[10px] text-slate-600">
                                 {{formatBytes(room.bytesWrite)}}
                             </td>
-                            <td class="px-4 py-3">
+                            <td class="px-1 py-1">
                                 <div
                                     class="flex items-center justify-center gap-1.5 opacity-70 group-hover:opacity-100 transition-opacity">
                                     <button @click="action('activate',room.id)" title="Activate"
@@ -506,7 +509,7 @@
                     timeLimit: null,
                     sizeLimit: null,
                     addInput: "",
-                    addQuality: "720p",
+                    addQuality: "highest",
                     sort: { "Room": 1, "Status": 1 },
                     roomInfo: {},
                     editLimits: {}, // Cache for limits inputs to prevent overlap with polling
@@ -514,6 +517,7 @@
                     allUrls: [],
                     snapshotcache: {},
                     activeVideos: {},
+                    previewHeight: 40,
                     darkMode: false,
                 }
             },
@@ -532,8 +536,8 @@
                             if (aVal !== bVal) return this.sort["Status"] === 1 ? bVal - aVal : aVal - bVal;
                         }
                         if (this.sort["Quality"]) {
-                            if (a.quality === "raw" && b.quality !== "raw") return this.sort["Quality"] === 1 ? 1 : -1;
-                            if (a.quality !== "raw" && b.quality === "raw") return this.sort["Quality"] === 1 ? -1 : 1;
+                            if (a.quality === "highest" && b.quality !== "highest") return -1;
+                            if (a.quality !== "highest" && b.quality === "highest") return 1;
                             const parseQ = (q) => {
                                 if (!q) return 0;
                                 const parts = q.split("p");
@@ -703,6 +707,7 @@
                             if (!newRoomInfo[room.room.name]) newRoomInfo[room.room.name] = {};
                             Object.assign(newRoomInfo[room.room.name], {
                                 sessionStatus: room.session.status,
+                                sessionQuality: room.session.quality,
                                 roomStatus: room.room.status,
                                 ...room.room,
                             });


### PR DESCRIPTION
…quality as default

- Parse EXT-X-STREAM-INF variants and EXT-X-MOUFLON PSCH keys from edge-hls.doppiocdn.org master playlist to resolve variant URLs
- Build quality name from RESOLUTION+FRAME-RATE instead of NAME attribute
- Match PSCH keys against persistedDecryptKeys via MatchDecryptKeys command
- Add "highest" quality (max-bandwidth variant) as new default, remove "raw"
- Use selectQuality distance-based matching in resolveVariantUrl
- Poll qualities from master playlist instead of Stripchat API
- Append matched PSCH key as psch/pkey query params to variant URLs
- Web UI: recording quality badge, time/size limits merged, preview size slider
- Dark mode: add missing styles for new elements

Closes #99