### PR TITLE
fix(v3): webui improvements, request bus fixes, postprocessor stability

### DIFF
--- a/src/main/kotlin/github/rikacelery/v3/Main.kt
+++ b/src/main/kotlin/github/rikacelery/v3/Main.kt
@@ -9,9 +9,7 @@ import github.rikacelery.v3.core.RequestBus
 import github.rikacelery.v3.data.SystemConfig
 import github.rikacelery.v3.hooks.EventHook
 import github.rikacelery.v3.m3u8.M3u8Parser
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.awaitCancellation
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
@@ -148,18 +146,17 @@ fun main(vararg args: String) {
         val engine = httpServer.start()
 
         // 6. Wait for shutdown
+        val shutdownSignal = CompletableDeferred<Unit>()
         eventBus.subscribe(appScope, String::class) { msg ->
             if (msg == "ServerShutdown") {
                 engine.stop(1000, 5000)
-                appScope.cancel()
+                shutdownSignal.complete(Unit)
             }
         }
 
         // 7. Cleanup on exit
         try {
-            awaitCancellation()
-        } catch (_: CancellationException) {
-            // normal shutdown
+            shutdownSignal.await()
         } finally {
             schedulerComponent.stop()
             sessionComponent.stop()

--- a/src/main/kotlin/github/rikacelery/v3/Main.kt
+++ b/src/main/kotlin/github/rikacelery/v3/Main.kt
@@ -9,9 +9,9 @@ import github.rikacelery.v3.core.RequestBus
 import github.rikacelery.v3.data.SystemConfig
 import github.rikacelery.v3.hooks.EventHook
 import github.rikacelery.v3.m3u8.M3u8Parser
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
@@ -56,123 +56,123 @@ fun main(vararg args: String) {
     }
 
     runBlocking {
-        coroutineScope {
-            val appScope = this
+        val appScope = this
 
-            val configPath = "xhrec.json"
-            val (defaultPkey, decryptKeys) = loadPersistedConfig(configPath)
+        val configPath = "xhrec.json"
+        val (defaultPkey, decryptKeys) = loadPersistedConfig(configPath)
 
-            val config = SystemConfig(
-                outputDir = File(cli.getOptionValue("output", "out")),
-                tmpDir = File(cli.getOptionValue("tmp", "tmp")),
-                port = cli.getOptionValue("port", "8090").toInt(),
-                proxy = System.getenv("http_proxy"),
-                decryptKeys = decryptKeys,
-                streamAuthKey = defaultPkey,
-                authToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiItMTA4MSIsImluZm8iOnsiaXNHdWVzdCI6dHJ1ZSwidXNlcklkIjotMTA4MX19.IXF36-UfCEmOPGvhl2a19rgLsh2rDCdXNJ3su9LkA9Y",
-                platformHost = "stripchat.com",
-                listConfPath = cli.getOptionValue("file", "list.conf"),
-                configPath = configPath
-            )
+        val config = SystemConfig(
+            outputDir = File(cli.getOptionValue("output", "out")),
+            tmpDir = File(cli.getOptionValue("tmp", "tmp")),
+            port = cli.getOptionValue("port", "8090").toInt(),
+            proxy = System.getenv("http_proxy"),
+            decryptKeys = decryptKeys,
+            streamAuthKey = defaultPkey,
+            authToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiItMTA4MSIsImluZm8iOnsiaXNHdWVzdCI6dHJ1ZSwidXNlcklkIjotMTA4MX19.IXF36-UfCEmOPGvhl2a19rgLsh2rDCdXNJ3su9LkA9Y",
+            platformHost = "stripchat.com",
+            listConfPath = cli.getOptionValue("file", "list.conf"),
+            configPath = configPath
+        )
 
-            // 1. Core infrastructure
-            val eventBus = EventBus()
-            val requestBus = RequestBus(eventBus, appScope)
-            val dataChannel = DataChannel()
-            val mseStore = MseStore()
-            dataChannel.installHook(mseStore)
-            eventBus.installHook(object : EventHook {
-                override suspend fun intercept(event: Any): Any {
+        // 1. Core infrastructure
+        val eventBus = EventBus()
+        val requestBus = RequestBus(eventBus, appScope)
+        val dataChannel = DataChannel()
+        val mseStore = MseStore()
+        dataChannel.installHook(mseStore)
+        eventBus.installHook(object : EventHook {
+            override suspend fun intercept(event: Any): Any {
 
-                    return event
-                }
-            })
-
-
-            // 2. Components
-            val metricComponent = MetricComponent(eventBus, appScope)
-            val configComponent = ConfigComponent(config, eventBus, appScope)
-            val authComponent = AuthComponent(cli.getOptionValue("users", "users.txt"), eventBus, appScope)
-            val roomComponent =
-                RoomComponent(ApiClient, config.listConfPath, config.platformHost, requestBus, eventBus, appScope)
-            val liveEventSource = LiveEventSource(config.authToken, eventBus, appScope)
-
-            val downloaderComponent = DownloaderComponent(
-                dataChannel, eventBus = eventBus, parentScope = appScope, initialConcurrency = 64
-            )
-            val writerComponent = WriterComponent(
-                dataChannel, config.tmpDir,
-                eventBus = eventBus, parentScope = appScope
-            )
-            val postProcessorComponent = PostProcessorComponent(eventBus = eventBus, parentScope = appScope)
-            val sessionComponent = SessionComponent(
-                dataChannel,
-                downloaderComponent,
-                M3u8Parser,
-                requestBus,
-                ApiClient,
-                config.streamAuthKey,
-                eventBus,
-                appScope
-            )
-            val schedulerComponent = SchedulerComponent(requestBus, sessionComponent, eventBus, appScope)
-
-            val httpServer = HttpServerComponent(
-                config.port,
-                eventBus,
-                requestBus,
-                metricComponent,
-                postProcessorComponent,
-                appScope,
-                mseStore
-            )
-
-
-            // 3. Start all Actors
-            configComponent.start()
-            authComponent.start()
-            roomComponent.start()
-            metricComponent.start()
-            liveEventSource.start()
-            downloaderComponent.start()
-            writerComponent.start()
-            postProcessorComponent.start()
-            sessionComponent.start()
-            schedulerComponent.start()
-
-            // 4. Bootstrap: load users, processors, rooms from config files
-            val bootstrap =
-                Bootstrap(ApiClient, roomComponent, authComponent, postProcessorComponent, schedulerComponent)
-            bootstrap.initialize(args.toList())
-
-            // 5. Start HTTP server
-            val engine = httpServer.start()
-
-            // 6. Wait for shutdown
-            eventBus.subscribe(appScope, String::class) { msg ->
-                if (msg == "ServerShutdown") {
-                    engine.stop(1000, 5000)
-                    appScope.cancel()
-                }
+                return event
             }
+        })
 
-            // 7. Cleanup on exit
-            try {
-                awaitCancellation()
-            } finally {
-                schedulerComponent.stop()
-                sessionComponent.stop()
-                downloaderComponent.stop()
-                writerComponent.stop()
-                postProcessorComponent.stop()
-                liveEventSource.stop()
-                metricComponent.stop()
-                roomComponent.stop()
-                authComponent.stop()
-                configComponent.stop()
-                dataChannel.close()
-                println("XhRec v3 shut down")
+
+        // 2. Components
+        val metricComponent = MetricComponent(eventBus, appScope)
+        val configComponent = ConfigComponent(config, eventBus, appScope)
+        val authComponent = AuthComponent(cli.getOptionValue("users", "users.txt"), eventBus, appScope)
+        val roomComponent =
+            RoomComponent(ApiClient, config.listConfPath, config.platformHost, requestBus, eventBus, appScope)
+        val liveEventSource = LiveEventSource(config.authToken, eventBus, appScope)
+
+        val downloaderComponent = DownloaderComponent(
+            dataChannel, eventBus = eventBus, parentScope = appScope, initialConcurrency = 64
+        )
+        val writerComponent = WriterComponent(
+            dataChannel, config.tmpDir,
+            eventBus = eventBus, parentScope = appScope
+        )
+        val postProcessorComponent = PostProcessorComponent(eventBus = eventBus, parentScope = appScope)
+        val sessionComponent = SessionComponent(
+            dataChannel,
+            downloaderComponent,
+            M3u8Parser,
+            requestBus,
+            ApiClient,
+            config.streamAuthKey,
+            eventBus,
+            appScope
+        )
+        val schedulerComponent = SchedulerComponent(requestBus, sessionComponent, eventBus, appScope)
+
+        val httpServer = HttpServerComponent(
+            config.port,
+            eventBus,
+            requestBus,
+            metricComponent,
+            postProcessorComponent,
+            appScope,
+            mseStore
+        )
+
+
+        // 3. Start all Actors
+        configComponent.start()
+        authComponent.start()
+        roomComponent.start()
+        metricComponent.start()
+        liveEventSource.start()
+        downloaderComponent.start()
+        writerComponent.start()
+        postProcessorComponent.start()
+        sessionComponent.start()
+        schedulerComponent.start()
+
+        // 4. Bootstrap: load users, processors, rooms from config files
+        val bootstrap =
+            Bootstrap(ApiClient, roomComponent, authComponent, postProcessorComponent, schedulerComponent)
+        bootstrap.initialize(args.toList())
+
+        // 5. Start HTTP server
+        val engine = httpServer.start()
+
+        // 6. Wait for shutdown
+        eventBus.subscribe(appScope, String::class) { msg ->
+            if (msg == "ServerShutdown") {
+                engine.stop(1000, 5000)
+                appScope.cancel()
             }
+        }
+
+        // 7. Cleanup on exit
+        try {
+            awaitCancellation()
+        } catch (_: CancellationException) {
+            // normal shutdown
+        } finally {
+            schedulerComponent.stop()
+            sessionComponent.stop()
+            downloaderComponent.stop()
+            writerComponent.stop()
+            postProcessorComponent.stop()
+            liveEventSource.stop()
+            metricComponent.stop()
+            roomComponent.stop()
+            authComponent.stop()
+            configComponent.stop()
+            dataChannel.close()
+            println("XhRec v3 shut down")
         }
     }
 }

--- a/src/main/kotlin/github/rikacelery/v3/bootstrap/Bootstrap.kt
+++ b/src/main/kotlin/github/rikacelery/v3/bootstrap/Bootstrap.kt
@@ -211,10 +211,10 @@ class Bootstrap(
     }
 
     private fun parseSize(s: String): Long {
-        val regex = Regex("(\\d+)(Ti|Gi|Mi|Ki|Bi|T|G|M|K|B)")
+        val regex = Regex("(\\d+(?:\\.\\d+)?)(Ti|Gi|Mi|Ki|Bi|T|G|M|K|B)")
         var total = 0L
         regex.findAll(s).forEach {
-            val v = it.groupValues[1].toLong()
+            val v = it.groupValues[1].toDouble()
             total += when (it.groupValues[2]) {
                 "Ti" -> v * 1024 * 1024 * 1024 * 1024
                 "Gi" -> v * 1024 * 1024 * 1024
@@ -226,8 +226,8 @@ class Bootstrap(
                 "M" -> v * 1000_000
                 "K" -> v * 1000
                 "B" -> v
-                else -> 0
-            }
+                else -> 0L
+            }.toLong()
         }
         return total
     }

--- a/src/main/kotlin/github/rikacelery/v3/components/PostProcessorComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/PostProcessorComponent.kt
@@ -64,8 +64,10 @@ class PostProcessorComponent(
     private suspend fun processFile(event: FileReady) {
         var files = listOf(event.file)
         for (processor in processors) {
+            val processorName = processor::class.simpleName ?: "?"
             files = files.flatMap { f ->
                 try {
+                    logger.info("[{}] running {}", processorName, f.name)
                     val ctx = ProcessorCtx(
                         roomId = event.roomId, roomName = event.roomName,
                         startTime = event.startTime, endTime = event.endTime,
@@ -73,7 +75,7 @@ class PostProcessorComponent(
                     )
                     processor.process(f, ctx)
                 } catch (e: Exception) {
-                    logger.error("Processor error: ${e.message}")
+                    logger.error("[{}] error: {}", processorName, e.message)
                     listOf(f)
                 }
             }

--- a/src/main/kotlin/github/rikacelery/v3/components/RoomComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/RoomComponent.kt
@@ -81,7 +81,13 @@ class RoomComponent(
             }
 
             is HandleRoomCommand -> {
-                scope.launch{ handleCommand(msg.env) }
+                scope.launch {
+                    try {
+                        handleCommand(msg.env)
+                    } catch (e: Exception) {
+                        eventBus.publish(CommandAck(msg.env.id, ErrorResponse(e.message ?: "error")))
+                    }
+                }
             }
 
             is RefreshRooms -> scope.launch{
@@ -94,18 +100,21 @@ class RoomComponent(
     private suspend fun handleCommand(env: CommandEnvelope) {
         val ack = when (val cmd = env.command) {
             is GetRoomName -> {
-                val r =
-                    rooms[cmd.roomId]; if (r != null) RoomNameResponse(r.name) else ErrorResponse("not found: ${cmd.roomId}")
+                val r = rooms[cmd.roomId]
+                    ?: throw NoSuchElementException("room ${cmd.roomId} not found")
+                RoomNameResponse(r.name)
             }
 
             is GetRoomConfig -> {
-                val r = rooms[cmd.roomId]; if (r != null) RoomConfigResponse(
+                val r = rooms[cmd.roomId]
+                    ?: throw NoSuchElementException("room ${cmd.roomId} not found")
+                RoomConfigResponse(
                     r.quality,
                     r.timeLimit,
                     r.sizeLimitBytes,
                     r.autoPay,
                     r.pkey
-                ) else ErrorResponse("not found: ${cmd.roomId}")
+                )
             }
 
             is SetRoomQuality -> {

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -436,7 +436,6 @@ class SessionComponent(
             )
             parameters["psch"] = "v2"
             parameters["pkey"] = rs.pkey
-            parameters["preferredVideoCodec"] = "H265"
             if (token != null) {
                 parameters["aclAuth"] = token
             }
@@ -482,20 +481,20 @@ class SessionComponent(
         val lock = Mutex()
         return counter@{ numbers: List<Int> ->
             lock.withLock {
-                if (numbers.isEmpty()) return@counter totalGaps
+                val filtered = numbers.filter { it != 0 }
+                if (filtered.isEmpty()) return@counter totalGaps
 
-                val currentMin = numbers.first()      // 连续递增，首项最小
-                val currentMax = numbers.last()       // 尾项最大
+                val currentMin = filtered.first()
+                val currentMax = filtered.last()
 
                 if (lastMax != null) {
                     val gap = currentMin - lastMax!! - 1
                     if (gap > 0) {
                         totalGaps += gap
                     }
-                    // 如果 gap <= 0，说明重叠或紧接，无新增不连续
                 }
 
-                lastMax = currentMax  // 更新状态
+                lastMax = currentMax
                 totalGaps
             }
         }

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -81,6 +81,7 @@ class SessionComponent(
 ) : Actor<SessionMsg>("SessionComponent", eventBus, parentScope) {
 
     private val sessions = ConcurrentHashMap<Long, RoomSession>()
+    private val lastBlockReason = ConcurrentHashMap<Long, String>()
 
     override suspend fun onStart(scope: CoroutineScope) {
         subscribe<RoomStatusChanged>(RoomStatusChanged::class)
@@ -192,6 +193,7 @@ class SessionComponent(
                     return@launch
                 }
                 rs.token = token.takeIf { it.isNotEmpty() }
+                lastBlockReason.remove(roomId)
             }
             val config = requestBus.request<RoomConfigResponse>(GetRoomConfig(roomId))
             rs.timeLimit = config.timeLimit
@@ -382,7 +384,9 @@ class SessionComponent(
                         rs.sizeLimitBytes = config.sizeLimitBytes
                     }
                     if (!config.autoPay) {
-                        logger.warn("[{}] Room not enable autopay", roomName)
+                        val reason = "autopay disabled"
+                        if (lastBlockReason.put(roomId, reason) != reason)
+                            logger.warn("[{}] Room not enable autopay", roomName)
                         return null
                     }
                     val camInfo = apiClient.roomFetchCamInfo(roomName, "")
@@ -390,7 +394,9 @@ class SessionComponent(
                     val users = requestBus.request<List<User>>(GetValidPaymentAccount(price.toLong()))
                     val u = users.firstOrNull()
                     if (u == null) {
-                        logger.warn("[{}] No account to pay. price={}", roomName, price)
+                        val reason = "insufficient balance"
+                        if (lastBlockReason.put(roomId, reason) != reason)
+                            logger.warn("[{}] No account to pay. price={}", roomName, price)
                         return null
                     }
                     var token = apiClient.roomFetchModelToken(roomName, u)

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -175,47 +175,48 @@ class SessionComponent(
             }
             if (blocked) return
         }
-        var token: String? = null
-        if (reconfigure) {
-            token = configureSession(roomId, name) ?: run {
-                logger.info("[{}] Session not started: configure returned false", name)
-                scope.launch {
-                    delay(5.seconds)
-                    requestBus.request<OkResponse>(RefreshRoomCmd(roomId))
-                }
-                return
-            }
-        }
-        val resolvedPkey = pkey.ifBlank { streamAuthKey }
-        val rs = RoomSession(roomId, name, quality, quality, pkey = resolvedPkey)
+        // Register session synchronously so DoStop/DoBreak can find it
+        val rs = RoomSession(roomId, name, quality, quality, pkey = pkey.ifBlank { streamAuthKey })
         sessions[roomId] = rs
-        rs.token = token.takeIf { !it.isNullOrEmpty() }
-        val config = requestBus.request<RoomConfigResponse>(GetRoomConfig(roomId))
-        rs.timeLimit = config.timeLimit
-        rs.sizeLimitBytes = config.sizeLimitBytes
         rs.state = SessionState.Fetching
         rs.startTime = Instant.now()
         dataChannel.send(StreamStart(roomId, name, rs.startTime, rs.quality))
-        try {
-            rs.masterPlaylist = fetchAndCacheMasterPlaylist(rs)
-            val availableNames = rs.masterPlaylist!!.variants.map { it.name }
-            val selected = selectQuality(availableNames, rs.quality)
-            rs.quality = selected
-            rs.targetquality = selected
-            rs.playlistUrl = resolveVariantUrl(rs)
-        } catch (e: Exception) {
-            logger.warn("[{}] Master playlist failed, falling back to API: {}", rs.roomName, e.message)
-            val qualities = apiClient.roomQualities(rs.roomName)
-            val selected = selectQuality(qualities, rs.quality)
-            val rawQuality = qualities.firstOrNull()
-            val useRaw = selected == rawQuality
-            rs.quality = selected
-            rs.targetquality = selected
-            rs.playlistUrl = buildFallbackPlaylistUrl(rs, useRaw)
+
+        scope.launch {
+            if (reconfigure) {
+                val token = configureSession(roomId, name) ?: run {
+                    logger.info("[{}] Session not started: configure returned false", name)
+                    sessions.remove(roomId)
+                    delay(5.seconds)
+                    requestBus.request<OkResponse>(RefreshRoomCmd(roomId))
+                    return@launch
+                }
+                rs.token = token.takeIf { it.isNotEmpty() }
+            }
+            val config = requestBus.request<RoomConfigResponse>(GetRoomConfig(roomId))
+            rs.timeLimit = config.timeLimit
+            rs.sizeLimitBytes = config.sizeLimitBytes
+            try {
+                rs.masterPlaylist = fetchAndCacheMasterPlaylist(rs)
+                val availableNames = rs.masterPlaylist!!.variants.map { it.name }
+                val selected = selectQuality(availableNames, rs.quality)
+                rs.quality = selected
+                rs.targetquality = selected
+                rs.playlistUrl = resolveVariantUrl(rs)
+            } catch (e: Exception) {
+                logger.warn("[{}] Master playlist failed, falling back to API: {}", rs.roomName, e.message)
+                val qualities = apiClient.roomQualities(rs.roomName)
+                val selected = selectQuality(qualities, rs.quality)
+                val rawQuality = qualities.firstOrNull()
+                val useRaw = selected == rawQuality
+                rs.quality = selected
+                rs.targetquality = selected
+                rs.playlistUrl = buildFallbackPlaylistUrl(rs, useRaw)
+            }
+            logger.info("Session starting: roomId={}, name={}, quality={}", roomId, name, rs.quality)
+            rs.pollingJob = launch { pollingLoop(rs) }
+            eventBus.publish(RecordingStarted(roomId, rs.quality))
         }
-        logger.info("Session starting: roomId={}, name={}, quality={}", roomId, name, rs.quality)
-        rs.pollingJob = scope.launch { pollingLoop(rs) }
-        eventBus.publish(RecordingStarted(roomId, rs.quality))
     }
 
     private suspend fun stopSession(roomId: Long) {

--- a/src/main/kotlin/github/rikacelery/v3/core/RequestBus.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/RequestBus.kt
@@ -2,6 +2,7 @@ package github.rikacelery.v3.core
 
 import github.rikacelery.v3.events.CommandAck
 import github.rikacelery.v3.events.CommandEnvelope
+import github.rikacelery.v3.events.ErrorResponse
 import github.rikacelery.v3.events.Request
 import kotlinx.coroutines.*
 import java.util.concurrent.ConcurrentHashMap
@@ -9,6 +10,9 @@ import java.util.concurrent.atomic.AtomicLong
 
 class RequestTimeoutException(cmd: Request, timeoutMs: Long) :
     RuntimeException("Request $cmd timed out after ${timeoutMs}ms")
+
+class RequestErrorException(cmd: Request, message: String) :
+    RuntimeException("Request $cmd failed: $message")
 
 class RequestBus(
     private val eventBus: EventBus,
@@ -33,7 +37,9 @@ class RequestBus(
         eventBus.publish(CommandEnvelope(id, cmd))
 
         return try {
-            withTimeout(timeoutMs) { deferred.await() as T }
+            val result = withTimeout(timeoutMs) { deferred.await() }
+            if (result is ErrorResponse) throw RequestErrorException(cmd, result.message)
+            result as T
         } catch (e: TimeoutCancellationException) {
             pending.remove(id)
             throw RequestTimeoutException(cmd, timeoutMs)

--- a/src/main/kotlin/github/rikacelery/v3/data/Room.kt
+++ b/src/main/kotlin/github/rikacelery/v3/data/Room.kt
@@ -70,13 +70,13 @@ object SizeStrSerializer : KSerializer<Long> {
         while (i < upper.length) {
             val c = upper[i]
             when {
-                c.isDigit() -> { numberBuf += c; i++ }
+                c.isDigit() || c == '.' -> { numberBuf += c; i++ }
                 c.isWhitespace() -> i++
                 c.isLetter() -> {
                     val matched = keys.firstOrNull { upper.startsWith(it, i) }
                         ?: throw IllegalArgumentException("Unknown unit at '$c' in '$input'")
                     if (numberBuf.isEmpty()) throw IllegalArgumentException("Missing number before '$matched' in '$input'")
-                    total += numberBuf.toLong() * unitMap[matched]!!
+                    total += (numberBuf.toDouble() * unitMap[matched]!!).toLong()
                     numberBuf = ""
                     i += matched.length
                 }

--- a/src/main/kotlin/github/rikacelery/v3/postprocessors/MoveProcessor.kt
+++ b/src/main/kotlin/github/rikacelery/v3/postprocessors/MoveProcessor.kt
@@ -4,6 +4,8 @@ import java.io.File
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 class MoveProcessor(
     private val template: String,
@@ -12,8 +14,10 @@ class MoveProcessor(
     private val fmt = DateTimeFormatter.ofPattern(datePattern).withZone(ZoneId.systemDefault())
 
     override suspend fun process(input: File, ctx: ProcessorCtx): List<File> {
-        val replace: (String) -> String = { arg ->
-            arg.replace("{{ROOM_NAME}}", ctx.roomName)
+        val needsFrames = "{{TOTAL_FRAMES}}" in template
+        val needsFramesGuess = "{{TOTAL_FRAMES_GUESS}}" in template
+        val replace: suspend (String) -> String = { arg ->
+            var s = arg.replace("{{ROOM_NAME}}", ctx.roomName)
                 .replace("{{ROOM_ID}}", ctx.roomId.toString())
                 .replace("{{RECORD_START}}", fmt.format(Instant.ofEpochMilli(ctx.startTime)))
                 .replace("{{RECORD_END}}", fmt.format(Instant.ofEpochMilli(ctx.endTime)))
@@ -24,8 +28,9 @@ class MoveProcessor(
                 .replace("{{INPUT_DIR}}", input.absoluteFile.parent)
                 .replace("{{INPUT_NAME}}", input.name)
                 .replace("{{INPUT_NAME_NOEXT}}", input.nameWithoutExtension)
-                .replace("{{TOTAL_FRAMES}}", totalFrames(input))
-                .replace("{{TOTAL_FRAMES_GUESS}}", totalFramesGuess(input, ctx.durationMs))
+            if (needsFrames) s = s.replace("{{TOTAL_FRAMES}}", totalFrames(input))
+            if (needsFramesGuess) s = s.replace("{{TOTAL_FRAMES_GUESS}}", totalFramesGuess(input, ctx.durationMs))
+            s
         }
         val resolved = replace(template)
         val isDir = File(resolved).extension.isEmpty()
@@ -57,22 +62,26 @@ class MoveProcessor(
         }
     }
 
-    private fun totalFrames(input: File): String = runCatching {
-        ProcessBuilder(
-            "ffprobe", "-v", "error", "-select_streams", "v:0",
-            "-count_frames", "-show_entries", "stream=nb_frames",
-            "-of", "default=noprint_wrappers=1:nokey=1", input.absolutePath
-        ).start().inputStream.bufferedReader().readText().trim()
-    }.getOrElse { "" }
+    private suspend fun totalFrames(input: File): String = withContext(Dispatchers.IO) {
+        runCatching {
+            ProcessBuilder(
+                "ffprobe", "-v", "error", "-select_streams", "v:0",
+                "-count_frames", "-show_entries", "stream=nb_frames",
+                "-of", "default=noprint_wrappers=1:nokey=1", input.absolutePath
+            ).start().inputStream.bufferedReader().readText().trim()
+        }.getOrElse { "" }
+    }
 
-    private fun totalFramesGuess(input: File, durationMs: Long): String = runCatching {
-        val fpsStr = ProcessBuilder(
-            "ffprobe", "-v", "error", "-select_streams", "v:0",
-            "-show_entries", "stream=r_frame_rate",
-            "-of", "default=noprint_wrappers=1:nokey=1", input.absolutePath
-        ).start().inputStream.bufferedReader().readText().trim()
-        val fps = fpsStr.split("/").mapNotNull { it.toLongOrNull() }
-            .takeIf { it.size == 2 }?.let { it[0].toDouble() / it[1] } ?: return@runCatching ""
-        (fps * durationMs / 1000).toLong().toString()
-    }.getOrElse { "" }
+    private suspend fun totalFramesGuess(input: File, durationMs: Long): String = withContext(Dispatchers.IO) {
+        runCatching {
+            val fpsStr = ProcessBuilder(
+                "ffprobe", "-v", "error", "-select_streams", "v:0",
+                "-show_entries", "stream=r_frame_rate",
+                "-of", "default=noprint_wrappers=1:nokey=1", input.absolutePath
+            ).start().inputStream.bufferedReader().readText().trim()
+            val fps = fpsStr.split("/").mapNotNull { it.toLongOrNull() }
+                .takeIf { it.size == 2 }?.let { it[0].toDouble() / it[1] } ?: return@withContext ""
+            (fps * durationMs / 1000).toLong().toString()
+        }.getOrElse { "" }
+    }
 }

--- a/src/main/kotlin/github/rikacelery/v3/postprocessors/ShellProcessor.kt
+++ b/src/main/kotlin/github/rikacelery/v3/postprocessors/ShellProcessor.kt
@@ -19,7 +19,7 @@ class ShellProcessor(
 
     override suspend fun process(input: File, ctx: ProcessorCtx): List<File> {
         val cmd = command.map { substitute(it, ctx, input) }
-        logger.info("run: {}", cmd.joinToString(" "))
+        logger.debug("run: {}", cmd.joinToString(" "))
         val p = withContext(Dispatchers.IO) { ProcessBuilder(cmd).start() }
 
         val (exitCode, lastLine) = coroutineScope {

--- a/src/main/kotlin/github/rikacelery/v3/postprocessors/ShellProcessor.kt
+++ b/src/main/kotlin/github/rikacelery/v3/postprocessors/ShellProcessor.kt
@@ -41,8 +41,8 @@ class ShellProcessor(
         }
     }
 
-    private fun substitute(template: String, ctx: ProcessorCtx, file: File): String {
-        return template
+    private suspend fun substitute(template: String, ctx: ProcessorCtx, file: File): String {
+        var s = template
             .replace("{{ROOM_NAME}}", ctx.roomName)
             .replace("{{ROOM_ID}}", ctx.roomId.toString())
             .replace("{{RECORD_START}}", fmt.format(Instant.ofEpochMilli(ctx.startTime)))
@@ -54,8 +54,9 @@ class ShellProcessor(
             .replace("{{INPUT_DIR}}", file.absoluteFile.parent)
             .replace("{{INPUT_NAME}}", file.name)
             .replace("{{INPUT_NAME_NOEXT}}", file.nameWithoutExtension)
-            .replace("{{TOTAL_FRAMES}}", totalFrames(file))
-            .replace("{{TOTAL_FRAMES_GUESS}}", totalFramesGuess(file, ctx.durationMs))
+        if ("{{TOTAL_FRAMES}}" in s) s = s.replace("{{TOTAL_FRAMES}}", totalFrames(file))
+        if ("{{TOTAL_FRAMES_GUESS}}" in s) s = s.replace("{{TOTAL_FRAMES_GUESS}}", totalFramesGuess(file, ctx.durationMs))
+        return s
     }
 
     private fun formatDuration(ms: Long): String {
@@ -67,22 +68,26 @@ class ShellProcessor(
         else "%02dh%02dm%02ds".format(hours % 24, minutes % 60, seconds % 60)
     }
 
-    private fun totalFrames(input: File): String = runCatching {
-        ProcessBuilder(
-            "ffprobe", "-v", "error", "-select_streams", "v:0",
-            "-count_frames", "-show_entries", "stream=nb_frames",
-            "-of", "default=noprint_wrappers=1:nokey=1", input.absolutePath
-        ).start().inputStream.bufferedReader().readText().trim()
-    }.getOrElse { "" }
+    private suspend fun totalFrames(input: File): String = withContext(Dispatchers.IO) {
+        runCatching {
+            ProcessBuilder(
+                "ffprobe", "-v", "error", "-select_streams", "v:0",
+                "-count_frames", "-show_entries", "stream=nb_frames",
+                "-of", "default=noprint_wrappers=1:nokey=1", input.absolutePath
+            ).start().inputStream.bufferedReader().readText().trim()
+        }.getOrElse { "" }
+    }
 
-    private fun totalFramesGuess(input: File, durationMs: Long): String = runCatching {
-        val fpsStr = ProcessBuilder(
-            "ffprobe", "-v", "error", "-select_streams", "v:0",
-            "-show_entries", "stream=r_frame_rate",
-            "-of", "default=noprint_wrappers=1:nokey=1", input.absolutePath
-        ).start().inputStream.bufferedReader().readText().trim()
-        val fps = fpsStr.split("/").mapNotNull { it.toLongOrNull() }
-            .takeIf { it.size == 2 }?.let { it[0].toDouble() / it[1] } ?: return@runCatching ""
-        (fps * durationMs / 1000).toLong().toString()
-    }.getOrElse { "" }
+    private suspend fun totalFramesGuess(input: File, durationMs: Long): String = withContext(Dispatchers.IO) {
+        runCatching {
+            val fpsStr = ProcessBuilder(
+                "ffprobe", "-v", "error", "-select_streams", "v:0",
+                "-show_entries", "stream=r_frame_rate",
+                "-of", "default=noprint_wrappers=1:nokey=1", input.absolutePath
+            ).start().inputStream.bufferedReader().readText().trim()
+            val fps = fpsStr.split("/").mapNotNull { it.toLongOrNull() }
+                .takeIf { it.size == 2 }?.let { it[0].toDouble() / it[1] } ?: return@withContext ""
+            (fps * durationMs / 1000).toLong().toString()
+        }.getOrElse { "" }
+    }
 }

--- a/src/main/kotlin/github/rikacelery/v3/postprocessors/ShellProcessor.kt
+++ b/src/main/kotlin/github/rikacelery/v3/postprocessors/ShellProcessor.kt
@@ -17,6 +17,7 @@ class ShellProcessor(
 
     override suspend fun process(input: File, ctx: ProcessorCtx): List<File> {
         val cmd = command.map { substitute(it, ctx, input) }
+        logger.info("run: {}", cmd.joinToString(" "))
         val builder = ProcessBuilder(cmd)
         val p = withContext(Dispatchers.IO) {
             builder.start()
@@ -24,7 +25,7 @@ class ShellProcessor(
         p.errorStream.bufferedReader().use {
             while (true) {
                 val line = it.readLine() ?: break
-                println(line)
+                logger.warn("[ffmpeg] {}", line)
             }
         }
         if (withContext(Dispatchers.IO) {

--- a/src/main/kotlin/github/rikacelery/v3/postprocessors/ShellProcessor.kt
+++ b/src/main/kotlin/github/rikacelery/v3/postprocessors/ShellProcessor.kt
@@ -1,6 +1,8 @@
 package github.rikacelery.v3.postprocessors
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.time.Instant
@@ -18,21 +20,37 @@ class ShellProcessor(
     override suspend fun process(input: File, ctx: ProcessorCtx): List<File> {
         val cmd = command.map { substitute(it, ctx, input) }
         logger.info("run: {}", cmd.joinToString(" "))
-        val builder = ProcessBuilder(cmd)
-        val p = withContext(Dispatchers.IO) {
-            builder.start()
-        }
-        p.errorStream.bufferedReader().use {
-            while (true) {
-                val line = it.readLine() ?: break
-                logger.warn("[ffmpeg] {}", line)
+        val p = withContext(Dispatchers.IO) { ProcessBuilder(cmd).start() }
+
+        val (exitCode, stdoutLines) = coroutineScope {
+            val stdoutJob = async(Dispatchers.IO) {
+                p.inputStream.bufferedReader().use { r ->
+                    val lines = mutableListOf<String>()
+                    while (true) {
+                        val line = r.readLine() ?: break
+                        logger.info("[stdout] {}", line)
+                        lines.add(line)
+                    }
+                    lines
+                }
             }
+            val stderrJob = async(Dispatchers.IO) {
+                p.errorStream.bufferedReader().use { r ->
+                    while (true) {
+                        val line = r.readLine() ?: break
+                        logger.info("[stderr] {}", line)
+                    }
+                }
+            }
+            val exitJob = async(Dispatchers.IO) { p.waitFor() }
+            val lines = stdoutJob.await()
+            stderrJob.await()
+            Pair(exitJob.await(), lines)
         }
-        if (withContext(Dispatchers.IO) {
-                p.waitFor()
-            } == 0) {
+
+        if (exitCode == 0) {
             if (noreturn) return listOf(input)
-            val outputFile = File(p.inputStream.bufferedReader().readLines().last())
+            val outputFile = File(stdoutLines.last())
             if (!outputFile.exists()) throw IllegalStateException("Output file not found: $outputFile")
             if (removeInput) input.delete()
             return listOf(outputFile)

--- a/src/main/kotlin/github/rikacelery/v3/postprocessors/ShellProcessor.kt
+++ b/src/main/kotlin/github/rikacelery/v3/postprocessors/ShellProcessor.kt
@@ -22,16 +22,15 @@ class ShellProcessor(
         logger.info("run: {}", cmd.joinToString(" "))
         val p = withContext(Dispatchers.IO) { ProcessBuilder(cmd).start() }
 
-        val (exitCode, stdoutLines) = coroutineScope {
+        val (exitCode, lastLine) = coroutineScope {
+            var outputLine: String? = null
             val stdoutJob = async(Dispatchers.IO) {
                 p.inputStream.bufferedReader().use { r ->
-                    val lines = mutableListOf<String>()
                     while (true) {
                         val line = r.readLine() ?: break
                         logger.info("[stdout] {}", line)
-                        lines.add(line)
+                        outputLine = line
                     }
-                    lines
                 }
             }
             val stderrJob = async(Dispatchers.IO) {
@@ -43,14 +42,15 @@ class ShellProcessor(
                 }
             }
             val exitJob = async(Dispatchers.IO) { p.waitFor() }
-            val lines = stdoutJob.await()
+            stdoutJob.await()
             stderrJob.await()
-            Pair(exitJob.await(), lines)
+            Pair(exitJob.await(), outputLine)
         }
 
         if (exitCode == 0) {
             if (noreturn) return listOf(input)
-            val outputFile = File(stdoutLines.last())
+            val outputLine = lastLine ?: throw IllegalStateException("No output from shell command")
+            val outputFile = File(outputLine)
             if (!outputFile.exists()) throw IllegalStateException("Output file not found: $outputFile")
             if (removeInput) input.delete()
             return listOf(outputFile)

--- a/src/main/resources/vue.html
+++ b/src/main/resources/vue.html
@@ -266,78 +266,75 @@
 
         <div class="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
             <div class="overflow-x-auto">
-                <table class="w-full text-sm text-left">
+                <table class="w-full text-xs text-left">
                     <thead
-                        class="bg-slate-50 text-slate-600 font-semibold border-b border-slate-200 uppercase text-xs tracking-wider text-nowrap">
+                        class="bg-slate-50 text-slate-600 font-semibold border-b border-slate-200 uppercase tracking-wider text-nowrap">
                         <tr>
-                            <th class="px-2 py-2 cursor-pointer hover:bg-slate-100 transition-colors select-none"
+                            <th class="px-3 py-2.5 cursor-pointer hover:bg-slate-100 transition-colors select-none text-xs"
                                 @click="sortToggle('Room')">
-                                Room <i class="fa-solid ml-0.5 text-[8px]"
+                                Room <i class="fa-solid ml-0.5 text-[9px]"
                                     :class="!sort['Room'] ? 'fa-sort text-slate-300' : (sort['Room'] === 1 ? 'fa-sort-down text-indigo-500' : 'fa-sort-up text-indigo-500')"></i>
                             </th>
-                            <th class="px-1 py-2 text-center text-[10px] cursor-pointer hover:bg-slate-100 transition-colors select-none"
+                            <th class="px-2 py-2.5 text-center cursor-pointer hover:bg-slate-100 transition-colors select-none text-xs"
                                 @click="sortToggle('RoomStatus')">
-                                Room <i class="fa-solid ml-0.5 text-[8px]"
+                                Status <i class="fa-solid ml-0.5 text-[9px]"
                                     :class="!sort['RoomStatus'] ? 'fa-sort text-slate-300' : (sort['RoomStatus'] === 1 ? 'fa-sort-down text-indigo-500' : 'fa-sort-up text-indigo-500')"></i>
                             </th>
-                            <th class="px-1 py-2 text-center text-[10px]">Preview</th>
-                            <th class="px-1 py-2 cursor-pointer hover:bg-slate-100 transition-colors select-none text-[10px]"
+                            <th class="px-2 py-2.5 text-center text-xs">Preview</th>
+                            <th class="px-2 py-2.5 cursor-pointer hover:bg-slate-100 transition-colors select-none text-center text-xs"
                                 @click="sortToggle('ID')">
-                                ID <i class="fa-solid ml-0.5 text-[8px]"
+                                ID <i class="fa-solid ml-0.5 text-[9px]"
                                     :class="!sort['ID'] ? 'fa-sort text-slate-300' : (sort['ID'] === 1 ? 'fa-sort-down text-indigo-500' : 'fa-sort-up text-indigo-500')"></i>
                             </th>
-                            <th class="px-1 py-2 cursor-pointer hover:bg-slate-100 transition-colors select-none text-center text-[10px]"
+                            <th class="px-2 py-2.5 cursor-pointer hover:bg-slate-100 transition-colors select-none text-center text-xs"
                                 @click="sortToggle('Quality')">
-                                Q <i class="fa-solid ml-0.5 text-[8px]"
+                                Quality <i class="fa-solid ml-0.5 text-[9px]"
                                     :class="!sort['Quality'] ? 'fa-sort text-slate-300' : (sort['Quality'] === 1 ? 'fa-sort-down text-indigo-500' : 'fa-sort-up text-indigo-500')"></i>
                             </th>
-                            <th class="px-1 py-2 cursor-pointer hover:bg-slate-100 transition-colors select-none text-center"
+                            <th class="px-2 py-2.5 cursor-pointer hover:bg-slate-100 transition-colors select-none text-center text-xs"
                                 @click="sortToggle('Limit')">
-                                <div class="flex flex-col text-[10px] leading-tight">
-                                    <span>T <i class="fa-solid ml-0.5 text-[8px]"
-                                        :class="!sort['Limit'] ? 'fa-sort text-slate-300' : (sort['Limit'] === 1 ? 'fa-sort-down text-indigo-500' : 'fa-sort-up text-indigo-500')"></i></span>
-                                    <span>Size</span>
-                                </div>
+                                Limit <i class="fa-solid ml-0.5 text-[9px]"
+                                    :class="!sort['Limit'] ? 'fa-sort text-slate-300' : (sort['Limit'] === 1 ? 'fa-sort-down text-indigo-500' : 'fa-sort-up text-indigo-500')"></i>
                             </th>
-                            <th class="px-1 py-2 cursor-pointer hover:bg-slate-100 transition-colors select-none text-center text-[10px]"
+                            <th class="px-2 py-2.5 cursor-pointer hover:bg-slate-100 transition-colors select-none text-center text-xs"
                                 @click="sortToggle('Status')">
-                                St <i class="fa-solid ml-0.5 text-[8px]"
+                                State <i class="fa-solid ml-0.5 text-[9px]"
                                     :class="!sort['Status'] ? 'fa-sort text-slate-300' : (sort['Status'] === 1 ? 'fa-sort-down text-indigo-500' : 'fa-sort-up text-indigo-500')"></i>
                             </th>
-                            <th class="px-1 py-2 cursor-pointer hover:bg-slate-100 transition-colors select-none text-center text-[10px]"
+                            <th class="px-2 py-2.5 cursor-pointer hover:bg-slate-100 transition-colors select-none text-center text-xs"
                                 @click="sortToggle('AutoPay')">
-                                AP <i class="fa-solid ml-0.5 text-[8px]"
+                                Auto Pay <i class="fa-solid ml-0.5 text-[9px]"
                                     :class="!sort['AutoPay'] ? 'fa-sort text-slate-300' : (sort['AutoPay'] === 1 ? 'fa-sort-down text-indigo-500' : 'fa-sort-up text-indigo-500')"></i>
                             </th>
-                            <th class="px-1 py-2 text-[10px] text-center">Seg</th>
-                            <th class="px-1 py-2 cursor-pointer hover:bg-slate-100 transition-colors select-none text-right text-[10px]"
+                            <th class="px-2 py-2.5 text-center text-xs">Segments</th>
+                            <th class="px-2 py-2.5 cursor-pointer hover:bg-slate-100 transition-colors select-none text-right text-xs"
                                 @click="sortToggle('Size')">
-                                Sz <i class="fa-solid ml-0.5 text-[8px]"
+                                Size <i class="fa-solid ml-0.5 text-[9px]"
                                     :class="!sort['Size'] ? 'fa-sort text-slate-300' : (sort['Size'] === 1 ? 'fa-sort-down text-indigo-500' : 'fa-sort-up text-indigo-500')"></i>
                             </th>
-                            <th class="px-1 py-2 text-center text-[10px]">Act</th>
+                            <th class="px-2 py-2.5 text-center text-xs">Actions</th>
                         </tr>
                     </thead>
                     <tbody class="divide-y divide-slate-100">
                         <tr v-if="roomDisplay.length === 0">
-                            <td colspan="9" class="px-4 py-12 text-center text-slate-400">
+                            <td colspan="11" class="px-4 py-12 text-center text-slate-400">
                                 <i class="fa-solid fa-inbox text-3xl mb-2"></i>
                                 <p>No rooms found. Add a room to start recording.</p>
                             </td>
                         </tr>
                         <tr v-for="room in roomDisplay" :key="room.name"
                             class="hover:bg-slate-50 transition-colors group">
-                            <td class="px-2 py-1 font-medium text-indigo-600 text-xs">
+                            <td class="px-3 py-1.5 font-medium text-indigo-600 text-xs">
                                 <a :href="`https://xhamsterlive.com/${room.name}`" target="_blank"
                                     class="hover:underline flex items-center gap-0.5">
                                     {{room.name}} <i
                                         class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] text-slate-400"></i>
                                 </a>
                             </td>
-                            <td class="px-1 py-1 text-center text-[10px] text-slate-500">
+                            <td class="px-2 py-1.5 text-center text-xs text-slate-500">
                                 {{room.roomStatus}}
                             </td>
-                            <td class="px-1 py-1 text-center">
+                            <td class="px-2 py-1.5 text-center">
                                 <div class="thumb-container">
                                     <template v-if="room.sessionStatus==='Recording'">
                                         <div v-if="!activeVideos[room.id]" class="thumb-placeholder border border-slate-200"
@@ -362,61 +359,65 @@
                                         N/A</div>
                                 </div>
                             </td>
-                            <td class="px-1 py-1 text-slate-400 font-mono text-[10px] text-center">{{room.id || '-'}}</td>
-                            <td class="px-2 py-1">
+                            <td class="px-2 py-1.5 text-slate-400 font-mono text-xs text-center">{{room.id || '-'}}</td>
+                            <td class="px-2 py-1.5">
                                 <div class="flex flex-col items-center gap-0.5">
                                     <select @change="ev => setQuality(ev.target.value, room.id)" :value="room.quality"
-                                        class="text-[10px] py-0.5 px-1 border border-slate-200 rounded bg-white focus:outline-none focus:border-indigo-500 w-16">
+                                        class="text-xs py-0.5 px-1 border border-slate-200 rounded bg-white focus:outline-none focus:border-indigo-500 w-18">
                                         <option
                                             v-for="q in ['highest','160p','240p','480p','720p','720p60','540p','960p','1080p','1080p60','2560p60']"
                                             :key="q">{{q}}</option>
                                     </select>
                                     <span v-if="room.sessionStatus==='Recording' && room.sessionQuality"
-                                        class="text-[10px] font-mono text-emerald-600 bg-emerald-50 px-1 rounded border border-emerald-200"
-                                        :title="'实际录制清晰度: ' + room.sessionQuality">
+                                        class="text-xs font-mono text-emerald-600 bg-emerald-50 px-1.5 py-0.5 rounded border border-emerald-200"
+                                        :title="'Actual recording quality: ' + room.sessionQuality">
                                         ⏺{{room.sessionQuality}}
                                     </span>
                                 </div>
                             </td>
-                            <td class="px-2 py-1">
-                                <div class="flex flex-col gap-0.5 text-[10px]">
+                            <td class="px-2 py-1.5">
+                                <div class="flex flex-col gap-1.5 items-end text-xs">
                                     <div class="flex items-center gap-1">
-                                        <span class="text-slate-500 text-right whitespace-nowrap">{{room.timeLimit > 0 ? (room.timeLimit / 1000) : 0}}</span>
+                                        <span class="text-slate-500 whitespace-nowrap font-mono w-12 text-right">{{room.timeLimit > 0 ? (room.timeLimit / 1000) : '∞'}}s</span>
                                         <input v-model.number="editLimits[room.id]" type="number" min="0"
-                                            class="w-12 px-1 py-0.5 text-[10px] border border-slate-200 rounded bg-white focus:outline-none focus:border-indigo-500"
-                                            placeholder="new">
+                                            class="w-14 px-1.5 py-0.5 text-xs border border-slate-200 rounded bg-white focus:outline-none focus:border-indigo-500"
+                                            placeholder="sec">
                                         <button @click="setLimit(room.id)" title="Set Time"
                                             class="text-emerald-600 hover:text-emerald-800 p-0.5 leading-none">
-                                            <i class="fa-solid fa-check text-[10px]"></i>
+                                            <i class="fa-solid fa-check text-[11px]"></i>
                                         </button>
                                     </div>
                                     <div class="flex items-center gap-1">
-                                        <span class="text-slate-500 text-right whitespace-nowrap">{{room.sizeLimitBytes > 0 ? formatBytes(room.sizeLimitBytes) : '0'}}</span>
+                                        <span class="text-slate-500 whitespace-nowrap font-mono w-12 text-right">{{room.sizeLimitBytes > 0 ? formatBytes(room.sizeLimitBytes) : '∞'}}</span>
                                         <input v-model="editSizeLimits[room.id]" type="text"
-                                            class="w-12 px-1 py-0.5 text-[10px] border border-slate-200 rounded bg-white focus:outline-none focus:border-indigo-500"
-                                            placeholder="new">
+                                            class="w-14 px-1.5 py-0.5 text-xs border border-slate-200 rounded bg-white focus:outline-none focus:border-indigo-500"
+                                            placeholder="e.g. 1G">
                                         <button @click="setSizeLimit(room.id)" title="Set Size"
                                             class="text-emerald-600 hover:text-emerald-800 p-0.5 leading-none">
-                                            <i class="fa-solid fa-check text-[10px]"></i>
+                                            <i class="fa-solid fa-check text-[11px]"></i>
                                         </button>
                                     </div>
                                 </div>
                             </td>
-                            <td class="px-1 py-1 text-center">
+                            <td class="px-2 py-1.5 text-center">
                                 <span v-if="room.sessionStatus==='Recording'"
-                                    class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-red-100 text-red-700">
+                                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-700">
                                     <span class="w-1.5 h-1.5 rounded-full bg-red-500 status-recording"></span>REC
                                 </span>
+                                <span v-else-if="room.sessionStatus==='Fetching'"
+                                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-700">
+                                    <i class="fa-solid fa-arrow-down text-[10px]"></i>FETCH
+                                </span>
                                 <span v-else-if="room.sessionStatus==='Listening'"
-                                    class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-blue-100 text-blue-700">
+                                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-700">
                                     <i class="fa-solid fa-hourglass-half fa-spin-pulse text-[10px]"></i>ARM
                                 </span>
                                 <span v-else-if="room.sessionStatus===''"
-                                    class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-slate-100 text-slate-500">
+                                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-slate-100 text-slate-500">
                                     <i class="fa-solid fa-video-slash text-[10px]"></i>OFF
                                 </span>
                                 <span v-else
-                                    class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-gray-100 text-gray-700">
+                                    class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-700">
                                     {{room.sessionStatus}}
                                 </span>
                             </td>
@@ -429,49 +430,52 @@
                                     </div>
                                 </label>
                             </td>
-                            <td class="px-1 py-1">
-                                <div v-if="room.sessionStatus==='Recording'" class="flex items-center gap-1 text-[10px] font-mono">
-                                    <span class="text-emerald-600 flex items-center gap-0.5" title="Running"><i
-                                            :class="[{'animate-bounce':room.running},'fa-download','fa-solid','text-[9px]']"></i>{{room.running
-                                        || 0}}</span>
-                                    <span class="text-blue-600 flex items-center gap-0.5" title="Success"><i
-                                            class="fa-solid fa-check text-[9px]"></i>{{room.success || 0}}</span>
-                                    <span class="text-red-600 flex items-center gap-0.5" title="Failed"><i
-                                            class="fa-solid fa-xmark text-[9px]"></i>{{room.failed || 0}}</span>
-                                    <span class="text-yellow-600 flex items-center gap-0.5" title="Missing"><i
-                                            class="fa-solid fa-question text-[9px]"></i>{{room.segMissing || 0}}</span>
+                            <td class="px-2 py-1.5">
+                                <div v-if="room.sessionStatus==='Recording'" class="flex flex-col gap-0.5 items-end text-xs font-mono">
+                                    <span class="text-emerald-600 flex items-center gap-1" title="Downloading">
+                                        <i :class="[{'animate-bounce':room.running},'fa-download','fa-solid','text-[10px]']"></i>
+                                        <span class="w-8 text-right">{{room.running || 0}}</span>
+                                    </span>
+                                    <span class="text-blue-600 flex items-center gap-1" title="Complete">
+                                        <i class="fa-solid fa-check text-[10px]"></i>
+                                        <span class="w-8 text-right">{{room.success || 0}}</span>
+                                    </span>
+                                    <span class="text-red-600 flex items-center gap-1" title="Failed">
+                                        <i class="fa-solid fa-xmark text-[10px]"></i>
+                                        <span class="w-8 text-right">{{room.failed || 0}}</span>
+                                    </span>
+                                    <span class="text-amber-600 flex items-center gap-1" title="Missing">
+                                        <i class="fa-solid fa-question text-[10px]"></i>
+                                        <span class="w-8 text-right">{{room.segMissing || 0}}</span>
+                                    </span>
                                 </div>
-                                <span v-else class="text-slate-300 text-[10px]">-</span>
+                                <span v-else class="text-slate-300 text-xs">-</span>
                             </td>
-                            <td class="px-1 py-1 text-right font-mono text-[10px] text-slate-600">
+                            <td class="px-2 py-1.5 text-right font-mono text-xs text-slate-600">
                                 {{formatBytes(room.bytesWrite)}}
                             </td>
-                            <td class="px-1 py-1">
+                            <td class="px-2 py-1.5">
                                 <div
-                                    class="flex items-center justify-center gap-1.5 opacity-70 group-hover:opacity-100 transition-opacity">
+                                    class="flex items-center justify-center gap-1 opacity-70 group-hover:opacity-100 transition-opacity">
                                     <button @click="action('activate',room.id)" title="Activate"
-                                        class="w-7 h-7 rounded bg-slate-100 text-emerald-600 hover:bg-emerald-600 hover:text-white transition-colors flex items-center justify-center">
-                                        <i class="fa-solid fa-play text-xs"></i>
+                                        class="w-6 h-6 rounded bg-slate-100 text-emerald-600 hover:bg-emerald-600 hover:text-white transition-colors flex items-center justify-center">
+                                        <i class="fa-solid fa-play text-[10px]"></i>
                                     </button>
-
                                     <button @click="action('deactivate',room.id)" title="Deactivate"
-                                        class="w-7 h-7 rounded bg-slate-100 text-amber-600 hover:bg-amber-600 hover:text-white transition-colors flex items-center justify-center">
-                                        <i class="fa-solid fa-stop text-xs"></i>
+                                        class="w-6 h-6 rounded bg-slate-100 text-amber-600 hover:bg-amber-600 hover:text-white transition-colors flex items-center justify-center">
+                                        <i class="fa-solid fa-stop text-[10px]"></i>
                                     </button>
-
-                                    <button @click="action('restart',room.id)" title="Save & Restart (Full)"
-                                        class="w-7 h-7 rounded bg-slate-100 text-purple-600 hover:bg-purple-600 hover:text-white transition-colors flex items-center justify-center">
-                                        <i class="fa-solid fa-rotate-right text-xs"></i>
+                                    <button @click="action('restart',room.id)" title="Restart"
+                                        class="w-6 h-6 rounded bg-slate-100 text-purple-600 hover:bg-purple-600 hover:text-white transition-colors flex items-center justify-center">
+                                        <i class="fa-solid fa-rotate-right text-[10px]"></i>
                                     </button>
-
-                                    <button @click="action('break',room.id)" title="Break (Split File Only)"
-                                        class="w-7 h-7 rounded bg-slate-100 text-blue-600 hover:bg-blue-600 hover:text-white transition-colors flex items-center justify-center">
-                                        <i class="fa-solid fa-scissors text-xs"></i>
+                                    <button @click="action('break',room.id)" title="Break"
+                                        class="w-6 h-6 rounded bg-slate-100 text-blue-600 hover:bg-blue-600 hover:text-white transition-colors flex items-center justify-center">
+                                        <i class="fa-solid fa-scissors text-[10px]"></i>
                                     </button>
-
                                     <button @click="action('remove',room.id)" title="Remove"
-                                        class="w-7 h-7 rounded bg-slate-100 text-red-600 hover:bg-red-600 hover:text-white transition-colors flex items-center justify-center">
-                                        <i class="fa-solid fa-trash-can text-xs"></i>
+                                        class="w-6 h-6 rounded bg-slate-100 text-red-600 hover:bg-red-600 hover:text-white transition-colors flex items-center justify-center">
+                                        <i class="fa-solid fa-trash-can text-[10px]"></i>
                                     </button>
                                 </div>
                             </td>

--- a/src/main/resources/vue.html
+++ b/src/main/resources/vue.html
@@ -361,16 +361,16 @@
                             </td>
                             <td class="px-2 py-1.5 text-slate-400 font-mono text-xs text-center">{{room.id || '-'}}</td>
                             <td class="px-2 py-1.5">
-                                <div class="flex flex-col items-center gap-0.5">
+                                <div class="flex items-center gap-1.5">
                                     <select @change="ev => setQuality(ev.target.value, room.id)" :value="room.quality"
-                                        class="text-xs py-0.5 px-1 border border-slate-200 rounded bg-white focus:outline-none focus:border-indigo-500 w-18">
+                                        class="text-xs py-0.5 px-1 border border-slate-200 rounded bg-white focus:outline-none focus:border-indigo-500 w-16">
                                         <option
                                             v-for="q in ['highest','160p','240p','480p','720p','720p60','540p','960p','1080p','1080p60','2560p60']"
                                             :key="q">{{q}}</option>
                                     </select>
                                     <span v-if="room.sessionStatus==='Recording' && room.sessionQuality"
-                                        class="text-xs font-mono text-emerald-600 bg-emerald-50 px-1.5 py-0.5 rounded border border-emerald-200"
-                                        :title="'Actual recording quality: ' + room.sessionQuality">
+                                        class="text-[11px] font-mono text-emerald-600 bg-emerald-50 px-1 py-0.5 rounded border border-emerald-200 whitespace-nowrap"
+                                        :title="'Actual recording quality'">
                                         ⏺{{room.sessionQuality}}
                                     </span>
                                 </div>
@@ -378,7 +378,7 @@
                             <td class="px-2 py-1.5">
                                 <div class="flex flex-col gap-1.5 items-end text-xs">
                                     <div class="flex items-center gap-1">
-                                        <span class="text-slate-500 whitespace-nowrap font-mono w-12 text-right">{{room.timeLimit > 0 ? (room.timeLimit / 1000) : '∞'}}s</span>
+                                        <span class="text-slate-500 font-mono text-right min-w-[3rem]">{{room.timeLimit > 0 ? (room.timeLimit / 1000) : '∞'}}s</span>
                                         <input v-model.number="editLimits[room.id]" type="number" min="0"
                                             class="w-14 px-1.5 py-0.5 text-xs border border-slate-200 rounded bg-white focus:outline-none focus:border-indigo-500"
                                             placeholder="sec">
@@ -388,7 +388,7 @@
                                         </button>
                                     </div>
                                     <div class="flex items-center gap-1">
-                                        <span class="text-slate-500 whitespace-nowrap font-mono w-12 text-right">{{room.sizeLimitBytes > 0 ? formatBytes(room.sizeLimitBytes) : '∞'}}</span>
+                                        <span class="text-slate-500 font-mono text-right min-w-[3rem]">{{room.sizeLimitBytes > 0 ? formatBytes(room.sizeLimitBytes) : '∞'}}</span>
                                         <input v-model="editSizeLimits[room.id]" type="text"
                                             class="w-14 px-1.5 py-0.5 text-xs border border-slate-200 rounded bg-white focus:outline-none focus:border-indigo-500"
                                             placeholder="e.g. 1G">
@@ -431,22 +431,22 @@
                                 </label>
                             </td>
                             <td class="px-2 py-1.5">
-                                <div v-if="room.sessionStatus==='Recording'" class="flex flex-col gap-0.5 items-end text-xs font-mono">
-                                    <span class="text-emerald-600 flex items-center gap-1" title="Downloading">
+                                <div v-if="room.sessionStatus==='Recording'" class="grid grid-cols-2 gap-x-3 gap-y-0.5 text-xs font-mono">
+                                    <span class="text-emerald-600 flex items-center gap-1 justify-end" title="Downloading">
                                         <i :class="[{'animate-bounce':room.running},'fa-download','fa-solid','text-[10px]']"></i>
-                                        <span class="w-8 text-right">{{room.running || 0}}</span>
+                                        <span class="w-7 text-right">{{room.running || 0}}</span>
                                     </span>
-                                    <span class="text-blue-600 flex items-center gap-1" title="Complete">
+                                    <span class="text-blue-600 flex items-center gap-1 justify-end" title="Complete">
                                         <i class="fa-solid fa-check text-[10px]"></i>
-                                        <span class="w-8 text-right">{{room.success || 0}}</span>
+                                        <span class="w-7 text-right">{{room.success || 0}}</span>
                                     </span>
-                                    <span class="text-red-600 flex items-center gap-1" title="Failed">
+                                    <span class="text-red-600 flex items-center gap-1 justify-end" title="Failed">
                                         <i class="fa-solid fa-xmark text-[10px]"></i>
-                                        <span class="w-8 text-right">{{room.failed || 0}}</span>
+                                        <span class="w-7 text-right">{{room.failed || 0}}</span>
                                     </span>
-                                    <span class="text-amber-600 flex items-center gap-1" title="Missing">
+                                    <span class="text-amber-600 flex items-center gap-1 justify-end" title="Missing">
                                         <i class="fa-solid fa-question text-[10px]"></i>
-                                        <span class="w-8 text-right">{{room.segMissing || 0}}</span>
+                                        <span class="w-7 text-right">{{room.segMissing || 0}}</span>
                                     </span>
                                 </div>
                                 <span v-else class="text-slate-300 text-xs">-</span>


### PR DESCRIPTION
## Summary

- WebUI: enlarged fonts, full column names, compact 2×2 segment grid, quality badge side-by-side, right-aligned limits
- Shutdown: CompletableDeferred instead of appScope.cancel() to avoid JobCancellationException
- Postprocessor: lazy ffprobe on IO dispatcher, structured concurrency for shell stdout/stderr, logger instead of println
- RequestBus: typed RequestErrorException, session startup decoupled from mailbox to prevent GetSessions timeouts
- Misc: filter segment ID 0 from gap detection, suppress repeated autopay warns, support fractional size values (50.2M)