### PR TITLE
docs: add zh-CN link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # XhREC
 
+[简体中文](README_zh-CN.md)
+
 Kotlin application for automatic live stream recording, with a browser extension for one-click control.
 
 ## Quick Start


### PR DESCRIPTION
Add [简体中文](README_zh-CN.md) link below the README title header.