### PR TITLE
feat(v3): log masking with CRC32+salt via logback converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Stream decryption key store. Created with defaults on first run if absent.
 ```json
 {
   "streamAuthKey": "default psch key, if failed to extract from master playlist",
+  "maskSensitiveLogs": true,
   "decryptKeys": {
     "psch key 1": "decrypt key",
     "psch key 2": "decrypt key"
@@ -66,7 +67,8 @@ Stream decryption key store. Created with defaults on first run if absent.
 
 | Field | Description |
 |---|---|
-| `streamAuthKey` | Default key psch key for stream auth |
+| `streamAuthKey` | Default psch key for stream auth |
+| `maskSensitiveLogs` | Enable log masking (model names, cookies, tokens, proxy URLs). Toggle in WebUI or via `/mask/toggle`. Default `true` |
 | `decryptKeys` | Key-value map of decryption keys (psch key → key) |
 
 ### users.txt
@@ -127,6 +129,9 @@ All endpoints return JSON unless noted. Parameters are passed as query strings.
 | `/list` | All rooms with status, session state, quality |
 | `/dashboard` | Consolidated payload: rooms, statuses, listv2, metrics |
 | `/metrics` | Prometheus metrics endpoint |
+
+| `/mask/toggle` | Toggle log masking on/off |
+| `/mask/status` | Get current mask status (true/false) |
 
 ### Live Preview
 
@@ -226,6 +231,18 @@ Available in `move` destinations and `shell` arguments:
 ## Logging & Monitoring
 
 Logs are written to `./logs` with daily rotation (`xhrec.yyyy-MM-dd.log`).
+
+### Log Masking
+
+Sensitive information is replaced in log output by default. Static patterns (JWT tokens, cookies, auth URL parameters, proxy addresses) are masked with `***`. Dynamic strings (model names, usernames) are registered at startup and replaced with a stable CRC32-based hash that persists within a session but changes on restart, allowing log correlation without revealing identities.
+
+Masking can be toggled at runtime via the eye icon in the WebUI toolbar, or through the API:
+```shell
+curl -k https://localhost:8090/mask/toggle     # on/off
+curl -k https://localhost:8090/mask/status     # current state
+```
+
+The setting persists to `xhrec.json` (`maskSensitiveLogs` field).
 
 Prometheus metrics are exposed at `/metrics`. Example Grafana dashboard:
 

--- a/src/main/kotlin/github/rikacelery/v3/Main.kt
+++ b/src/main/kotlin/github/rikacelery/v3/Main.kt
@@ -7,6 +7,7 @@ import github.rikacelery.v3.core.DataChannel
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
 import github.rikacelery.v3.data.SystemConfig
+import github.rikacelery.v3.utils.SensitiveStringRegistry
 import github.rikacelery.v3.hooks.EventHook
 import github.rikacelery.v3.m3u8.M3u8Parser
 import kotlinx.coroutines.CompletableDeferred
@@ -20,18 +21,25 @@ import org.apache.commons.cli.ParseException
 import org.apache.commons.cli.help.HelpFormatter
 import java.io.File
 
-private fun loadPersistedConfig(configPath: String): Pair<String, Map<String, String>> {
+private data class PersistedConfig(
+    val pkey: String,
+    val decryptKeys: Map<String, String>,
+    val maskSensitiveLogs: Boolean
+)
+
+private fun loadPersistedConfig(configPath: String): PersistedConfig {
     val file = File(configPath)
     val key = "YzWScuyQRGAGcxx1KIJmiQ7BY9Vi35ftwLqUOVO8uoo="
     val pkey = "Fq6m2TO2ZeBkRPm9"
-    val default = pkey to mapOf(pkey to key)
+    val default = PersistedConfig(pkey, mapOf(pkey to key), true)
     if (!file.exists()) return default
     try {
         val json = Json.parseToJsonElement(file.readText()).jsonObject
         val pkey = json["streamAuthKey"]?.jsonPrimitive?.content ?: pkey
         val keys = mutableMapOf(pkey to key)
         json["decryptKeys"]?.jsonObject?.forEach { (k, v) -> keys[k] = v.jsonPrimitive.content }
-        return pkey to keys
+        val mask = json["maskSensitiveLogs"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() ?: true
+        return PersistedConfig(pkey, keys, mask)
     } catch (_: Exception) {
         return default
     }
@@ -57,20 +65,24 @@ fun main(vararg args: String) {
         val appScope = this
 
         val configPath = "xhrec.json"
-        val (defaultPkey, decryptKeys) = loadPersistedConfig(configPath)
+        val persisted = loadPersistedConfig(configPath)
 
         val config = SystemConfig(
             outputDir = File(cli.getOptionValue("output", "out")),
             tmpDir = File(cli.getOptionValue("tmp", "tmp")),
             port = cli.getOptionValue("port", "8090").toInt(),
             proxy = System.getenv("http_proxy"),
-            decryptKeys = decryptKeys,
-            streamAuthKey = defaultPkey,
+            decryptKeys = persisted.decryptKeys,
+            streamAuthKey = persisted.pkey,
             authToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiItMTA4MSIsImluZm8iOnsiaXNHdWVzdCI6dHJ1ZSwidXNlcklkIjotMTA4MX19.IXF36-UfCEmOPGvhl2a19rgLsh2rDCdXNJ3su9LkA9Y",
             platformHost = "stripchat.com",
             listConfPath = cli.getOptionValue("file", "list.conf"),
-            configPath = configPath
+            configPath = configPath,
+            maskSensitiveLogs = persisted.maskSensitiveLogs
         )
+
+        // Apply mask config from persisted config
+        SensitiveStringRegistry.enabled = persisted.maskSensitiveLogs
 
         // 1. Core infrastructure
         val eventBus = EventBus()

--- a/src/main/kotlin/github/rikacelery/v3/bootstrap/Bootstrap.kt
+++ b/src/main/kotlin/github/rikacelery/v3/bootstrap/Bootstrap.kt
@@ -2,6 +2,7 @@ package github.rikacelery.v3.bootstrap
 
 import github.rikacelery.v3.api.ApiClient
 import github.rikacelery.v3.components.*
+import github.rikacelery.v3.utils.SensitiveStringRegistry
 import github.rikacelery.v3.exceptions.RenameException
 import github.rikacelery.v3.postprocessors.*
 import kotlinx.coroutines.async
@@ -79,7 +80,7 @@ class Bootstrap(
         val cookies = file.readLines().filter { it.isNotBlank() && !it.startsWith("#") && !it.startsWith(";") }
         val users = cookies.mapNotNull { cookie ->
             try {
-                apiClient.getUserFromCookie(cookie.trim())
+                apiClient.getUserFromCookie(cookie.trim()).also { SensitiveStringRegistry.mask(it.username) }
             } catch (e: Exception) {
                 logger.warn("Failed to validate cookie: ${e.message}"); null
             }
@@ -181,6 +182,7 @@ class Bootstrap(
     }
 
     private fun addRoomFromParsed(id: Long, name: String, parsed: ListConfLine) {
+        SensitiveStringRegistry.mask(name)
         val timeLimit = if (parsed.timeLimit > 0) parsed.timeLimit.seconds else Duration.INFINITE
         roomComponent.internalAdd(id, name, parsed.quality, timeLimit, parsed.sizeLimit, parsed.autoPay, parsed.pkey)
         if (parsed.armed) {

--- a/src/main/kotlin/github/rikacelery/v3/components/ConfigComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/ConfigComponent.kt
@@ -4,6 +4,7 @@ import github.rikacelery.v3.core.Actor
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.data.SystemConfig
 import github.rikacelery.v3.events.*
+import github.rikacelery.v3.utils.SensitiveStringRegistry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
@@ -26,6 +27,7 @@ class ConfigComponent(
     private val configFile = File(config.configPath)
     private var persistedStreamAuthKey: String = config.streamAuthKey
     private val persistedDecryptKeys = config.decryptKeys.toMutableMap()
+    private var maskSensitiveLogs = config.maskSensitiveLogs
 
     private fun loadConfig() {
         if (!configFile.exists()) return
@@ -35,6 +37,8 @@ class ConfigComponent(
             json["decryptKeys"]?.jsonObject?.forEach { (k, v) ->
                 persistedDecryptKeys[k] = v.jsonPrimitive.content
             }
+            json["maskSensitiveLogs"]?.jsonPrimitive?.content?.toBooleanStrictOrNull()?.let { maskSensitiveLogs = it }
+            SensitiveStringRegistry.enabled = maskSensitiveLogs
             logger.info("Loaded config from ${config.configPath}")
         } catch (e: Exception) {
             logger.warn("Failed to load config.json: ${e.message}")
@@ -47,6 +51,7 @@ class ConfigComponent(
             configFile.writeText(json.encodeToString(JsonElement.serializer(),
                 buildJsonObject {
                     put("streamAuthKey", persistedStreamAuthKey)
+                    put("maskSensitiveLogs", maskSensitiveLogs)
                     put("decryptKeys", buildJsonObject {
                         persistedDecryptKeys.forEach { (k, v) -> put(k, v) }
                     })
@@ -86,6 +91,12 @@ class ConfigComponent(
                 val found = env.command.keys.firstOrNull { persistedDecryptKeys.containsKey(it) }
                 if (found != null) DecryptKeyMatch(found, persistedDecryptKeys[found]!!)
                 else DecryptKeyMatch("", "")
+            }
+            is GetMaskStatus -> ConfigResponse(maskSensitiveLogs)
+            is ToggleMask -> {
+                maskSensitiveLogs = !maskSensitiveLogs
+                SensitiveStringRegistry.enabled = maskSensitiveLogs
+                ConfigResponse(maskSensitiveLogs)
             }
             else -> return
         }

--- a/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
@@ -338,6 +338,15 @@ class HttpServerComponent(
                 get("/metrics") {
                     call.respondText(metricComponent.prometheusText())
                 }
+                get("/mask/status") {
+                    val status = requestBus.request<ConfigResponse>(GetMaskStatus).value
+                    call.respondText(status.toString())
+                }
+                get("/mask/toggle") {
+                    val status = requestBus.request<ConfigResponse>(ToggleMask).value
+                    persistConfig()
+                    call.respondText(status.toString())
+                }
                 get("/mse/live") {
                     val id = call.request.queryParameters["id"]?.toLongOrNull()
                         ?: return@get call.respondText("Missing id", status = HttpStatusCode.BadRequest)

--- a/src/main/kotlin/github/rikacelery/v3/components/RoomComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/RoomComponent.kt
@@ -1,5 +1,6 @@
 package github.rikacelery.v3.components
 
+import github.rikacelery.v3.utils.SensitiveStringRegistry
 import github.rikacelery.v3.utils.PathSingle
 import github.rikacelery.v3.utils.asString
 import github.rikacelery.v3.api.ApiClient
@@ -150,6 +151,7 @@ class RoomComponent(
                         ErrorResponse("Exist $name")
                     } else {
                         rooms[id] = Room(id, name, cmd.quality, cmd.timeLimit, cmd.sizeLimitBytes, cmd.autoPay, null, pkey = cmd.pkey)
+                        SensitiveStringRegistry.mask(name)
                         logger.info("Room added: id={}, name={}, quality={}", id, name, cmd.quality)
                         eventBus.publish(RoomAdded(id, name))
                         RoomNameResponse(name)

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -167,6 +167,7 @@ class SessionComponent(
     private suspend fun startSession(
         roomId: Long, name: String, quality: String, pkey: String = "", reconfigure: Boolean = true
     ) {
+        SensitiveStringRegistry.mask(name)
         val existing = sessions[roomId]
         if (existing != null) {
             val blocked = when (existing.state) {

--- a/src/main/kotlin/github/rikacelery/v3/data/Config.kt
+++ b/src/main/kotlin/github/rikacelery/v3/data/Config.kt
@@ -12,5 +12,6 @@ data class SystemConfig(
     val authToken: String,
     val platformHost: String,
     val listConfPath: String = "list.conf",
-    val configPath: String = "xhrec.json"
+    val configPath: String = "xhrec.json",
+    val maskSensitiveLogs: Boolean = true
 )

--- a/src/main/kotlin/github/rikacelery/v3/events/Commands.kt
+++ b/src/main/kotlin/github/rikacelery/v3/events/Commands.kt
@@ -23,6 +23,8 @@ data class RemoveRoom(val roomId: Long) : Request
 
 data class GetDecryptKey(val keyName: String) : Request
 data class MatchDecryptKeys(val keys: List<String>) : Request
+object GetMaskStatus : Request
+object ToggleMask : Request
 // ── Scheduler commands ──
 
 data class StartRecordingCmd(val roomId: Long) : Request

--- a/src/main/kotlin/github/rikacelery/v3/utils/MaskingMessageConverter.kt
+++ b/src/main/kotlin/github/rikacelery/v3/utils/MaskingMessageConverter.kt
@@ -1,0 +1,30 @@
+package github.rikacelery.v3.utils
+
+import ch.qos.logback.classic.pattern.MessageConverter
+import ch.qos.logback.classic.spi.ILoggingEvent
+
+class MaskingMessageConverter : MessageConverter() {
+
+    override fun convert(event: ILoggingEvent): String {
+        var msg = event.formattedMessage ?: return ""
+        if (!SensitiveStringRegistry.enabled) return msg
+        msg = STATIC_RULES.fold(msg) { acc, rule -> rule.first.replace(acc, rule.second) }
+        msg = SensitiveStringRegistry.maskText(msg)
+        return msg
+    }
+
+    companion object {
+        private val STATIC_RULES: List<Pair<Regex, String>> = listOf(
+            // JWT token
+            Regex("eyJ[a-zA-Z0-9_-]+\\.[a-zA-Z0-9_-]+\\.[a-zA-Z0-9_-]+") to "***jwt***",
+            // Cookie header value (case-insensitive: Cookie: xxx)
+            Regex("[Cc]ookie:\\s*[^\\s,;()]+") to "Cookie: ***",
+            // aclAuth URL parameter
+            Regex("aclAuth=[^&\\s]+") to "aclAuth=***",
+            // pkey URL parameter value
+            Regex("pkey=[^&\\s]+") to "pkey=***",
+            // HTTP proxy address
+            Regex("proxy=https?://[^\\s]+") to "proxy=***",
+        )
+    }
+}

--- a/src/main/kotlin/github/rikacelery/v3/utils/SensitiveStringRegistry.kt
+++ b/src/main/kotlin/github/rikacelery/v3/utils/SensitiveStringRegistry.kt
@@ -1,0 +1,30 @@
+package github.rikacelery.v3.utils
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.zip.CRC32
+
+object SensitiveStringRegistry {
+    @Volatile var enabled: Boolean = true
+    private val randomSuffix: String = Integer.toHexString((Math.random() * 0x10000).toInt()).padStart(4, '0')
+    private val mapping = ConcurrentHashMap<String, String>()
+
+    fun mask(original: String): String {
+        return mapping.getOrPut(original) {
+            val crc = CRC32()
+            crc.update(original.toByteArray(Charsets.UTF_8))
+            "%08x_%s".format(crc.value, randomSuffix)
+        }
+    }
+
+    fun maskText(text: String): String {
+        var result = text
+        mapping.entries
+            .sortedByDescending { it.key.length }
+            .forEach { (original, masked) ->
+                if (original in result) {
+                    result = result.replace(original, masked)
+                }
+            }
+        return result
+    }
+}

--- a/src/main/kotlin/github/rikacelery/v3/utils/SensitiveStringRegistry.kt
+++ b/src/main/kotlin/github/rikacelery/v3/utils/SensitiveStringRegistry.kt
@@ -12,7 +12,8 @@ object SensitiveStringRegistry {
         return mapping.getOrPut(original) {
             val crc = CRC32()
             crc.update(original.toByteArray(Charsets.UTF_8))
-            "%08x%s".format(crc.value, randomSuffix)
+            crc.update(randomSuffix.toByteArray(Charsets.UTF_8))
+            "%08x".format(crc.value)
         }
     }
 

--- a/src/main/kotlin/github/rikacelery/v3/utils/SensitiveStringRegistry.kt
+++ b/src/main/kotlin/github/rikacelery/v3/utils/SensitiveStringRegistry.kt
@@ -12,7 +12,7 @@ object SensitiveStringRegistry {
         return mapping.getOrPut(original) {
             val crc = CRC32()
             crc.update(original.toByteArray(Charsets.UTF_8))
-            "%08x_%s".format(crc.value, randomSuffix)
+            "%08x%s".format(crc.value, randomSuffix)
         }
     }
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -5,7 +5,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{MM-dd HH:mm:ss} %-5level %16logger{16} - %maskedMsg ::%M%n</pattern>
+            <pattern>%d{MM-dd HH:mm:ss} %-5level %logger{0} - %maskedMsg ::%M%n</pattern>
             <charset>utf8</charset>
         </encoder>
     </appender>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -5,7 +5,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{MM-dd HH:mm:ss} %-5level %logger{0} - %maskedMsg ::%M%n</pattern>
+            <pattern>%d{MM-dd HH:mm:ss} %-5level %logger{2} - %maskedMsg ::%M%n</pattern>
             <charset>utf8</charset>
         </encoder>
     </appender>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,7 +1,11 @@
 <configuration  scan="true" scanPeriod="30 seconds">
+
+    <conversionRule conversionWord="maskedMsg"
+        converterClass="github.rikacelery.v3.utils.MaskingMessageConverter" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{MM-dd HH:mm:ss} %highlight(%-5level) %16logger{16} - %cyan(%msg) ::%M%n</pattern>
+            <pattern>%d{MM-dd HH:mm:ss} %highlight(%-5level) %16logger{16} - %cyan(%maskedMsg) ::%M%n</pattern>
             <charset>utf8</charset>
         </encoder>
     </appender>
@@ -17,7 +21,7 @@
             <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger - %msg ::%M%n</pattern>
+            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger - %maskedMsg ::%M%n</pattern>
         </encoder>
     </appender>
     <root level="DEBUG">

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -5,7 +5,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{MM-dd HH:mm:ss} %highlight(%-5level) %16logger{16} - %cyan(%maskedMsg) ::%M%n</pattern>
+            <pattern>%d{MM-dd HH:mm:ss} %-5level %16logger{16} - %maskedMsg ::%M%n</pattern>
             <charset>utf8</charset>
         </encoder>
     </appender>

--- a/src/main/resources/vue.html
+++ b/src/main/resources/vue.html
@@ -251,7 +251,7 @@
                         <input type="range" min="40" max="240" v-model.number="previewHeight"
                             class="w-24 h-1 accent-indigo-500 cursor-pointer">
                     </div>
-                    <button @click="toggleMask()" title="Toggle Log Mask"
+                    <button @click="toggleMask()" title="Log Masking — hides sensitive data (model names, cookies, tokens) in logs. CRC32 hash stays stable per session, changes on restart."
                         class="w-8 h-8 flex items-center justify-center rounded text-xs font-bold transition-colors"
                         :class="maskEnabled ? 'bg-amber-100 text-amber-700 hover:bg-amber-600 hover:text-white' : 'bg-slate-100 text-slate-400 hover:bg-slate-200 hover:text-slate-600'">
                         <i class="fa-solid" :class="maskEnabled ? 'fa-eye-slash' : 'fa-eye'"></i>

--- a/src/main/resources/vue.html
+++ b/src/main/resources/vue.html
@@ -251,6 +251,11 @@
                         <input type="range" min="40" max="240" v-model.number="previewHeight"
                             class="w-24 h-1 accent-indigo-500 cursor-pointer">
                     </div>
+                    <button @click="toggleMask()" title="Toggle Log Mask"
+                        class="w-8 h-8 flex items-center justify-center rounded text-xs font-bold transition-colors"
+                        :class="maskEnabled ? 'bg-amber-100 text-amber-700 hover:bg-amber-600 hover:text-white' : 'bg-slate-100 text-slate-400 hover:bg-slate-200 hover:text-slate-600'">
+                        <i class="fa-solid" :class="maskEnabled ? 'fa-eye-slash' : 'fa-eye'"></i>
+                    </button>
                     <button @click="poweroff()" title="Power Off Server"
                         class="w-8 h-8 flex items-center justify-center rounded bg-red-100 text-red-700 hover:bg-red-600 hover:text-white transition-colors ml-2">
                         <i class="fa-solid fa-power-off text-sm"></i>
@@ -533,6 +538,7 @@
                     activeVideos: {},
                     previewHeight: 40,
                     darkMode: false,
+                    maskEnabled: true,
                 }
             },
             computed: {
@@ -590,6 +596,14 @@
                     this.darkMode = !this.darkMode;
                     document.documentElement.classList.toggle('dark', this.darkMode);
                     localStorage.setItem('xhrec-dark', this.darkMode ? '1' : '0');
+                },
+                async toggleMask() {
+                    try {
+                        const r = await fetch(`${HOST}/mask/toggle`);
+                        const text = await r.text();
+                        this.maskEnabled = text === 'true';
+                        this.showToast(this.maskEnabled ? 'Mask ON' : 'Mask OFF');
+                    } catch (e) { this.showToast("Network Error", "error"); }
                 },
                 showToast(message, type = "success") {
                     const id = this.toastId++;
@@ -792,6 +806,9 @@
                 // Dark mode restore
                 this.darkMode = localStorage.getItem('xhrec-dark') === '1';
                 document.documentElement.classList.toggle('dark', this.darkMode);
+
+                // Mask status
+                try { const r = await fetch(`${HOST}/mask/status`); this.maskEnabled = (await r.text()) === 'true'; } catch (_) {}
 
                 // Load cache
                 try { this.snapshotcache = JSON.parse(localStorage.getItem("xhrec-thumb")) || {}; }


### PR DESCRIPTION
## Summary

- 新增 `MaskingMessageConverter` (logback MessageConverter) 和 `SensitiveStringRegistry` (CRC32 + 随机 salt)
- 静态正则脱敏: JWT token、Cookie header、aclAuth/pkey URL 参数、HTTP代理地址
- 动态脱敏: 主播名(username)在加载时注册到 Registry，替换为 `xxxxxxxx_salt` 格式
- 同一会话中相同字符串掩码一致，重启后 salt 变化

## Config

- `xhrec.json` 新增 `maskSensitiveLogs` 字段，默认 true
- Web UI 工具栏新增眼睛图标按钮，可动态开关
- API: GET /mask/status 和 GET /mask/toggle

## Test plan

- [x] 编译通过 (./gradlew build)
- [ ] 启动应用，确认日志中主播名被替换为 CRC32+salt
- [ ] 同一主播名掩码一致
- [ ] 重启后掩码变化
- [ ] Web UI 开关切换生效