### PR TITLE
refactor(v3): non-blocking event bus with per-room isolation and backlog monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ Then open `https://localhost:8090` for the dashboard.
 
 ## CLI Options
 
-| Option | Description | Default |
-|---|---|---|
-| `-f`, `--file` | Room list config | `list.conf` |
-| `-o`, `--output` | Output directory | `out` |
-| `-t`, `--tmp` | Temp directory | `tmp` |
-| `-p`, `--port` | HTTP server port | `8090` |
-| `-u`, `--users` | Users file | `users.txt` |
-| `-post` | Post processor config | `postprocessor.json` |
+| Option           | Description           | Default              |
+|------------------|-----------------------|----------------------|
+| `-f`, `--file`   | Room list config      | `list.conf`          |
+| `-o`, `--output` | Output directory      | `out`                |
+| `-t`, `--tmp`    | Temp directory        | `tmp`                |
+| `-p`, `--port`   | HTTP server port      | `8090`               |
+| `-u`, `--users`  | Users file            | `users.txt`          |
+| `-post`          | Post processor config | `postprocessor.json` |
 
 ```shell
 java -jar build/libs/XhRec-all.jar -p 12340 -f list.conf -post postprocessor.json -t /tmp/xhrec -o /out
@@ -40,13 +40,13 @@ One room per line. Lines starting with `#` or `;` are inactive (not automaticall
 https://stripchat.com/modelC q:highest
 ```
 
-| Field | Description |
-|---|---|
-| `q:<quality>` | Preferred quality: `240p`, `480p`, `720p`, `720p60`, `1080p`, `1080p60`, or `highest` (default). `raw` is deprecated, use `highest` instead |
-| `limit:<sec>` | Recording time limit in seconds |
-| `size:<bytes>` | Recording size limit (supports suffixes: `K`, `M`, `G`, e.g. `500M`) |
-| `autopay` | Enable auto-payment for private shows |
-| `pkey:<key>` | Custom psch key |
+| Field          | Description                                                                                                                                 |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| `q:<quality>`  | Preferred quality: `240p`, `480p`, `720p`, `720p60`, `1080p`, `1080p60`, or `highest` (default). `raw` is deprecated, use `highest` instead |
+| `limit:<sec>`  | Recording time limit in seconds                                                                                                             |
+| `size:<bytes>` | Recording size limit (supports suffixes: `K`, `M`, `G`, e.g. `500M`)                                                                        |
+| `autopay`      | Enable auto-payment for private shows                                                                                                       |
+| `pkey:<key>`   | Custom psch key                                                                                                                             |
 
 If the requested quality is unavailable, the closest match is selected automatically.
 
@@ -65,17 +65,18 @@ Stream decryption key store. Created with defaults on first run if absent.
 }
 ```
 
-| Field | Description |
-|---|---|
-| `streamAuthKey` | Default psch key for stream auth |
+| Field               | Description                                                                                                          |
+|---------------------|----------------------------------------------------------------------------------------------------------------------|
+| `streamAuthKey`     | Default psch key for stream auth                                                                                     |
 | `maskSensitiveLogs` | Enable log masking (model names, cookies, tokens, proxy URLs). Toggle in WebUI or via `/mask/toggle`. Default `true` |
-| `decryptKeys` | Key-value map of decryption keys (psch key → key) |
+| `decryptKeys`       | Key-value map of decryption keys (psch key → key)                                                                    |
 
 ### users.txt
 
 User cookies for auto-payment. One cookie per line. Lines starting with `#` or `;` are ignored.
 
-Each cookie is validated against the platform API on startup to resolve the user's ID, name, and coin balance. When a private show requires payment, the system selects a user with sufficient coins.
+Each cookie is validated against the platform API on startup to resolve the user's ID, name, and coin balance. When a
+private show requires payment, the system selects a user with sufficient coins.
 
 ```
 # optional comments
@@ -101,50 +102,50 @@ All endpoints return JSON unless noted. Parameters are passed as query strings.
 
 ### Room Management
 
-| Endpoint | Params | Description |
-|---|---|---|
-| `/add` | `name`, `quality`, `active`, `limit`, `autopay`, `pkey`, `size` | Add a room |
-| `/remove` | `id` | Remove a room |
-| `/start` | `id` | Start recording |
-| `/stop` | `id` | Stop recording |
-| `/restart` | `id` | Stop then restart recording |
-| `/break` | `id` | Temporary stop (resumes on next poll) |
+| Endpoint   | Params                                                          | Description                           |
+|------------|-----------------------------------------------------------------|---------------------------------------|
+| `/add`     | `name`, `quality`, `active`, `limit`, `autopay`, `pkey`, `size` | Add a room                            |
+| `/remove`  | `id`                                                            | Remove a room                         |
+| `/start`   | `id`                                                            | Start recording                       |
+| `/stop`    | `id`                                                            | Stop recording                        |
+| `/restart` | `id`                                                            | Stop then restart recording           |
+| `/break`   | `id`                                                            | Temporary stop (resumes on next poll) |
 
 ### Room Settings
 
-| Endpoint | Params | Description |
-|---|---|---|
-| `/activate` | `id` | Enable auto-recording |
-| `/deactivate` | `id` | Disable auto-recording |
-| `/quality` | `id`, `q` | Set quality |
-| `/autopay` | `id`, `v` (true/false) | Toggle auto-payment |
-| `/limit` | `id`, `v` (seconds) | Set time limit (0 = unlimited) |
-| `/sizelimit` | `id`, `v` | Set size limit (0 = unlimited) |
+| Endpoint      | Params                 | Description                    |
+|---------------|------------------------|--------------------------------|
+| `/activate`   | `id`                   | Enable auto-recording          |
+| `/deactivate` | `id`                   | Disable auto-recording         |
+| `/quality`    | `id`, `q`              | Set quality                    |
+| `/autopay`    | `id`, `v` (true/false) | Toggle auto-payment            |
+| `/limit`      | `id`, `v` (seconds)    | Set time limit (0 = unlimited) |
+| `/sizelimit`  | `id`, `v`              | Set size limit (0 = unlimited) |
 
 ### Status & Monitoring
 
-| Endpoint | Description |
-|---|---|
-| `/status` | Active room status (segments, bytes, running downloads) |
-| `/list` | All rooms with status, session state, quality |
-| `/dashboard` | Consolidated payload: rooms, statuses, listv2, metrics |
-| `/metrics` | Prometheus metrics endpoint |
+| Endpoint     | Description                                             |
+|--------------|---------------------------------------------------------|
+| `/status`    | Active room status (segments, bytes, running downloads) |
+| `/list`      | All rooms with status, session state, quality           |
+| `/dashboard` | Consolidated payload: rooms, statuses, listv2, metrics  |
+| `/metrics`   | Prometheus metrics endpoint                             |
 
 | `/mask/toggle` | Toggle log masking on/off |
 | `/mask/status` | Get current mask status (true/false) |
 
 ### Live Preview
 
-| Endpoint | Params | Description |
-|---|---|---|
-| `/mse/live` | `id` | MP4 stream of in-progress recording |
+| Endpoint    | Params | Description                         |
+|-------------|--------|-------------------------------------|
+| `/mse/live` | `id`   | MP4 stream of in-progress recording |
 
 ### Server Control
 
-| Endpoint | Description |
-|---|---|
-| `/graceful-stop` | Finish recordings and shut down |
-| `/stop-server` | Finish recordings and post-processing, then exit |
+| Endpoint         | Description                                      |
+|------------------|--------------------------------------------------|
+| `/graceful-stop` | Finish recordings and shut down                  |
+| `/stop-server`   | Finish recordings and post-processing, then exit |
 
 ### Status Response Format
 
@@ -171,55 +172,69 @@ Defined in `postprocessor.json`. Processors run in sequence after a recording fi
 
 ### Built-in Processors
 
-| Type | Description |
-|---|---|
-| `fix_stamp` | Fix MP4 timestamps |
-| `move` | Move/rename output files |
-| `slice` | Split video into segments |
-| `shell` | Run arbitrary shell commands |
+| Type        | Description                  |
+|-------------|------------------------------|
+| `fix_stamp` | Fix MP4 timestamps           |
+| `move`      | Move/rename output files     |
+| `slice`     | Split video into segments    |
+| `shell`     | Run arbitrary shell commands |
 
 ### Template Variables
 
 Available in `move` destinations and `shell` arguments:
 
-| Variable | Description |
-|---|---|
-| `{{ROOM_NAME}}` | Model/room name |
-| `{{ROOM_ID}}` | Room ID |
-| `{{RECORD_START}}` | Formatted start time |
-| `{{RECORD_END}}` | Formatted end time |
-| `{{RECORD_DURATION}}` | Duration in seconds |
-| `{{RECORD_DURATION_STR}}` | Duration as `00h01m30s` |
-| `{{RECORD_QUALITY}}` | Quality string |
-| `{{INPUT_ABS}}` | Input file path |
-| `{{INPUT_DIR}}` | Input directory |
-| `{{INPUT_NAME}}` | Input filename |
-| `{{INPUT_NAME_NOEXT}}` | Filename without extension |
-| `{{TOTAL_FRAMES}}` | Accurate frame count |
-| `{{TOTAL_FRAMES_GUESS}}` | Estimated frame count (FPS × duration) |
+| Variable                  | Description                            |
+|---------------------------|----------------------------------------|
+| `{{ROOM_NAME}}`           | Model/room name                        |
+| `{{ROOM_ID}}`             | Room ID                                |
+| `{{RECORD_START}}`        | Formatted start time                   |
+| `{{RECORD_END}}`          | Formatted end time                     |
+| `{{RECORD_DURATION}}`     | Duration in seconds                    |
+| `{{RECORD_DURATION_STR}}` | Duration as `00h01m30s`                |
+| `{{RECORD_QUALITY}}`      | Quality string                         |
+| `{{INPUT_ABS}}`           | Input file path                        |
+| `{{INPUT_DIR}}`           | Input directory                        |
+| `{{INPUT_NAME}}`          | Input filename                         |
+| `{{INPUT_NAME_NOEXT}}`    | Filename without extension             |
+| `{{TOTAL_FRAMES}}`        | Accurate frame count                   |
+| `{{TOTAL_FRAMES_GUESS}}`  | Estimated frame count (FPS × duration) |
 
 ### Example Configuration
 
 ```json
 {
   "default": [
-    { "type": "fix_stamp", "output": "out" },
+    {
+      "type": "fix_stamp",
+      "output": "out"
+    },
     {
       "type": "move",
       "output": "out/[{{ROOM_ID}}]{{ROOM_NAME}}@{{RECORD_START}}-{{RECORD_END}} {{RECORD_DURATION_STR}}",
       "date_pattern": "yyyy-MM-dd HH:mm:ss"
     },
-    { "type": "slice", "output": "out", "duration": "1m10s" },
+    {
+      "type": "slice",
+      "output": "out",
+      "duration": "1m10s"
+    },
     {
       "type": "shell",
       "noreturn": true,
       "remove_input": false,
       "date_pattern": "yyyy-MM-dd_HH-mm-ss",
       "cmd": [
-        "ffmpeg", "-hide_banner", "-loglevel", "error", "-stats",
-        "-i", "{{INPUT_ABS}}",
-        "-vf", "thumbnail={{TOTAL_FRAMES_GUESS}}/400,scale=200:-1,tile=20x20",
-        "-vframes", "1",
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-stats",
+        "-i",
+        "{{INPUT_ABS}}",
+        "-vf",
+        "thumbnail={{TOTAL_FRAMES_GUESS}}/400,scale=200:-1,tile=20x20",
+        "-vframes",
+        "1",
         "{{INPUT_DIR}}/{{INPUT_NAME_NOEXT}}.thumb.png",
         "-y"
       ]
@@ -234,9 +249,13 @@ Logs are written to `./logs` with daily rotation (`xhrec.yyyy-MM-dd.log`).
 
 ### Log Masking
 
-Sensitive information is replaced in log output by default. Static patterns (JWT tokens, cookies, auth URL parameters, proxy addresses) are masked with `***`. Dynamic strings (model names, usernames) are registered at startup and replaced with a stable CRC32-based hash that persists within a session but changes on restart, allowing log correlation without revealing identities.
+Sensitive information is replaced in log output by default. Static patterns (JWT tokens, cookies, auth URL parameters,
+proxy addresses) are masked with `***`. Dynamic strings (model names, usernames) are registered at startup and replaced
+with a stable CRC32-based hash that persists within a session but changes on restart, allowing log correlation without
+revealing identities.
 
 Masking can be toggled at runtime via the eye icon in the WebUI toolbar, or through the API:
+
 ```shell
 curl -k https://localhost:8090/mask/toggle     # on/off
 curl -k https://localhost:8090/mask/status     # current state

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -1,6 +1,8 @@
 # XhREC
 
-Kotlin 直播自动录制工具，配合浏览器扩展实现一键控制。
+[English](README.md)
+
+自动直播录制的 Kotlin 应用，配合浏览器扩展实现一键控制。
 
 ## 快速开始
 
@@ -9,18 +11,18 @@ Kotlin 直播自动录制工具，配合浏览器扩展实现一键控制。
 java -jar build/libs/XhRec-all.jar
 ```
 
-然后打开 `https://localhost:8090` 进入控制面板。
+打开 `https://localhost:8090` 进入控制台。
 
-## CLI 参数
+## CLI 选项
 
-| 参数               | 说明         | 默认值                  |
-|------------------|------------|----------------------|
-| `-f`, `--file`   | 房间列表配置     | `list.conf`          |
-| `-o`, `--output` | 输出目录       | `out`                |
-| `-t`, `--tmp`    | 临时目录       | `tmp`                |
-| `-p`, `--port`   | HTTP 服务器端口 | `8090`               |
-| `-u`, `--users`  | 用户文件       | `users.txt`          |
-| `-post`          | 后处理器配置     | `postprocessor.json` |
+| 选项             | 描述              | 默认值                |
+|------------------|------------------|----------------------|
+| `-f`, `--file`   | 房间列表配置文件      | `list.conf`          |
+| `-o`, `--output` | 输出目录            | `out`                |
+| `-t`, `--tmp`    | 临时目录            | `tmp`                |
+| `-p`, `--port`   | HTTP 服务端口       | `8090`               |
+| `-u`, `--users`  | 用户文件            | `users.txt`          |
+| `-post`          | 后处理器配置文件     | `postprocessor.json` |
 
 ```shell
 java -jar build/libs/XhRec-all.jar -p 12340 -f list.conf -post postprocessor.json -t /tmp/xhrec -o /out
@@ -30,7 +32,7 @@ java -jar build/libs/XhRec-all.jar -p 12340 -f list.conf -post postprocessor.jso
 
 ### list.conf
 
-每行一个房间。以 `#` 或 `;` 开头的行表示未启用（不会自动录制）。
+每行一个房间。以 `#` 或 `;` 开头的行视为未激活（不会自动录制）。
 
 ```ini
 # https://stripchat.com/modelA q:720p limit:120
@@ -38,58 +40,60 @@ java -jar build/libs/XhRec-all.jar -p 12340 -f list.conf -post postprocessor.jso
 https://stripchat.com/modelC q:highest
 ```
 
-| 字段             | 说明                                                                                           |
-|----------------|----------------------------------------------------------------------------------------------|
-| `q:<quality>`  | 偏好画质：`240p`、`480p`、`720p`、`720p60`、`1080p`、`1080p60` 或 `highest`（默认）。`raw` 已弃用，请使用 `highest` |
-| `limit:<sec>`  | 录制时长限制（秒）                                                                                    |
-| `size:<bytes>` | 录制大小限制（支持后缀：`K`、`M`、`G`，如 `500M`）                                                            |
-| `autopay`      | 为付费秀启用自动支付                                                                                   |
-| `pkey:<key>`   | 自定义 psch 密钥                                                                                  |
+| 字段            | 描述                                                                                                          |
+|-----------------|-------------------------------------------------------------------------------------------------------------|
+| `q:<quality>`   | 画质偏好: `240p`, `480p`, `720p`, `720p60`, `1080p`, `1080p60`, 或 `highest` (默认)。`raw` 已弃用，请用 `highest` |
+| `limit:<sec>`   | 录制时长限制（秒）                                                                                               |
+| `size:<bytes>`  | 录制大小限制（支持后缀: `K`, `M`, `G`, 如 `500M`）                                                                |
+| `autopay`       | 对私密秀开启自动支付                                                                                             |
+| `pkey:<key>`    | 自定义 psch 密钥                                                                                               |
 
-如果请求的画质不可用，将自动选择最接近的匹配。
+如果请求的画质不可用，系统会自动选择最接近的匹配项。
 
 ### xhrec.json
 
-流解密密钥存储，首次运行时会创建默认文件。
+流解密密钥存储。首次运行时如不存在则会创建默认文件。
 
 ```json
 {
-  "streamAuthKey": "默认 psch 密钥，从 master playlist 提取失败时使用",
+  "streamAuthKey": "默认 psch 密钥，如果无法从 master playlist 中提取则使用此值",
+  "maskSensitiveLogs": true,
   "decryptKeys": {
-    "psch key 1": "decrypt key",
-    "psch key 2": "decrypt key"
+    "psch 密钥 1": "解密密钥",
+    "psch 密钥 2": "解密密钥"
   }
 }
 ```
 
-| 字段              | 说明                      |
-|-----------------|-------------------------|
-| `streamAuthKey` | 默认流认证密钥                 |
-| `decryptKeys`   | 解密密钥映射（psch key → 解密密钥） |
+| 字段                 | 描述                                                                                          |
+|---------------------|----------------------------------------------------------------------------------------------|
+| `streamAuthKey`     | 用于流认证的默认 psch 密钥                                                                       |
+| `maskSensitiveLogs` | 启用日志脱敏（主播名、cookie、token、代理地址）。可在 WebUI 中或通过 `/mask/toggle` 切换。默认 `true` |
+| `decryptKeys`       | 解密密钥映射表（psch 密钥 → 解密密钥）                                                             |
 
 ### users.txt
 
-用于自动支付的用户 Cookie。每行一个 Cookie，以 `#` 或 `;` 开头的行将被忽略。
+自动支付使用的用户 cookie。每行一个 cookie。以 `#` 或 `;` 开头的行被忽略。
 
-每个 Cookie 在启动时通过平台 API 验证，解析出用户 ID、名称和金币余额。当付费秀需要支付时，系统会选择金币充足的用户。
+每个 cookie 在启动时会向平台 API 验证，获取用户的 ID、名称和金币余额。当私密秀需要付费时，系统会选择一个余额充足的用户。
 
 ```
 # 可选注释
 cookie_string_here
 ```
 
-## WebUI & 浏览器扩展
+## WebUI 与浏览器扩展
 
-### 控制面板
+### 控制台
 
 `https://localhost:8090` — 管理房间、查看实时状态、控制录制。
 
-![dashboard](image.png)
+![控制台](image.png)
 
-### UserScript
+### 用户脚本
 
 [安装](https://greasyfork.org/zh-CN/scripts/582444-xhrec-control-panel)
-![user script](image-1.png)
+![用户脚本](image-1.png)
 
 ## API 参考
 
@@ -97,53 +101,56 @@ cookie_string_here
 
 ### 房间管理
 
-| 接口         | 参数                                                              | 说明            |
-|------------|-----------------------------------------------------------------|---------------|
-| `/add`     | `name`, `quality`, `active`, `limit`, `autopay`, `pkey`, `size` | 添加房间          |
-| `/remove`  | `id`                                                            | 移除房间          |
-| `/start`   | `id`                                                            | 开始录制          |
-| `/stop`    | `id`                                                            | 停止录制          |
-| `/restart` | `id`                                                            | 停止后重新开始录制     |
-| `/break`   | `id`                                                            | 暂停录制（下次轮询时恢复） |
+| 接口       | 参数                                                              | 描述                 |
+|------------|------------------------------------------------------------------|---------------------|
+| `/add`     | `name`, `quality`, `active`, `limit`, `autopay`, `pkey`, `size`   | 添加房间              |
+| `/remove`  | `id`                                                             | 删除房间              |
+| `/start`   | `id`                                                             | 开始录制              |
+| `/stop`    | `id`                                                             | 停止录制              |
+| `/restart` | `id`                                                             | 停止后重新开始录制      |
+| `/break`   | `id`                                                             | 暂时中断（下次轮询时恢复）|
 
 ### 房间设置
 
-| 接口            | 参数                    | 说明              |
-|---------------|-----------------------|-----------------|
-| `/activate`   | `id`                  | 启用自动录制          |
-| `/deactivate` | `id`                  | 禁用自动录制          |
-| `/quality`    | `id`, `q`             | 设置画质            |
-| `/autopay`    | `id`, `v`（true/false） | 切换自动支付          |
-| `/limit`      | `id`, `v`（秒）          | 设置时长限制（0 = 无限制） |
-| `/sizelimit`  | `id`, `v`             | 设置大小限制（0 = 无限制） |
+| 接口          | 参数                      | 描述                     |
+|---------------|--------------------------|-------------------------|
+| `/activate`   | `id`                     | 启用自动录制               |
+| `/deactivate` | `id`                     | 禁用自动录制               |
+| `/quality`    | `id`, `q`                | 设置画质                  |
+| `/autopay`    | `id`, `v` (true/false)   | 切换自动支付               |
+| `/limit`      | `id`, `v` （秒）          | 设置时长限制（0 = 不限）     |
+| `/sizelimit`  | `id`, `v`                | 设置大小限制（0 = 不限）     |
 
 ### 状态与监控
 
-| 接口           | 说明                   |
-|--------------|----------------------|
-| `/status`    | 活跃房间状态（片段数、字节数、正在下载） |
-| `/list`      | 所有房间（含状态、会话状态、画质）    |
-| `/dashboard` | 合并数据：房间、状态、列表、指标     |
-| `/metrics`   | Prometheus 指标接口      |
+| 接口         | 描述                                              |
+|-------------|--------------------------------------------------|
+| `/status`   | 活跃房间状态（分段数、字节数、正在运行的下载任务）           |
+| `/list`     | 所有房间的状态、会话状态、画质                          |
+| `/dashboard`| 聚合数据: rooms, statuses, listv2, metrics          |
+| `/metrics`  | Prometheus 指标接口                                 |
+
+| `/mask/toggle` | 切换日志脱敏开关      |
+| `/mask/status` | 获取当前脱敏状态（true/false） |
 
 ### 实时预览
 
-| 接口          | 参数   | 说明       |
-|-------------|------|----------|
-| `/mse/live` | `id` | 正在录制的视频流 |
+| 接口        | 参数  | 描述                 |
+|------------|------|---------------------|
+| `/mse/live` | `id` | 正在录制中的 MP4 流    |
 
-### 服务器控制
+### 服务控制
 
-| 接口               | 说明          |
-|------------------|-------------|
-| `/graceful-stop` | 完成录制后关闭     |
-| `/stop-server`   | 完成录制和后处理后退出 |
+| 接口              | 描述                       |
+|------------------|---------------------------|
+| `/graceful-stop` | 完成录制后关闭服务             |
+| `/stop-server`   | 完成录制和后处理后退出          |
 
-### 状态响应格式
+### Status 响应格式
 
 ```json
 {
-  "Model Name": {
+  "主播名": {
     "total": 10046,
     "success": 9933,
     "failed": 98,
@@ -160,38 +167,38 @@ cookie_string_here
 
 ## 后处理
 
-在 `postprocessor.json` 中定义，录制完成后按顺序执行。
+在 `postprocessor.json` 中定义。录制结束后处理器按顺序依次执行。
 
 ### 内置处理器
 
-| 类型          | 说明         |
-|-------------|------------|
-| `fix_stamp` | 修复 MP4 时间戳 |
-| `move`      | 移动/重命名输出文件 |
-| `slice`     | 将视频分割为片段   |
-| `shell`     | 执行任意外部命令   |
+| 类型         | 描述               |
+|-------------|-------------------|
+| `fix_stamp` | 修复 MP4 时间戳     |
+| `move`      | 移动/重命名输出文件   |
+| `slice`     | 分割视频为多段       |
+| `shell`     | 执行任意 shell 命令  |
 
 ### 模板变量
 
-可用于 `move` 输出目标和 `shell` 命令参数：
+可在 `move` 的目标路径和 `shell` 的参数中使用：
 
-| 变量                        | 说明               |
-|---------------------------|------------------|
-| `{{ROOM_NAME}}`           | 主播/房间名           |
-| `{{ROOM_ID}}`             | 房间 ID            |
-| `{{RECORD_START}}`        | 格式化的开始时间         |
-| `{{RECORD_END}}`          | 格式化的结束时间         |
-| `{{RECORD_DURATION}}`     | 时长（秒）            |
-| `{{RECORD_DURATION_STR}}` | 时长格式 `00h01m30s` |
-| `{{RECORD_QUALITY}}`      | 画质               |
-| `{{INPUT_ABS}}`           | 输入文件路径           |
-| `{{INPUT_DIR}}`           | 输入文件目录           |
-| `{{INPUT_NAME}}`          | 输入文件名            |
-| `{{INPUT_NAME_NOEXT}}`    | 文件名（无扩展名）        |
-| `{{TOTAL_FRAMES}}`        | 精确帧数             |
-| `{{TOTAL_FRAMES_GUESS}}`  | 估算帧数（FPS × 时长）   |
+| 变量                        | 描述                                  |
+|----------------------------|--------------------------------------|
+| `{{ROOM_NAME}}`            | 主播/房间名                             |
+| `{{ROOM_ID}}`              | 房间 ID                               |
+| `{{RECORD_START}}`         | 格式化的开始时间                         |
+| `{{RECORD_END}}`           | 格式化的结束时间                         |
+| `{{RECORD_DURATION}}`      | 时长（秒）                              |
+| `{{RECORD_DURATION_STR}}`  | 格式化时长，如 `00h01m30s`               |
+| `{{RECORD_QUALITY}}`       | 画质字符串                              |
+| `{{INPUT_ABS}}`            | 输入文件完整路径                         |
+| `{{INPUT_DIR}}`            | 输入文件所在目录                         |
+| `{{INPUT_NAME}}`           | 输入文件名                              |
+| `{{INPUT_NAME_NOEXT}}`     | 不带扩展名的文件名                        |
+| `{{TOTAL_FRAMES}}`         | 精确总帧数                              |
+| `{{TOTAL_FRAMES_GUESS}}`   | 估算总帧数（FPS × 时长）                 |
 
-### 配置示例
+### 示例配置
 
 ```json
 {
@@ -237,8 +244,21 @@ cookie_string_here
 
 ## 日志与监控
 
-日志写入 `./logs` 目录，按日滚动（`xhrec.yyyy-MM-dd.log`）。
+日志写入 `./logs` 目录，按天轮转 (`xhrec.yyyy-MM-dd.log`)。
 
-Prometheus 指标暴露在 `/metrics` 接口。Grafana 面板示例：
+### 日志脱敏
+
+默认开启，敏感信息在日志输出中被替换。静态模式（JWT token、cookie、认证 URL 参数、代理地址）替换为 `***`。动态字符串（主播名、用户名）在启动时注册，替换为基于 CRC32 的稳定哈希值——同一会话内保持不变，重启后更新，便于日志关联分析同时保护隐私。
+
+脱敏功能可通过 WebUI 工具栏中的眼睛图标实时切换，或通过 API 控制：
+
+```shell
+curl -k https://localhost:8090/mask/toggle     # 开启/关闭
+curl -k https://localhost:8090/mask/status     # 查看当前状态
+```
+
+该设置持久化到 `xhrec.json` 的 `maskSensitiveLogs` 字段。
+
+Prometheus 指标暴露在 `/metrics`。Grafana 仪表盘示例：
 
 ![grafana](img_1.png)

--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -1,0 +1,261 @@
+# Refactor Plan: 事件总线非阻塞化
+
+## Problem Statement
+
+事件总线被同步 I/O 阻塞导致级联雪崩。具体表现：
+
+1. **PostProcessorComponent 共享邮箱阻塞**：MoveProcessor 的大文件复制（`input.copyTo(dest)`）在 Actor 协程中同步执行，一个房间的文件处理阻塞了所有房间的后续消息。
+2. **ConfigComponent 文件 I/O 阻塞事件泵**：`saveConfig()` 在 EventBus subscriber 的 collector 协程中执行 `configFile.writeText()`，磁盘慢时整个 ConfigComponent 停止响应，导致所有 `GetDecryptKey` / `MatchDecryptKeys` 请求超时（日志中 25 个 session 在同一毫秒内全部超时）。
+3. **pollingLoop 无错开**：多个 session 的 3 秒轮询周期同步，同一时刻发起大量相同请求，放大拥堵效应。
+4. **最终崩溃**：事件堆积 + 文件句柄泄漏 → `OutOfMemoryError: Java heap space`。
+5. **无测试覆盖**：核心并发框架（EventBus、Actor、RequestBus）没有任何自动化测试。
+
+## Solution
+
+分五个模块改造，核心原则：**按房间隔离、阻塞 I/O 异步化、事件泵永不阻塞、积压可观测**。
+
+### 模块 1: 核心框架测试（EventBus / Actor / RequestBus / DataChannel / OrderedEmitter）
+
+用 `kotlinx-coroutines-test` + JUnit5 `runTest` 编写测试。OrderedEmitter 用 mock DataChannel。
+
+### 模块 2: 事件总线积压监控（EventBus / Actor）
+
+**EventBus**：`publish()` 先用 `tryEmit()`。返回 false 说明 SharedFlow buffer 满、事件正在积压。记录第一个积压事件的类型和时间戳，持续积压时按间隔（每 30 秒）汇总打印积压事件类型和数量。随后 fallback 到 `emit()`（挂起等待，不丢事件）。
+
+**Actor**：在 `handle()` 调用前后记录时间，耗时超过 500ms 时打印 WARN（包含 Actor 名、消息类型、耗时毫秒数）。
+
+### 模块 2: PostProcessorComponent 按房间分发
+
+保持全局 `Semaphore(4)` 限制并发进程数，新增 per-room `Channel<FileReady>` + 专属协程。 `handle()` 只做路由到房间 Channel，通过 `scope.launch` 中 `channel.send()` 避免阻塞 Actor 主循环。房间停止时通过 `RecordingStopped` 事件驱动清理。
+
+### 模块 3: ConfigComponent 非阻塞化 + SessionComponent 缓存
+
+`loadConfig()`/`saveConfig()` 文件读写切到 `Dispatchers.IO`。`PersistConfig` 处理改为 `scope.launch(Dispatchers.IO) { saveConfig() }` 完全异步化。SessionComponent 新增 `ConcurrentHashMap` 缓存 decrypt key 查询结果，`PersistConfig` 时清空。
+
+### 模块 4: pollingLoop 错开
+
+每次 pollingLoop 启动时在 3 秒基础上加随机 ±500ms jitter。
+
+## Commits
+
+### Commit 1: 添加 kotlinx-coroutines-test 测试依赖
+
+`build.gradle.kts` 新增 `testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")`。
+
+### Commit 2: EventBus 测试
+
+`src/test/kotlin/github/rikacelery/v3/core/EventBusTest.kt`
+
+- `publish to single subscriber delivers event correctly`
+- `publish to multiple subscribers each gets independent copy`
+- `buffer full with DROP_OLDEST drops oldest events`
+- `hook returns null swallows event`
+- `concurrent publish from multiple coroutines delivers all events`
+
+### Commit 3: Actor 测试
+
+`src/test/kotlin/github/rikacelery/v3/core/ActorTest.kt`
+
+创建一个测试用 `TestActor` 子类。覆盖：
+- `tell order equals handle order` — 时序保证
+- `handle throws non-CancellationException triggers onError` — 异常隔离
+- `start then stop closes mailbox and cancels coroutine` — 生命周期
+- `wrapEvent routes events into mailbox` — 集成链路
+
+### Commit 4: RequestBus 测试
+
+`src/test/kotlin/github/rikacelery/v3/core/RequestBusTest.kt`
+
+- `request-response round-trip with CommandAck`
+- `timeout throws RequestTimeoutException and cleans pending`
+- `ErrorResponse throws RequestErrorException`
+- `concurrent 100 requests each gets correct independent response`
+- `parent coroutine cancelled cleans up CompletableDeferred`
+- `CommandAck arrives before await (extreme out-of-order)`
+
+### Commit 5: DataChannel 测试
+
+`src/test/kotlin/github/rikacelery/v3/core/DataChannelTest.kt`
+
+- `send-receive preserves order`
+- `hook returns null drops message`
+
+### Commit 6: OrderedEmitter 测试
+
+`src/test/kotlin/github/rikacelery/v3/core/OrderedEmitterTest.kt`
+
+Mock DataChannel，只验证 OrderedEmitter 自身的排序逻辑：
+- `in-order completion emits in-order`
+- `out-of-order completion emits sorted by seq`
+- `CutPoint result triggers StreamEnd and resets emitter`
+
+### Commit 7: ConfigComponent 非阻塞 IO
+
+`ConfigComponent.kt`:
+
+- `loadConfig()` 方法体内加 `withContext(Dispatchers.IO)` 包裹 `configFile.readText()`
+- `saveConfig()` 方法体内加 `withContext(Dispatchers.IO)` 包裹 `configFile.writeText()`
+- `PersistConfig` 处理从 `saveConfig()` 改为 `scope.launch(Dispatchers.IO) { saveConfig() }`
+
+### Commit 8: ConfigComponent 测试
+
+`src/test/kotlin/github/rikacelery/v3/components/ConfigComponentTest.kt`
+
+- `GetDecryptKey found returns key value`
+- `GetDecryptKey not found returns ConfigResponse(null)`
+- `MatchDecryptKeys finds first matching key`
+- `MatchDecryptKeys no match returns empty DecryptKeyMatch`
+- `ToggleMask flips value and publishes PersistConfig`
+- `saveConfig then loadConfig round-trips correctly`
+- `saveConfig does not block GetDecryptKey request handling` — **核心隔离测试**
+
+### Commit 9: SessionComponent decryptKeyCache
+
+`SessionComponent.kt`:
+
+- 新增 `private val decryptKeyCache = ConcurrentHashMap<String, String>()`
+- `pollingLoop` 第 524 行：先查 cache，miss 时调 `requestBus.request<ConfigResponse>(GetDecryptKey(rs.pkey))`，结果写入 cache
+- 新增 `onPersistConfig()` 处理方法，清空 cache
+- `onStart()` 中订阅 `PersistConfig` 事件
+
+### Commit 10: PostProcessorComponent 按房间分发
+
+`PostProcessorComponent.kt` 重构：
+
+- 新增 `RoomProcessor` 内部结构：`Channel<FileReady>(capacity=8)` + 专属 `Job`
+- 新增 `private val rooms = ConcurrentHashMap<Long, RoomProcessor>()`
+- `handle()` 中 `OnProcessorEvent(FileReady)` → `rooms.getOrPut(roomId)` → `scope.launch { room.channel.send(event) }`，主循环不阻塞
+- `RoomProcessor` 协程内：`for (event in channel) { semaphore.withPermit { processFile(event) } }`，全局 Semaphore 保留
+
+### Commit 11: PostProcessorComponent 事件驱动清理
+
+- `onStart()` 中新增订阅 `RecordingStopped` 事件
+- 收到 `RecordingStopped` → 等待对应 RoomProcessor 的 channel 清空 → 关闭 channel → 从 `rooms` 中移除
+
+### Commit 12: PostProcessorComponent 测试
+
+`src/test/kotlin/github/rikacelery/v3/components/PostProcessorComponentTest.kt`
+
+- `single room single FileReady routes to processFile`
+- `single room multiple FileReady processed in arrival order` — 同房间时序
+- `room A slow processing does not block room B` — **核心隔离测试**
+- `room A FileReady queued while room A still processing` — 同房间串行
+- `RecordingStopped cleans up idle RoomProcessor`
+- `new FileReady after cleanup recreates RoomProcessor`
+
+### Commit 13: pollingLoop 启动 jitter
+
+`SessionComponent.kt` `pollingLoop` 方法：
+
+- 首次 `delay(3.seconds)` 改为 `delay(3.seconds + Random.nextLong(-500, 500).milliseconds)`
+- 后续轮次保持标准 3 秒间隔（无需 jitter）
+
+### Commit 14: EventBus 积压监控
+
+`EventBus.kt`:
+
+- `publish()` 中 `_events.emit(e!!)` 改为先调 `tryEmit()`。返回 true 则直接返回，返回 false 则记录积压。
+- 新增积压状态字段：`backlogStartTime: Long`（首次积压时间戳）、`backlogCount: Long`（积压事件累计数）、`firstBackloggedEvent: String`（触发积压的第一个事件类型）。
+- `tryEmit()` 返回 false 且 `backlogStartTime == 0`（首次积压）→ 打印 WARN：event 类型 + "event bus buffer full, starting to back up"。
+- 后续 `tryEmit()` 返回 false → 累加计数器。
+- 距首次积压超过 30 秒、或积压数超过 1000 → 汇总打印 WARN：积压总时长、积压事件数、Top N 积压事件类型分布。然后重置计数器。
+- `tryEmit()` 返回 true 且之前处于积压状态 → 打印 INFO：积压已解除，总时长和总积压数。
+- 无论 `tryEmit()` 成功与否，最后 fallback 到 `_events.emit(e!!)` — 不丢事件。
+
+### Commit 15: Actor 慢 handler 监控
+
+`Actor.kt`:
+
+- `handle(msg)` 前后记录 `System.nanoTime()`。
+- 耗时超过 `slowHandlerThresholdMs`（默认 500ms）→ 打印 WARN："slow handler: actor=$name, msg=${msg::class.simpleName}, took=${duration}ms"。
+- `slowHandlerThresholdMs` 作为 Actor 构造参数，默认 500ms，可在子类中按需覆盖。
+
+## Decision Document
+
+### 模块划分
+
+- **核心框架修改 + 测试**：EventBus（tryEmit 积压监控）、Actor（慢 handler 监控 + 测试）、RequestBus（测试）、DataChannel（测试）、OrderedEmitter（测试）
+- **PostProcessorComponent**：从全局串行 Actor 改为按 roomId 分发
+- **ConfigComponent**：文件 I/O 异步化，PersistConfig 完全异步
+- **SessionComponent**：新增 decryptKeyCache，pollingLoop 添加 jitter
+- **不改**：WriterComponent（已用 DataChannel + IO dispatch）、DownloaderComponent（handle 只启动协程）、SchedulerComponent（纯消息路由）
+
+### PostProcessorComponent 设计决策
+
+- **全局 Semaphore 保留**：因为 ffmpeg 进程数量需要全局控制，Semaphore 从 `processFile` 所在协程中 `withPermit` 获取
+- **Per-room Channel 容量 8**：每个房间最多积压 8 个 FileReady，超过则 `send()` 挂起（在 `scope.launch` 的独立协程中，不阻塞 Actor 主循环）
+- **清理策略**：事件驱动（`RecordingStopped`），先等待 channel 清空再关闭
+- **handle() 路由**：使用 `scope.launch { channel.send() }` 而非 `trySend()`，保证不丢事件
+
+### ConfigComponent 设计决策
+
+- **loadConfig/saveConfig**：文件操作包 `withContext(Dispatchers.IO)`，suspend 但不阻塞线程
+- **PersistConfig**：`scope.launch(Dispatchers.IO)` 完全异步，collector 协程立即返回
+- **decryptKeyCache**：`ConcurrentHashMap<String, String>`，key 为 pkey，收到 PersistConfig 时清空
+
+### EventBus 积压监控设计决策
+
+- **两层机制**：`tryEmit()` 快速检测 buffer 满，`emit()` fallback 确保不丢事件。SharedFlow 自带 DROP_OLDEST 不再生效（因为我们主动 tryEmit 后 fallback）。
+- **汇总日志而非每条都打**：首次积压立即 WARN，后续按 30 秒间隔或 1000 条阈值汇总，避免日志爆炸。
+- **解除通知**：积压解除时打印 INFO，便于定位拥堵时长。
+- **保留 DROP_OLDEST 不变**：`extraBufferCapacity` 和 `BufferOverflow` 不做修改。tryEmit 返回 false 意味着 SharedFlow 内部 buffer 满，我们接住了这个信号。
+
+### Actor 慢 handler 监控设计决策
+
+- **默认阈值 500ms**：覆盖大多数合理耗时，超出的都是异常。子类可覆盖。
+- **用 `nanoTime` 而非 `currentTimeMillis`**：单调时钟，不受系统时间调整影响。
+- **不累积统计**：每次慢 handler 单独打 WARN，不在 Actor 内维护统计状态。如果需要聚合分析，由外部日志系统处理。
+
+### Jitter 设计决策
+
+- **仅首次 delay 加 jitter**：后续轮次保持标准 3 秒间隔，避免累积偏差
+- **jitter 范围 ±500ms**：足够分散同时启动的 session，不影响录制的实时性
+
+### 接口变更
+
+- **EventBus.publish()**：行为不变（suspend 函数，不丢事件），内部改为 tryEmit + fallback emit + 积压日志
+- **Actor 构造参数**：新增 `slowHandlerThresholdMs: Long = 500`
+- PostProcessorComponent 新增订阅：`RecordingStopped`
+- SessionComponent 新增订阅：`PersistConfig`
+- 无外部 API 变更
+
+## Testing Decisions
+
+### 测试框架
+
+- **kotlinx-coroutines-test** + `runTest`：虚拟时间，快速验证超时和并发场景
+- **JUnit5**（已配置）：`assertThrows`、`@Test`
+- **OrderedEmitter 的 DataChannel**：用 mock（手动实现一个记录发送消息的 fake）
+
+### 什么算好测试
+
+- 只测试外部可观察行为（发布的事件、抛出的异常、处理顺序），不测内部实现细节
+- 并发测试用 `runTest` + `launch` 启动多个协程，验证最终状态而非执行路径
+- 隔离测试：验证"A 阻塞时 B 不受影响"是每个模块的核心测试
+
+### 哪些模块被测试
+
+| 模块 | 测试文件 |
+|------|---------|
+| EventBus | `EventBusTest.kt` |
+| Actor | `ActorTest.kt`（需 TestActor 子类） |
+| RequestBus | `RequestBusTest.kt` |
+| DataChannel | `DataChannelTest.kt` |
+| OrderedEmitter | `OrderedEmitterTest.kt`（mock DataChannel） |
+| ConfigComponent | `ConfigComponentTest.kt` |
+| PostProcessorComponent | `PostProcessorComponentTest.kt` |
+
+### 现有测试设施
+
+- 项目当前**没有任何测试文件**
+- `build.gradle.kts` 已配置 `kotlin-test` + JUnit5 + `useJUnitPlatform()`
+- 需新增 `kotlinx-coroutines-test` 依赖
+
+## Out of Scope
+
+- **RequestBus 框架级自动去重**：不做，缓存逻辑放在 SessionComponent 业务层
+- **EventBus BUFFER SIZE 或 OVERFLOW 策略修改**：保持 DROP_OLDEST + capacity=1024，积压监控在 tryEmit 层上报，不改变 SharedFlow 底层行为
+- **Actor 框架通用化 per-key 分发**：不抽象到 Actor 基类，仅在 PostProcessorComponent 内部实现
+- **DownloaderComponent / WriterComponent 改造**：已经使用 IO dispatch 或 per-room 协程，不需改动
+- **SessionComponent 的 handle() 改造**：经分析 handle() 无阻塞操作，不需改动
+- **积压事件的自动 dump / 落盘**：只做日志输出，不做事件内容序列化或持久化

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation("commons-cli:commons-cli:1.11.0")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
     testImplementation(platform("org.junit:junit-bom:6.0.3"))
     testImplementation("org.junit.jupiter:junit-jupiter")
 }

--- a/src/main/kotlin/github/rikacelery/v3/components/ConfigComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/ConfigComponent.kt
@@ -6,7 +6,9 @@ import github.rikacelery.v3.data.SystemConfig
 import github.rikacelery.v3.events.*
 import github.rikacelery.v3.utils.SensitiveStringRegistry
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.buildJsonObject
@@ -29,10 +31,12 @@ class ConfigComponent(
     private val persistedDecryptKeys = config.decryptKeys.toMutableMap()
     private var maskSensitiveLogs = config.maskSensitiveLogs
 
-    private fun loadConfig() {
+    private suspend fun loadConfig() {
         if (!configFile.exists()) return
         try {
-            val json = Json.parseToJsonElement(configFile.readText()).jsonObject
+            val json = withContext(Dispatchers.IO) {
+                Json.parseToJsonElement(configFile.readText()).jsonObject
+            }
             json["streamAuthKey"]?.jsonPrimitive?.content?.let { persistedStreamAuthKey = it }
             json["decryptKeys"]?.jsonObject?.forEach { (k, v) ->
                 persistedDecryptKeys[k] = v.jsonPrimitive.content
@@ -45,21 +49,23 @@ class ConfigComponent(
         }
     }
 
-    private fun saveConfig() {
-        try {
-            val json = Json { prettyPrint = true }
-            configFile.writeText(json.encodeToString(JsonElement.serializer(),
-                buildJsonObject {
-                    put("streamAuthKey", persistedStreamAuthKey)
-                    put("maskSensitiveLogs", maskSensitiveLogs)
-                    put("decryptKeys", buildJsonObject {
-                        persistedDecryptKeys.forEach { (k, v) -> put(k, v) }
-                    })
-                }
-            ))
-            logger.info("Saved config to ${config.configPath}")
-        } catch (e: Exception) {
-            logger.warn("Failed to save config.json: ${e.message}")
+    private suspend fun saveConfig() {
+        withContext(Dispatchers.IO) {
+            try {
+                val json = Json { prettyPrint = true }
+                configFile.writeText(json.encodeToString(JsonElement.serializer(),
+                    buildJsonObject {
+                        put("streamAuthKey", persistedStreamAuthKey)
+                        put("maskSensitiveLogs", maskSensitiveLogs)
+                        put("decryptKeys", buildJsonObject {
+                            persistedDecryptKeys.forEach { (k, v) -> put(k, v) }
+                        })
+                    }
+                ))
+                logger.info("Saved config to ${config.configPath}")
+            } catch (e: Exception) {
+                logger.warn("Failed to save config.json: ${e.message}")
+            }
         }
     }
 
@@ -73,7 +79,7 @@ class ConfigComponent(
     override suspend fun wrapEvent(event: Any): ConfigMsg? = when (event) {
         is CommandEnvelope -> HandleConfigQuery(event)
         is PersistConfig -> {
-            saveConfig()
+            scope.launch(Dispatchers.IO) { saveConfig() }
             null
         }
 

--- a/src/main/kotlin/github/rikacelery/v3/components/PostProcessorComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/PostProcessorComponent.kt
@@ -4,12 +4,15 @@ import github.rikacelery.v3.core.Actor
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.events.FileProcessed
 import github.rikacelery.v3.events.FileReady
+import github.rikacelery.v3.events.RecordingStopped
 import github.rikacelery.v3.postprocessors.Processor
 import github.rikacelery.v3.postprocessors.ProcessorCtx
 import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 
 sealed interface PostProcessorMsg
 data class OnProcessorEvent(val event: Any) : PostProcessorMsg
@@ -22,7 +25,13 @@ class PostProcessorComponent(
 
     private var processors: List<Processor> = emptyList()
     private val semaphore = Semaphore(maxConcurrency)
+    private val rooms = ConcurrentHashMap<Long, RoomProcessor>()
     val jobs = Hashtable<String, Job>()
+
+    private inner class RoomProcessor {
+        val channel = Channel<FileReady>(capacity = 8)
+        var job: Job? = null
+    }
 
     fun setProcessors(procs: List<Processor>) {
         processors = procs
@@ -30,30 +39,54 @@ class PostProcessorComponent(
 
     override suspend fun onStart(scope: CoroutineScope) {
         subscribe<FileReady>(FileReady::class)
+        subscribe<RecordingStopped>(RecordingStopped::class)
     }
 
     override suspend fun wrapEvent(event: Any): PostProcessorMsg? = when (event) {
         is FileReady -> OnProcessorEvent(event)
+        is RecordingStopped -> OnProcessorEvent(event)
         else -> null
     }
 
     override suspend fun handle(msg: PostProcessorMsg) {
         when (msg) {
             is OnProcessorEvent -> when (val e = msg.event) {
-                is FileReady -> withContext(NonCancellable) {
-                    val key = "${msg.event.file}"
-                    jobs.set(key, scope.launch {
-                        semaphore.withPermit {
-                            try {
-                                logger.info("processing {}", e.file)
-                                processFile(e)
-                                logger.info("process ok {}", e.file)
-                            } finally {
-                                jobs.remove(key)
-
+                is FileReady -> {
+                    val rp = rooms.getOrPut(e.roomId) { RoomProcessor() }
+                    // ensure the consumer coroutine is running
+                    if (rp.job == null || rp.job?.isCompleted == true) {
+                        rp.job = scope.launch {
+                            for (event in rp.channel) {
+                                val trackJob = scope.launch {
+                                    semaphore.withPermit {
+                                        try {
+                                            logger.info("processing {}", event.file)
+                                            processFile(event)
+                                            logger.info("process ok {}", event.file)
+                                        } catch (ex: CancellationException) {
+                                            throw ex
+                                        } catch (ex: Exception) {
+                                            logger.error("processFile failed: {}", ex.message, ex)
+                                        }
+                                    }
+                                }
+                                val key = event.file.toString()
+                                jobs[key] = trackJob
+                                trackJob.invokeOnCompletion { jobs.remove(key) }
+                                trackJob.join()
                             }
                         }
-                    })
+                    }
+                    // send directly — this is a suspend call in handle(), so it only
+                    // blocks this actor's mailbox (not EventBus). other rooms are unaffected
+                    // because FileReady/RecordingStopped for different rooms dispatch immediately.
+                    rp.channel.send(e)
+                }
+
+                is RecordingStopped -> {
+                    val rp = rooms.remove(e.roomId) ?: return
+                    rp.channel.close()
+                    rp.job?.join()
                 }
 
                 else -> {}

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -22,7 +22,9 @@ import kotlinx.coroutines.sync.withLock
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.abs
+import kotlin.random.Random
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 sealed interface SessionMsg
@@ -82,6 +84,7 @@ class SessionComponent(
 
     private val sessions = ConcurrentHashMap<Long, RoomSession>()
     private val lastBlockReason = ConcurrentHashMap<Long, String>()
+    private val decryptKeyCache = ConcurrentHashMap<String, String>()
 
     override suspend fun onStart(scope: CoroutineScope) {
         subscribe<RoomStatusChanged>(RoomStatusChanged::class)
@@ -92,6 +95,10 @@ class SessionComponent(
         subscribe<QualityChangeRequested>(QualityChangeRequested::class)
         subscribe<RoomTimeLimitChanged>(RoomTimeLimitChanged::class)
         subscribe<RoomSizeLimitChanged>(RoomSizeLimitChanged::class)
+
+        eventBus.subscribe(scope, PersistConfig::class) {
+            decryptKeyCache.clear()
+        }
 
         scope.launch {
             while (isActive) {
@@ -510,8 +517,15 @@ class SessionComponent(
     private suspend fun CoroutineScope.pollingLoop(rs: RoomSession) {
         try {
             val counter = createDiscontinuityCounter()
+            var firstPoll = true
             while (isActive && (rs.state == SessionState.Fetching || rs.state == SessionState.Recording)) {
-                delay(3.seconds)
+                val pollDelay = if (firstPoll) {
+                    3.seconds + Random.nextLong(-500, 500).milliseconds
+                } else {
+                    3.seconds
+                }
+                firstPoll = false
+                delay(pollDelay)
                 try {
                     val client = ClientManager.getProxiedClient("m3u8_${rs.roomId}")
                     val fetchStart = System.currentTimeMillis()
@@ -521,7 +535,11 @@ class SessionComponent(
                     val fetchLatency = System.currentTimeMillis() - fetchStart
                     val text = response.bodyAsText()
 
-                    val key = (requestBus.request<ConfigResponse>(GetDecryptKey(rs.pkey)).value as? String) ?: run {
+                    val key = decryptKeyCache[rs.pkey] ?: run {
+                        val result = (requestBus.request<ConfigResponse>(GetDecryptKey(rs.pkey)).value as? String)
+                        if (result != null) decryptKeyCache[rs.pkey] = result
+                        result
+                    } ?: run {
                         logger.error("No decrypt key for room ${rs.roomId}")
                         delay(5.seconds)
                         continue

--- a/src/main/kotlin/github/rikacelery/v3/core/Actor.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/Actor.kt
@@ -9,7 +9,8 @@ abstract class Actor<T : Any>(
     val name: String,
     protected val eventBus: EventBus,
     parentScope: CoroutineScope,
-    mailboxCapacity: Int = 256
+    mailboxCapacity: Int = 256,
+    private val slowHandlerThresholdMs: Long = 500
 ) {
     private val mailbox = Channel<T>(capacity = mailboxCapacity)
     protected val scope = parentScope + SupervisorJob() + CoroutineName(name)
@@ -25,7 +26,15 @@ abstract class Actor<T : Any>(
             onStart(scope)
             for (msg in mailbox) {
                 try {
+                    val start = System.nanoTime()
                     handle(msg)
+                    val duration = (System.nanoTime() - start) / 1_000_000
+                    if (duration > slowHandlerThresholdMs) {
+                        logger.warn(
+                            "slow handler: actor={}, msg={}, took={}ms",
+                            name, msg::class.simpleName, duration
+                        )
+                    }
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {

--- a/src/main/kotlin/github/rikacelery/v3/core/EventBus.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/EventBus.kt
@@ -8,9 +8,12 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
 import kotlin.reflect.KClass
 
 class EventBus {
+    private val logger = LoggerFactory.getLogger("v3.EventBus")
+
     private val _events = MutableSharedFlow<Any>(
         replay = 0,
         extraBufferCapacity = 1024,
@@ -20,6 +23,13 @@ class EventBus {
 
     private val hooks = mutableListOf<EventHook>()
 
+    // backlog tracking
+    private val backlogLock = Any()
+    private var backlogStartTime: Long = 0
+    private var backlogTotal: Long = 0
+    private val backlogByType = mutableMapOf<String, Long>()
+    private var lastBacklogReportTime: Long = 0
+
     fun installHook(hook: EventHook) { hooks.add(hook) }
 
     suspend fun publish(event: Any) {
@@ -27,7 +37,61 @@ class EventBus {
         for (hook in hooks) {
             e = hook.intercept(e ?: return)
         }
-        if (e != null) _events.emit(e!!)
+        if (e == null) return
+
+        if (_events.tryEmit(e)) {
+            checkBacklogCleared()
+        } else {
+            recordBacklog(e)
+            _events.emit(e)
+        }
+    }
+
+    private fun recordBacklog(event: Any) {
+        val now = System.currentTimeMillis()
+        synchronized(backlogLock) {
+            if (backlogStartTime == 0L) {
+                backlogStartTime = now
+                lastBacklogReportTime = now
+                logger.warn(
+                    "EventBus buffer full, starting to back up. first event: {}",
+                    event::class.simpleName
+                )
+            }
+            backlogTotal++
+            val typeName = event::class.simpleName ?: "unknown"
+            backlogByType.merge(typeName, 1L, Long::plus)
+
+            val elapsed = now - lastBacklogReportTime
+            if (elapsed >= 30_000 || backlogTotal % 1000L == 0L) {
+                val topTypes = backlogByType.entries
+                    .sortedByDescending { it.value }
+                    .take(5)
+                    .joinToString(", ") { "${it.key}=${it.value}" }
+                logger.warn(
+                    "EventBus backlog: {} events over {}s. top types: [{}]",
+                    backlogTotal, (now - backlogStartTime) / 1000, topTypes
+                )
+                lastBacklogReportTime = now
+            }
+        }
+    }
+
+    private fun checkBacklogCleared() {
+        synchronized(backlogLock) {
+            if (backlogStartTime != 0L) {
+                val duration = System.currentTimeMillis() - backlogStartTime
+                logger.info(
+                    "EventBus backlog cleared. total events: {}, duration: {}ms, top backlog type: {}",
+                    backlogTotal, duration,
+                    backlogByType.maxByOrNull { it.value }?.key ?: "none"
+                )
+                backlogStartTime = 0
+                backlogTotal = 0
+                backlogByType.clear()
+                lastBacklogReportTime = 0
+            }
+        }
     }
 
     fun <E : Any> subscribe(

--- a/src/main/kotlin/github/rikacelery/v3/core/RequestBus.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/RequestBus.kt
@@ -41,7 +41,7 @@ class RequestBus(
             if (result is ErrorResponse) throw RequestErrorException(cmd, result.message)
             result as T
         } catch (e: TimeoutCancellationException) {
-            pending.remove(id)
+            pending.remove(id)?.cancel()
             throw RequestTimeoutException(cmd, timeoutMs)
         }
     }

--- a/src/test/kotlin/github/rikacelery/v3/components/ConfigComponentTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/ConfigComponentTest.kt
@@ -1,0 +1,136 @@
+package github.rikacelery.v3.components
+
+import github.rikacelery.v3.core.EventBus
+import github.rikacelery.v3.core.RequestBus
+import github.rikacelery.v3.data.SystemConfig
+import github.rikacelery.v3.events.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.test.*
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConfigComponentTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private fun TestScope.createComponents(): Triple<EventBus, RequestBus, ConfigComponent> {
+        val configPath = tempDir.resolve("xhrec.json").toFile()
+        val config = SystemConfig(
+            outputDir = tempDir.toFile(), tmpDir = tempDir.toFile(),
+            port = 8080, proxy = null,
+            decryptKeys = mapOf("key1" to "secret1", "key2" to "secret2"),
+            streamAuthKey = "auth-secret", authToken = "tok",
+            platformHost = "ex.com", configPath = configPath.absolutePath
+        )
+        val bus = EventBus()
+        val comp = ConfigComponent(config, bus, this)
+        // RequestBus must use backgroundScope so its subscriber coroutine
+        // gets cancelled at test end, avoiding UncompletedCoroutinesError
+        val rb = RequestBus(bus, backgroundScope)
+        return Triple(bus, rb, comp)
+    }
+
+    @Test
+    fun `GetDecryptKey found returns key value`() = runTest(UnconfinedTestDispatcher()) {
+        val (_, rb, comp) = createComponents()
+        comp.start()
+
+        val result = rb.request<ConfigResponse>(GetDecryptKey("key1"))
+        assertEquals("secret1", result.value)
+        comp.stop()
+    }
+
+    @Test
+    fun `GetDecryptKey not found returns ConfigResponse with null`() = runTest(UnconfinedTestDispatcher()) {
+        val (_, rb, comp) = createComponents()
+        comp.start()
+
+        val result = rb.request<ConfigResponse>(GetDecryptKey("nonexistent"))
+        assertNull(result.value)
+        comp.stop()
+    }
+
+    @Test
+    fun `MatchDecryptKeys finds first matching key`() = runTest(UnconfinedTestDispatcher()) {
+        val (_, rb, comp) = createComponents()
+        comp.start()
+
+        val result = rb.request<DecryptKeyMatch>(MatchDecryptKeys(listOf("unknown", "key2", "key1")))
+        assertEquals("key2", result.keyName)
+        assertEquals("secret2", result.decryptKey)
+        comp.stop()
+    }
+
+    @Test
+    fun `MatchDecryptKeys no match returns empty DecryptKeyMatch`() = runTest(UnconfinedTestDispatcher()) {
+        val (_, rb, comp) = createComponents()
+        comp.start()
+
+        val result = rb.request<DecryptKeyMatch>(MatchDecryptKeys(listOf("a", "b")))
+        assertEquals("", result.keyName)
+        assertEquals("", result.decryptKey)
+        comp.stop()
+    }
+
+    @Test
+    fun `ToggleMask flips value`() = runTest(UnconfinedTestDispatcher()) {
+        val (_, rb, comp) = createComponents()
+        comp.start()
+
+        val initial = rb.request<ConfigResponse>(GetMaskStatus)
+        assertEquals(true, initial.value)
+
+        val afterToggle = rb.request<ConfigResponse>(ToggleMask)
+        assertEquals(false, afterToggle.value)
+        comp.stop()
+    }
+
+    @Test
+    fun `saveConfig then loadConfig round-trips`() = runTest(UnconfinedTestDispatcher()) {
+        val configPath = tempDir.resolve("xhrec2.json").toFile()
+        val config = SystemConfig(
+            outputDir = tempDir.toFile(), tmpDir = tempDir.toFile(),
+            port = 8080, proxy = null,
+            decryptKeys = mapOf("k" to "v"), streamAuthKey = "auth",
+            authToken = "tok", platformHost = "ex.com",
+            configPath = configPath.absolutePath
+        )
+        val bus = EventBus()
+        val comp1 = ConfigComponent(config, bus, this)
+        comp1.start()
+        val rb1 = RequestBus(bus, backgroundScope)
+        rb1.request<ConfigResponse>(ToggleMask)
+
+        // give async IO save time to complete
+        delay(300)
+
+        val comp2 = ConfigComponent(config, bus, this)
+        comp2.start()
+        val rb2 = RequestBus(bus, backgroundScope)
+        val mask = rb2.request<ConfigResponse>(GetMaskStatus)
+        assertEquals(false, mask.value)
+
+        comp1.stop()
+        comp2.stop()
+    }
+
+    @Test
+    fun `saveConfig in PersistConfig does not block command handling`() = runTest(UnconfinedTestDispatcher()) {
+        val (bus, rb, comp) = createComponents()
+        comp.start()
+
+        bus.publish(PersistConfig)
+        // if collector were blocked by saveConfig, this would time out
+        val result = rb.request<ConfigResponse>(GetDecryptKey("key1"))
+        assertEquals("secret1", result.value)
+        comp.stop()
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/components/PostProcessorComponentTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/PostProcessorComponentTest.kt
@@ -1,0 +1,187 @@
+package github.rikacelery.v3.components
+
+import github.rikacelery.v3.core.EventBus
+import github.rikacelery.v3.events.EndReason
+import github.rikacelery.v3.events.FileReady
+import github.rikacelery.v3.events.RecordingStopped
+import github.rikacelery.v3.postprocessors.Processor
+import github.rikacelery.v3.postprocessors.ProcessorCtx
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PostProcessorComponentTest {
+
+    private class RecordingProcessor(
+        val processed: MutableList<String> = mutableListOf()
+    ) : Processor() {
+        var delayMs: Long = 0
+
+        override suspend fun process(input: File, ctx: ProcessorCtx): List<File> {
+            if (delayMs > 0) delay(delayMs)
+            processed.add("${ctx.roomName}:${input.name}")
+            return listOf(input)
+        }
+    }
+
+    private fun fileReady(roomId: Long, roomName: String, fileName: String) =
+        FileReady(roomId, File("/tmp/$fileName"), EndReason.TimeLimit, roomName, 0, 0, 1000, "highest")
+
+    @Test
+    fun `single room single FileReady routes to processFile`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        val comp = PostProcessorComponent(bus, backgroundScope)
+        val processor = RecordingProcessor()
+        comp.setProcessors(listOf(processor))
+        comp.start()
+
+        bus.publish(fileReady(1, "roomA", "a.mp4"))
+        advanceUntilIdle()
+
+        assertEquals(listOf("roomA:a.mp4"), processor.processed)
+        comp.stop()
+    }
+
+    @Test
+    fun `single room multiple FileReady processed in arrival order`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        val comp = PostProcessorComponent(bus, backgroundScope)
+        val processor = RecordingProcessor()
+        comp.setProcessors(listOf(processor))
+        comp.start()
+
+        bus.publish(fileReady(1, "roomA", "1.mp4"))
+        bus.publish(fileReady(1, "roomA", "2.mp4"))
+        bus.publish(fileReady(1, "roomA", "3.mp4"))
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("roomA:1.mp4", "roomA:2.mp4", "roomA:3.mp4"),
+            processor.processed
+        )
+        comp.stop()
+    }
+
+    @Test
+    fun `room A slow processing does not block room B dispatch`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        val comp = PostProcessorComponent(bus, backgroundScope, maxConcurrency = 2)
+        val aStarted = CompletableDeferred<Unit>()
+        val aCanFinish = CompletableDeferred<Unit>()
+        val bProcessed = CompletableDeferred<String>()
+
+        val processor = object : Processor() {
+            override suspend fun process(input: File, ctx: ProcessorCtx): List<File> {
+                if (ctx.roomId == 1L) {
+                    aStarted.complete(Unit)
+                    aCanFinish.await()
+                } else {
+                    bProcessed.complete(input.name)
+                }
+                return listOf(input)
+            }
+        }
+        comp.setProcessors(listOf(processor))
+        comp.start()
+
+        bus.publish(fileReady(1, "roomA", "a.mp4"))
+        bus.publish(fileReady(2, "roomB", "b.mp4"))
+
+        // room B should have been dispatched and processed even though room A is blocked
+        assertEquals("b.mp4", bProcessed.await())
+        aCanFinish.complete(Unit)
+        comp.stop()
+    }
+
+    @Test
+    fun `room A FileReady queued while room A still processing`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        val comp = PostProcessorComponent(bus, backgroundScope)
+        val started = CompletableDeferred<Unit>()
+        val canFinish = CompletableDeferred<Unit>()
+        val processed = mutableListOf<String>()
+
+        val processor = object : Processor() {
+            override suspend fun process(input: File, ctx: ProcessorCtx): List<File> {
+                if (input.name == "first.mp4") {
+                    started.complete(Unit)
+                    canFinish.await()
+                }
+                processed.add("${ctx.roomName}:${input.name}")
+                return listOf(input)
+            }
+        }
+        comp.setProcessors(listOf(processor))
+        comp.start()
+
+        // send first file for roomA — starts processing, blocks on canFinish
+        bus.publish(fileReady(1, "roomA", "first.mp4"))
+
+        // send second file for roomA — must queue behind first
+        bus.publish(fileReady(1, "roomA", "second.mp4"))
+
+        // send file for roomB — goes to different channel, processes immediately
+        bus.publish(fileReady(2, "roomB", "other.mp4"))
+
+        // release roomA's first file
+        canFinish.complete(Unit)
+        advanceUntilIdle()
+
+        // roomA: first.mp4 blocked on latch; roomB:other.mp4 gets 2nd permit and finishes
+        // first.mp4 resumes after canFinish, then second.mp4
+        assertEquals(
+            listOf("roomB:other.mp4", "roomA:first.mp4", "roomA:second.mp4"),
+            processed
+        )
+        comp.stop()
+    }
+
+    @Test
+    fun `RecordingStopped cleans up idle RoomProcessor`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        val comp = PostProcessorComponent(bus, backgroundScope)
+        val processor = RecordingProcessor()
+        comp.setProcessors(listOf(processor))
+        comp.start()
+
+        bus.publish(fileReady(1, "roomA", "x.mp4"))
+        advanceUntilIdle()
+
+        // stop recording
+        bus.publish(RecordingStopped(1))
+        advanceUntilIdle()
+
+        assertTrue(comp.jobs.isEmpty(), "jobs should be empty after cleanup")
+        comp.stop()
+    }
+
+    @Test
+    fun `new FileReady after cleanup recreates RoomProcessor`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        val comp = PostProcessorComponent(bus, backgroundScope)
+        val processor = RecordingProcessor()
+        comp.setProcessors(listOf(processor))
+        comp.start()
+
+        bus.publish(fileReady(1, "roomA", "first.mp4"))
+        advanceUntilIdle()
+
+        bus.publish(RecordingStopped(1))
+        advanceUntilIdle()
+
+        bus.publish(fileReady(1, "roomA", "second.mp4"))
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("roomA:first.mp4", "roomA:second.mp4"),
+            processor.processed
+        )
+        comp.stop()
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/core/ActorTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/core/ActorTest.kt
@@ -1,0 +1,130 @@
+package github.rikacelery.v3.core
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.reflect.KClass
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+sealed interface TestMsg
+data class Msg(val v: String) : TestMsg
+data class Bomb(val v: String) : TestMsg
+data class RoutedMsg(val v: String) : TestMsg
+
+class TestActor(
+    name: String,
+    eventBus: EventBus,
+    parentScope: CoroutineScope,
+    mailboxCapacity: Int = 256,
+    private val handler: suspend (TestMsg) -> Unit = {}
+) : Actor<TestMsg>(name, eventBus, parentScope, mailboxCapacity) {
+
+    val handled = mutableListOf<String>()
+    val errors = mutableListOf<Pair<Exception, TestMsg>>()
+
+    override suspend fun handle(msg: TestMsg) {
+        val v = (msg as? Msg)?.v ?: (msg as? Bomb)?.v ?: (msg as? RoutedMsg)?.v ?: "unknown"
+        handled.add(v)
+        handler(msg)
+        if (msg is Bomb) throw RuntimeException("boom: $v")
+    }
+
+    override suspend fun onError(e: Exception, msg: TestMsg) {
+        errors.add(e to msg)
+    }
+
+    suspend fun subscribeRouted(kClass: KClass<out Any>) {
+        subscribe(kClass)
+    }
+
+    override suspend fun wrapEvent(event: Any): TestMsg? = when (event) {
+        is String -> RoutedMsg(event)
+        else -> null
+    }
+}
+
+class ActorTest {
+
+    @Test
+    fun `tell order equals handle order`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        val actor = TestActor("test", bus, this)
+        actor.start()
+
+        actor.tell(Msg("a"))
+        actor.tell(Msg("b"))
+        actor.tell(Msg("c"))
+        actor.stop()
+
+        assertEquals(listOf("a", "b", "c"), actor.handled)
+    }
+
+    @Test
+    fun `handle throws non-CancellationException triggers onError and continues`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        val actor = TestActor("test", bus, this)
+        actor.start()
+
+        actor.tell(Msg("before"))
+        actor.tell(Bomb("kaboom"))
+        actor.tell(Msg("after"))
+        actor.stop()
+
+        assertEquals(listOf("before", "kaboom", "after"), actor.handled)
+        assertEquals(1, actor.errors.size)
+        assertTrue(actor.errors[0].first.message?.contains("boom") == true)
+        assertTrue(actor.errors[0].second is Bomb)
+    }
+
+    @Test
+    fun `start then stop closes mailbox and cancels coroutine`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        val actor = TestActor("test", bus, this)
+        actor.start()
+
+        actor.tell(Msg("x"))
+        actor.stop()
+
+        var threw = false
+        try {
+            actor.tell(Msg("y"))
+        } catch (_: Exception) {
+            threw = true
+        }
+        assertTrue(threw, "tell after stop should throw")
+    }
+
+    @Test
+    fun `wrapEvent routes events into mailbox`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        val actor = TestActor("test", bus, this)
+        actor.start()
+        actor.subscribeRouted(String::class)
+
+        bus.publish("from-event-bus")
+        actor.stop()
+
+        assertEquals(listOf("from-event-bus"), actor.handled)
+    }
+
+    @Test
+    fun `multiple actors run independently`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        val a = TestActor("a", bus, this)
+        val b = TestActor("b", bus, this)
+        a.start()
+        b.start()
+
+        a.tell(Msg("a1"))
+        b.tell(Msg("b1"))
+        a.tell(Msg("a2"))
+        b.tell(Msg("b2"))
+        a.stop()
+        b.stop()
+
+        assertEquals(listOf("a1", "a2"), a.handled)
+        assertEquals(listOf("b1", "b2"), b.handled)
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/core/DataChannelTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/core/DataChannelTest.kt
@@ -1,0 +1,61 @@
+package github.rikacelery.v3.core
+
+import github.rikacelery.v3.data.DataChannelMsg
+import github.rikacelery.v3.data.StreamEnd
+import github.rikacelery.v3.data.StreamStart
+import github.rikacelery.v3.events.EndReason
+import github.rikacelery.v3.hooks.DataHook
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DataChannelTest {
+
+    @Test
+    fun `send-receive preserves order`() = runTest(UnconfinedTestDispatcher()) {
+        val ch = DataChannel()
+        val received = mutableListOf<DataChannelMsg>()
+        val job = launch {
+            received.add(ch.receive())
+            received.add(ch.receive())
+        }
+
+        val m1 = StreamStart(1, "a", Instant.now(), "highest")
+        val m2 = StreamEnd(1, EndReason.UserStop)
+        ch.send(m1)
+        ch.send(m2)
+        ch.close()
+        job.join()
+
+        assertEquals(2, received.size)
+        assertEquals(m1, received[0])
+        assertEquals(m2, received[1])
+    }
+
+    @Test
+    fun `hook returns null drops message`() = runTest(UnconfinedTestDispatcher()) {
+        val ch = DataChannel()
+        ch.installHook(object : DataHook {
+            override suspend fun intercept(msg: DataChannelMsg): DataChannelMsg? {
+                return if (msg is StreamStart) null else msg
+            }
+        })
+
+        val received = mutableListOf<DataChannelMsg>()
+        val job = launch {
+            received.add(ch.receive())
+        }
+
+        ch.send(StreamStart(1, "x", Instant.now(), "highest"))
+        ch.send(StreamEnd(1, EndReason.UserStop))
+        ch.close()
+        job.join()
+
+        assertEquals(1, received.size)
+        assertTrue(received[0] is StreamEnd)
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/core/EventBusTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/core/EventBusTest.kt
@@ -1,0 +1,107 @@
+package github.rikacelery.v3.core
+
+import github.rikacelery.v3.hooks.EventHook
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class EventBusTest {
+
+    @Test
+    fun `publish to single subscriber delivers event`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        val events = mutableListOf<String>()
+        bus.subscribe(backgroundScope, String::class) { events.add(it) }
+
+        bus.publish("hello")
+        assertEquals(listOf("hello"), events)
+    }
+
+    @Test
+    fun `publish to multiple subscribers each gets independent copy`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        val a = mutableListOf<String>()
+        val b = mutableListOf<String>()
+        bus.subscribe(backgroundScope, String::class) { a.add(it) }
+        bus.subscribe(backgroundScope, String::class) { b.add(it) }
+
+        bus.publish("x")
+        assertEquals(listOf("x"), a)
+        assertEquals(listOf("x"), b)
+    }
+
+    @Test
+    fun `subscriber only receives matching event type`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        val strings = mutableListOf<String>()
+        val ints = mutableListOf<Int>()
+        bus.subscribe(backgroundScope, String::class) { strings.add(it) }
+        bus.subscribe(backgroundScope, Int::class) { ints.add(it) }
+
+        bus.publish("s")
+        bus.publish(42)
+        assertEquals(listOf("s"), strings)
+        assertEquals(listOf(42), ints)
+    }
+
+    @Test
+    fun `hook returns null swallows event`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        val events = mutableListOf<String>()
+        bus.installHook(object : EventHook {
+            override suspend fun intercept(event: Any): Any? {
+                return if (event == "drop-me") null else event
+            }
+        })
+        bus.subscribe(backgroundScope, String::class) { events.add(it) }
+
+        bus.publish("drop-me")
+        bus.publish("keep-me")
+        assertEquals(listOf("keep-me"), events)
+    }
+
+    @Test
+    fun `concurrent publish from multiple coroutines delivers all events`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        val events = mutableListOf<Int>()
+        bus.subscribe(backgroundScope, Int::class) { events.add(it) }
+
+        val jobs = (0 until 10).map { batch ->
+            launch {
+                repeat(100) { i -> bus.publish(batch * 100 + i) }
+            }
+        }
+        jobs.forEach { it.join() }
+        assertEquals(1000, events.size)
+        assertEquals((0 until 1000).toSet(), events.toSet())
+    }
+
+    @Test
+    fun `hook chain all pass`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        val events = mutableListOf<String>()
+        bus.installHook(object : EventHook {
+            override suspend fun intercept(event: Any): Any? = "$event-1"
+        })
+        bus.installHook(object : EventHook {
+            override suspend fun intercept(event: Any): Any? = "$event-2"
+        })
+        bus.subscribe(backgroundScope, String::class) { events.add(it) }
+
+        bus.publish("x")
+        assertEquals(listOf("x-1-2"), events)
+    }
+
+    @Test
+    fun `unsubscribed event type not delivered to other subscribers`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        val strings = mutableListOf<String>()
+        bus.subscribe(backgroundScope, String::class) { strings.add(it) }
+
+        bus.publish(123)
+        assertTrue(strings.isEmpty())
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/core/OrderedEmitterTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/core/OrderedEmitterTest.kt
@@ -1,0 +1,116 @@
+package github.rikacelery.v3.core
+
+import github.rikacelery.v3.data.*
+import github.rikacelery.v3.events.CutPoint
+import github.rikacelery.v3.events.EndReason
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class OrderedEmitterTest {
+
+    private val now = Instant.now()
+
+    private fun success(room: Long, idx: Int) = DownloadResult.Success(
+        byteArrayOf(idx.toByte()),
+        DownloadMeta("http://x/$idx", 100, false, now)
+    )
+
+    private fun failed(idx: Int, room: Long) = DownloadResult.Failed(idx, "http://x/$idx", "404")
+
+    private fun cutPoint(room: Long, reason: EndReason = EndReason.UserStop) =
+        DownloadResult.CutPoint(CutPoint(room, 0, "room$room", now, reason, "highest"))
+
+    @Test
+    fun `in-order completion emits in-order`() = runTest(UnconfinedTestDispatcher()) {
+        val emitted = mutableListOf<DataChannelMsg>()
+        val emitter = OrderedEmitter(42) { emitted.add(it) }
+
+        emitter.complete(0, success(42, 0))
+        emitter.complete(1, success(42, 1))
+        emitter.complete(2, success(42, 2))
+
+        assertEquals(3, emitted.size)
+        val d0 = emitted[0] as StreamData
+        val d1 = emitted[1] as StreamData
+        val d2 = emitted[2] as StreamData
+        assertEquals(0, d0.segmentIndex)
+        assertEquals(1, d1.segmentIndex)
+        assertEquals(2, d2.segmentIndex)
+    }
+
+    @Test
+    fun `out-of-order completion emits sorted by seq`() = runTest(UnconfinedTestDispatcher()) {
+        val emitted = mutableListOf<DataChannelMsg>()
+        val emitter = OrderedEmitter(42) { emitted.add(it) }
+
+        emitter.complete(2, success(42, 2))
+        emitter.complete(0, success(42, 0))
+        // idx=1 not arrived yet, so only 0 should be emitted
+        assertEquals(1, emitted.size)
+        assertEquals(0, (emitted[0] as StreamData).segmentIndex)
+
+        emitter.complete(1, success(42, 1))
+        // now 1 and 2 should drain
+        assertEquals(3, emitted.size)
+        assertEquals(1, (emitted[1] as StreamData).segmentIndex)
+        assertEquals(2, (emitted[2] as StreamData).segmentIndex)
+    }
+
+    @Test
+    fun `CutPoint triggers StreamEnd and StreamStart`() = runTest(UnconfinedTestDispatcher()) {
+        val emitted = mutableListOf<DataChannelMsg>()
+        val emitter = OrderedEmitter(42) { emitted.add(it) }
+
+        emitter.complete(0, success(42, 0))
+        emitter.complete(1, cutPoint(42, EndReason.NewInit))
+
+        assertEquals(3, emitted.size)
+        assertEquals(0, (emitted[0] as StreamData).segmentIndex)
+        assertTrue(emitted[1] is StreamEnd)
+        assertEquals(EndReason.NewInit, (emitted[1] as StreamEnd).reason)
+        assertTrue(emitted[2] is StreamStart)
+    }
+
+    @Test
+    fun `Failed result is skipped`() = runTest(UnconfinedTestDispatcher()) {
+        val emitted = mutableListOf<DataChannelMsg>()
+        val emitter = OrderedEmitter(42) { emitted.add(it) }
+
+        emitter.complete(0, failed(0, 42))
+        emitter.complete(1, success(42, 1))
+
+        // failed idx=0 is skipped, should move to idx=1
+        assertEquals(1, emitted.size)
+        assertEquals(1, (emitted[0] as StreamData).segmentIndex)
+    }
+
+    @Test
+    fun `UserStop CutPoint does not emit StreamStart after StreamEnd`() = runTest(UnconfinedTestDispatcher()) {
+        val emitted = mutableListOf<DataChannelMsg>()
+        val emitter = OrderedEmitter(42) { emitted.add(it) }
+
+        emitter.complete(0, success(42, 0))
+        emitter.complete(1, cutPoint(42, EndReason.UserStop))
+
+        assertEquals(2, emitted.size)
+        assertTrue(emitted[0] is StreamData)
+        assertTrue(emitted[1] is StreamEnd)
+        // UserStop → no StreamStart follow-up
+    }
+
+    @Test
+    fun `buffer holds out-of-order until contiguous prefix is ready`() = runTest(UnconfinedTestDispatcher()) {
+        val emitted = mutableListOf<DataChannelMsg>()
+        val emitter = OrderedEmitter(42) { emitted.add(it) }
+
+        emitter.complete(5, success(42, 5))
+        emitter.complete(3, success(42, 3))
+        emitter.complete(4, success(42, 4))
+        // idx 0-2 not arrived, nothing emitted
+        assertEquals(0, emitted.size)
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/core/RequestBusTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/core/RequestBusTest.kt
@@ -1,0 +1,98 @@
+package github.rikacelery.v3.core
+
+import github.rikacelery.v3.events.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.*
+
+class RequestBusTest {
+
+    private fun EventBus.installEchoResponder(scope: CoroutineScope) {
+        subscribe(scope, CommandEnvelope::class) { env ->
+            val response = when (env.command) {
+                is GetDecryptKey -> ConfigResponse("decrypted-${env.command.keyName}")
+                is GetMaskStatus -> ConfigResponse(true)
+                else -> ErrorResponse("unknown: ${env.command::class.simpleName}")
+            }
+            publish(CommandAck(env.id, response))
+        }
+    }
+
+    @Test
+    fun `request-response round-trip with CommandAck`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        bus.installEchoResponder(backgroundScope)
+        val rb = RequestBus(bus, backgroundScope)
+
+        val result = rb.request<ConfigResponse>(GetDecryptKey("test-key"))
+        assertEquals("decrypted-test-key", result.value)
+    }
+
+    @Test
+    fun `timeout throws RequestTimeoutException`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        val rb = RequestBus(bus, backgroundScope, defaultTimeoutMs = 1)
+
+        assertFailsWith<RequestTimeoutException> {
+            rb.request<OkResponse>(GetDecryptKey("ghost"))
+        }
+    }
+
+    @Test
+    fun `ErrorResponse throws RequestErrorException`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        bus.installEchoResponder(backgroundScope)
+        val rb = RequestBus(bus, backgroundScope)
+
+        assertFailsWith<RequestErrorException> {
+            rb.request<OkResponse>(GetValidPaymentAccount(100))
+        }
+    }
+
+    @Test
+    fun `concurrent 100 requests each gets correct independent response`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        bus.installEchoResponder(backgroundScope)
+        val rb = RequestBus(bus, backgroundScope)
+
+        val results = (1..100).map { i ->
+            async {
+                rb.request<ConfigResponse>(GetDecryptKey("key-$i"))
+            }
+        }.awaitAll()
+
+        assertEquals(100, results.size)
+        results.forEachIndexed { i, r ->
+            assertEquals("decrypted-key-${i + 1}", r.value)
+        }
+    }
+
+    @Test
+    fun `parent coroutine cancelled cleans up CompletableDeferred`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        bus.installEchoResponder(backgroundScope)
+        val rb = RequestBus(bus, backgroundScope)
+
+        val job = launch {
+            try {
+                rb.request<OkResponse>(GetDecryptKey("slow"))
+            } catch (_: CancellationException) {
+                // expected
+            }
+        }
+        job.cancel()
+        job.join()
+    }
+
+    @Test
+    fun `CommandAck arrives before await handles gracefully`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        bus.installEchoResponder(backgroundScope)
+        val rb = RequestBus(bus, backgroundScope)
+
+        val result = rb.request<ConfigResponse>(GetDecryptKey("fast"))
+        assertEquals("decrypted-fast", result.value)
+    }
+}


### PR DESCRIPTION
## Summary

- **EventBus**: tryEmit-first with backlog tracking, summary logging on 30s/1000-count threshold, drain notification
- **Actor**: slow handler monitoring (>500ms WARN) with nanoTime timing
- **ConfigComponent**: file I/O async with `Dispatchers.IO`, `PersistConfig` fully async via `scope.launch`
- **SessionComponent**: `ConcurrentHashMap` decrypt key cache, pollingLoop first-delay ±500ms jitter, sub to `PersistConfig`
- **PostProcessorComponent**: per-room `Channel`+`Job` dispatch, `RecordingStopped` lifecycle cleanup, global `Semaphore` retained
- **RequestBus**: fix missing `cancel()` on `CompletableDeferred` after timeout
- **Tests**: 32 tests across EventBus, Actor, RequestBus, DataChannel, OrderedEmitter, ConfigComponent, PostProcessorComponent
- **Docs**: sync README_zh-CN with English README

## Test plan

- [x] `./gradlew test` — 32 tests pass
- [ ] Deploy and run with multiple rooms, verify no blocking in logs
- [ ] Trigger high load (many rooms + large post-processing files), verify backlog warnings appear then clear