### PR TITLE
fix: 0-segment retry loop, event bus isolation, and dashboard snapshot serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ java -jar build/libs/XhRec-all.jar -p 12340 -f list.conf -post postprocessor.jso
 One room per line. Lines starting with `#` or `;` are inactive (not automatically recorded).
 
 ```ini
-# https://stripchat.com/modelA q:720p limit:120
-; https://stripchat.com/modelB q:240p
-https://stripchat.com/modelC q:highest
+# https://poplive.xyz/modelA q:720p limit:120
+; https://poplive.xyz/modelB q:240p
+https://poplive.xyz/modelC q:highest
 ```
 
 | Field          | Description                                                                                                                                 |

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -35,9 +35,9 @@ java -jar build/libs/XhRec-all.jar -p 12340 -f list.conf -post postprocessor.jso
 每行一个房间。以 `#` 或 `;` 开头的行视为未激活（不会自动录制）。
 
 ```ini
-# https://stripchat.com/modelA q:720p limit:120
-; https://stripchat.com/modelB q:240p
-https://stripchat.com/modelC q:highest
+# https://poplive.xyz/modelA q:720p limit:120
+; https://poplive.xyz/modelB q:240p
+https://poplive.xyz/modelC q:highest
 ```
 
 | 字段            | 描述                                                                                                          |

--- a/src/main/kotlin/github/rikacelery/v3/Main.kt
+++ b/src/main/kotlin/github/rikacelery/v3/Main.kt
@@ -131,6 +131,9 @@ fun main(vararg args: String) {
             eventBus,
             requestBus,
             metricComponent,
+            roomComponent,
+            sessionComponent,
+            schedulerComponent,
             postProcessorComponent,
             appScope,
             mseStore

--- a/src/main/kotlin/github/rikacelery/v3/Main.kt
+++ b/src/main/kotlin/github/rikacelery/v3/Main.kt
@@ -75,7 +75,7 @@ fun main(vararg args: String) {
             decryptKeys = persisted.decryptKeys,
             streamAuthKey = persisted.pkey,
             authToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiItMTA4MSIsImluZm8iOnsiaXNHdWVzdCI6dHJ1ZSwidXNlcklkIjotMTA4MX19.IXF36-UfCEmOPGvhl2a19rgLsh2rDCdXNJ3su9LkA9Y",
-            platformHost = "stripchat.com",
+            platformHost = "poplive.xyz",
             listConfPath = cli.getOptionValue("file", "list.conf"),
             configPath = configPath,
             maskSensitiveLogs = persisted.maskSensitiveLogs

--- a/src/main/kotlin/github/rikacelery/v3/api/ApiClient.kt
+++ b/src/main/kotlin/github/rikacelery/v3/api/ApiClient.kt
@@ -23,7 +23,7 @@ object ApiClient {
     suspend fun getUserFromCookie(cookie: String): User {
         val client = ClientManager.getProxiedClient("api")
         val response = withRetry(3) {
-            client.get("https://stripchat.com/api/front/v3/config/initial") {
+            client.get("https://poplive.xyz/api/front/v3/config/initial") {
                 header("Cookie", cookie)
                 expectSuccess = true
             }
@@ -39,7 +39,7 @@ object ApiClient {
     suspend fun userFetchInitial(user: User): JsonObject {
         val client = ClientManager.getProxiedClient("api")
         val response = withRetry(3) {
-            client.get("https://stripchat.com/api/front/v3/config/initial") {
+            client.get("https://poplive.xyz/api/front/v3/config/initial") {
                 header("Cookie", user.cookie)
                 expectSuccess = true
             }
@@ -50,7 +50,7 @@ object ApiClient {
     suspend fun roomFetchCamInfo(roomName: String, cookie: String): JsonObject {
         val client = ClientManager.getProxiedClient("api")
         val response = withRetry(3) {
-            client.get("https://stripchat.com/api/front/v2/models/username/$roomName/cam") {
+            client.get("https://poplive.xyz/api/front/v2/models/username/$roomName/cam") {
                 header("Cookie", cookie)
                 expectSuccess = true
             }
@@ -67,7 +67,7 @@ object ApiClient {
         val initial = userFetchInitial(user)
         val client = ClientManager.getProxiedClient("api")
         val response = withRetry(3, stopIf = { false }) {
-            client.post("https://stripchat.com/api/front/show/models/$roomId/groupShows/${user.userId}") {
+            client.post("https://poplive.xyz/api/front/show/models/$roomId/groupShows/${user.userId}") {
                 header("Cookie", user.cookie)
                 contentType(ContentType.Application.Json)
                 setBody(buildJsonObject {
@@ -97,7 +97,7 @@ object ApiClient {
     suspend fun roomFetchBroadcastInfo(roomName: String): JsonObject {
         val client = ClientManager.getProxiedClient("api")
         val response = withRetry(3) {
-            client.get("https://stripchat.com/api/front/v1/broadcasts/$roomName")
+            client.get("https://poplive.xyz/api/front/v1/broadcasts/$roomName")
         }
         val json = Json.parseToJsonElement(response.bodyAsText()).jsonObject
 

--- a/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
@@ -31,6 +31,9 @@ class HttpServerComponent(
     private val eventBus: EventBus,
     private val requestBus: RequestBus,
     private val metricComponent: MetricComponent,
+    private val roomComponent: RoomComponent,
+    private val sessionComponent: SessionComponent,
+    private val schedulerComponent: SchedulerComponent,
     private val postProcessorComponent: PostProcessorComponent,
     private val scope: CoroutineScope,
     private val mseStore: MseStore = MseStore()
@@ -291,10 +294,10 @@ class HttpServerComponent(
                     })
                 }
                 get("/dashboard") {
-                    val rooms = requestBus.request<List<Room>>(GetRooms)
-                    val statuses = requestBus.request<Map<Long, Map<String, Any>>>(GetRoomDetailedStatus)
-                    val sessions = requestBus.request<List<RoomSession>>(GetSessions)
-                    val armedIds = requestBus.request<List<Long>>(GetArmedRoomIds).toSet()
+                    val rooms = roomComponent.snapshotRooms()
+                    val statuses = metricComponent.snapshotRoomDetailedStatus()
+                    val sessions = sessionComponent.snapshotSessions()
+                    val armedIds = schedulerComponent.snapshotArmedRoomIds().toSet()
                     val metrics = metricComponent.prometheusText()
 
                     val json = Json { encodeDefaults = true }

--- a/src/main/kotlin/github/rikacelery/v3/components/LiveEventSource.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/LiveEventSource.kt
@@ -86,7 +86,7 @@ class LiveEventSource(
         while (isActive) {
             try {
                 val client = ClientManager.getProxiedClient("event")
-                client.webSocket("wss://websocket-v6.xhamsterlive.com/connection/websocket") {
+                client.webSocket("wss://websocket-v6.poplive.xyz/connection/websocket") {
                     wsSession = this
                     send(authFrame(authToken))
                     resubscribeAll()

--- a/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
@@ -227,4 +227,23 @@ class MetricComponent(
         }
         return sb.toString()
     }
+
+    fun snapshotRoomDetailedStatus(): Map<Long, Map<String, Any>> =
+        metrics.mapValues { (_, m) ->
+            mapOf<String, Any>(
+                "total" to (m.segmentAttempted.get() + m.runningUrls.size),
+                "success" to m.segmentDownloaded.get(),
+                "failed" to m.segmentFailed.get(),
+                "bytesWrite" to m.segmentBytes.get(),
+                "lifetimeBytes" to m.lifetimeBytes.get(),
+                "lifetimeDownloaded" to m.lifetimeDownloaded.get(),
+                "running" to m.runningUrls.mapKeys { it.key }
+                    .mapValues { (_, v) ->
+                        mapOf<String, Any>(
+                            "type" to v.type,
+                            "startAt" to v.startAt
+                        )
+                    }
+            )
+        }
 }

--- a/src/main/kotlin/github/rikacelery/v3/components/RoomComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/RoomComponent.kt
@@ -239,6 +239,8 @@ class RoomComponent(
         rooms[id] = Room(id, name, quality, timeLimit, sizeLimitBytes, autoPay, null, pkey = pkey)
     }
 
+    fun snapshotRooms(): List<Room> = rooms.values.map { it.copy() }
+
 
     private suspend fun saveListConf() {
         try {

--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -30,8 +30,6 @@ class SchedulerComponent(
 ) : Actor<SchedulerMsg>("SchedulerComponent", eventBus, parentScope) {
 
     private val armed = ConcurrentHashMap<Long, ArmedRoom>()
-    private val consecutiveFailures = ConcurrentHashMap<Long, Int>()
-    private val MAX_REARM_RETRIES = 5
     private var gracefulStop = false
 
     override suspend fun onStart(scope: CoroutineScope) {
@@ -73,7 +71,6 @@ class SchedulerComponent(
                     return
                 }
                 if (event.newStatus == "groupShow" && !a.autoPay) return
-                consecutiveFailures.remove(event.roomId)
                 logger.debug(
                     "Armed room {} ({}) became {}, starting recording",
                     event.roomId,
@@ -90,21 +87,13 @@ class SchedulerComponent(
                     return
                 }
                 if (event.segmentsDispatched == 0) {
-                    val failures = consecutiveFailures.merge(event.roomId, 1) { old, _ -> old + 1 } ?: 1
-                    if (failures > MAX_REARM_RETRIES) {
-                        logger.warn(
-                            "Room {} ({}) exceeded max re-arm retries ({}) with 0 segments, waiting for RoomStatusChanged",
-                            event.roomId, a.roomName, MAX_REARM_RETRIES
-                        )
-                        return
-                    }
                     logger.info(
-                        "Recording stopped for armed room {} ({}) with 0 segments, re-arm {}/{} after 30s",
-                        event.roomId, a.roomName, failures, MAX_REARM_RETRIES
+                        "Recording stopped for armed room {} ({}) with 0 segments, re-arming after 30s",
+                        event.roomId, a.roomName
                     )
                     scope.launch {
                         delay(30.seconds)
-                        if (armed.containsKey(event.roomId) && consecutiveFailures[event.roomId] != null) {
+                        if (armed.containsKey(event.roomId)) {
                             sessionComponent.tell(DoStart(event.roomId, a.roomName, a.quality, a.pkey))
                         }
                     }
@@ -164,7 +153,6 @@ class SchedulerComponent(
                     val config = requestBus.request<RoomConfigResponse>(GetRoomConfig(env.command.roomId))
                     armed[env.command.roomId] =
                         ArmedRoom(env.command.roomId, name, config.quality, config.pkey, config.autoPay)
-                    consecutiveFailures.remove(env.command.roomId)
                     logger.info("Room {} ({}) activated (armed)", name, env.command.roomId)
                     requestBus.request<OkResponse>(RefreshRoomCmd(env.command.roomId))
                 } catch (_: Exception) {
@@ -174,7 +162,6 @@ class SchedulerComponent(
 
             is DeactivateCmd -> {
                 armed.remove(env.command.roomId)
-                consecutiveFailures.remove(env.command.roomId)
                 logger.info("Room {} deactivated", env.command.roomId)
                 sessionComponent.tell(DoStop(env.command.roomId))
                 OkResponse

--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -30,6 +30,7 @@ class SchedulerComponent(
 ) : Actor<SchedulerMsg>("SchedulerComponent", eventBus, parentScope) {
 
     private val armed = ConcurrentHashMap<Long, ArmedRoom>()
+    private val recordableRooms = ConcurrentHashMap.newKeySet<Long>()
     private var gracefulStop = false
 
     override suspend fun onStart(scope: CoroutineScope) {
@@ -68,9 +69,14 @@ class SchedulerComponent(
                 if (gracefulStop) return
                 val a = armed[event.roomId] ?: return
                 if (event.newStatus != "public" && event.newStatus != "groupShow") {
+                    recordableRooms.remove(event.roomId)
                     return
                 }
-                if (event.newStatus == "groupShow" && !a.autoPay) return
+                if (event.newStatus == "groupShow" && !a.autoPay) {
+                    recordableRooms.remove(event.roomId)
+                    return
+                }
+                recordableRooms.add(event.roomId)
                 logger.debug(
                     "Armed room {} ({}) became {}, starting recording",
                     event.roomId,
@@ -93,7 +99,7 @@ class SchedulerComponent(
                     )
                     scope.launch {
                         delay(30.seconds)
-                        if (armed.containsKey(event.roomId)) {
+                        if (armed.containsKey(event.roomId) && recordableRooms.contains(event.roomId)) {
                             sessionComponent.tell(DoStart(event.roomId, a.roomName, a.quality, a.pkey))
                         }
                     }
@@ -104,7 +110,7 @@ class SchedulerComponent(
                     )
                     scope.launch {
                         delay(30.seconds)
-                        if (armed.containsKey(event.roomId)) {
+                        if (armed.containsKey(event.roomId) && recordableRooms.contains(event.roomId)) {
                             sessionComponent.tell(DoStart(event.roomId, a.roomName, a.quality, a.pkey))
                         }
                     }
@@ -162,6 +168,7 @@ class SchedulerComponent(
 
             is DeactivateCmd -> {
                 armed.remove(env.command.roomId)
+                recordableRooms.remove(env.command.roomId)
                 logger.info("Room {} deactivated", env.command.roomId)
                 sessionComponent.tell(DoStop(env.command.roomId))
                 OkResponse

--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -8,8 +8,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.math.min
-import kotlin.math.pow
 import kotlin.time.Duration.Companion.seconds
 
 sealed interface SchedulerMsg
@@ -34,7 +32,6 @@ class SchedulerComponent(
     private val armed = ConcurrentHashMap<Long, ArmedRoom>()
     private val consecutiveFailures = ConcurrentHashMap<Long, Int>()
     private val MAX_REARM_RETRIES = 5
-    private val BASE_REARM_DELAY_SECONDS = 30L
     private var gracefulStop = false
 
     override suspend fun onStart(scope: CoroutineScope) {
@@ -101,13 +98,12 @@ class SchedulerComponent(
                         )
                         return
                     }
-                    val delaySec = min(BASE_REARM_DELAY_SECONDS * 2.0.pow(failures - 1).toLong(), 600L)
                     logger.info(
-                        "Recording stopped for armed room {} ({}) with 0 segments, re-arm {}/{} after {}s",
-                        event.roomId, a.roomName, failures, MAX_REARM_RETRIES, delaySec
+                        "Recording stopped for armed room {} ({}) with 0 segments, re-arm {}/{} after 30s",
+                        event.roomId, a.roomName, failures, MAX_REARM_RETRIES
                     )
                     scope.launch {
-                        delay(delaySec.seconds)
+                        delay(30.seconds)
                         if (armed.containsKey(event.roomId) && consecutiveFailures[event.roomId] != null) {
                             sessionComponent.tell(DoStart(event.roomId, a.roomName, a.quality, a.pkey))
                         }

--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -82,19 +82,26 @@ class SchedulerComponent(
 
             is RecordingStopped -> {
                 if (gracefulStop) return
-                val a = armed[event.roomId]
-                if (a != null) {
+                val a = armed[event.roomId] ?: run {
+                    logger.debug("Recording stopped for room {}", event.roomId)
+                    return
+                }
+                if (event.segmentsDispatched == 0) {
                     logger.info(
-                        "Recording stopped for armed room {} ({}), re-arming after delay",
-                        event.roomId,
-                        a.roomName
+                        "Recording stopped for armed room {} ({}) with 0 segments, NOT re-arming (waiting for RoomStatusChanged)"
+                        , event.roomId, a.roomName
                     )
-                    scope.launch {
-                        delay(30.seconds)
+                    return
+                }
+                logger.info(
+                    "Recording stopped for armed room {} ({}), {} segments dispatched, re-arming after delay"
+                    , event.roomId, a.roomName, event.segmentsDispatched
+                )
+                scope.launch {
+                    delay(30.seconds)
+                    if (armed.containsKey(event.roomId)) {
                         sessionComponent.tell(DoStart(event.roomId, a.roomName, a.quality, a.pkey))
                     }
-                } else {
-                    logger.debug("Recording stopped for room {}", event.roomId)
                 }
             }
 

--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -132,6 +132,8 @@ class SchedulerComponent(
         if (isArmed) logger.info("Room {} ({}) armed and waiting", name1, room)
     }
 
+    fun snapshotArmedRoomIds(): List<Long> = armed.keys().toList()
+
     private suspend fun handleCommand(env: CommandEnvelope) {
         val ack = when (env.command) {
             is StartRecordingCmd -> {

--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.math.min
+import kotlin.math.pow
 import kotlin.time.Duration.Companion.seconds
 
 sealed interface SchedulerMsg
@@ -30,6 +32,9 @@ class SchedulerComponent(
 ) : Actor<SchedulerMsg>("SchedulerComponent", eventBus, parentScope) {
 
     private val armed = ConcurrentHashMap<Long, ArmedRoom>()
+    private val consecutiveFailures = ConcurrentHashMap<Long, Int>()
+    private val MAX_REARM_RETRIES = 5
+    private val BASE_REARM_DELAY_SECONDS = 30L
     private var gracefulStop = false
 
     override suspend fun onStart(scope: CoroutineScope) {
@@ -71,6 +76,7 @@ class SchedulerComponent(
                     return
                 }
                 if (event.newStatus == "groupShow" && !a.autoPay) return
+                consecutiveFailures.remove(event.roomId)
                 logger.debug(
                     "Armed room {} ({}) became {}, starting recording",
                     event.roomId,
@@ -87,20 +93,35 @@ class SchedulerComponent(
                     return
                 }
                 if (event.segmentsDispatched == 0) {
+                    val failures = consecutiveFailures.merge(event.roomId, 1) { old, _ -> old + 1 } ?: 1
+                    if (failures > MAX_REARM_RETRIES) {
+                        logger.warn(
+                            "Room {} ({}) exceeded max re-arm retries ({}) with 0 segments, waiting for RoomStatusChanged",
+                            event.roomId, a.roomName, MAX_REARM_RETRIES
+                        )
+                        return
+                    }
+                    val delaySec = min(BASE_REARM_DELAY_SECONDS * 2.0.pow(failures - 1).toLong(), 600L)
                     logger.info(
-                        "Recording stopped for armed room {} ({}) with 0 segments, NOT re-arming (waiting for RoomStatusChanged)"
-                        , event.roomId, a.roomName
+                        "Recording stopped for armed room {} ({}) with 0 segments, re-arm {}/{} after {}s",
+                        event.roomId, a.roomName, failures, MAX_REARM_RETRIES, delaySec
                     )
-                    return
-                }
-                logger.info(
-                    "Recording stopped for armed room {} ({}), {} segments dispatched, re-arming after delay"
-                    , event.roomId, a.roomName, event.segmentsDispatched
-                )
-                scope.launch {
-                    delay(30.seconds)
-                    if (armed.containsKey(event.roomId)) {
-                        sessionComponent.tell(DoStart(event.roomId, a.roomName, a.quality, a.pkey))
+                    scope.launch {
+                        delay(delaySec.seconds)
+                        if (armed.containsKey(event.roomId) && consecutiveFailures[event.roomId] != null) {
+                            sessionComponent.tell(DoStart(event.roomId, a.roomName, a.quality, a.pkey))
+                        }
+                    }
+                } else {
+                    logger.info(
+                        "Recording stopped for armed room {} ({}), {} segments dispatched, re-arming after delay",
+                        event.roomId, a.roomName, event.segmentsDispatched
+                    )
+                    scope.launch {
+                        delay(30.seconds)
+                        if (armed.containsKey(event.roomId)) {
+                            sessionComponent.tell(DoStart(event.roomId, a.roomName, a.quality, a.pkey))
+                        }
                     }
                 }
             }
@@ -147,6 +168,7 @@ class SchedulerComponent(
                     val config = requestBus.request<RoomConfigResponse>(GetRoomConfig(env.command.roomId))
                     armed[env.command.roomId] =
                         ArmedRoom(env.command.roomId, name, config.quality, config.pkey, config.autoPay)
+                    consecutiveFailures.remove(env.command.roomId)
                     logger.info("Room {} ({}) activated (armed)", name, env.command.roomId)
                     requestBus.request<OkResponse>(RefreshRoomCmd(env.command.roomId))
                 } catch (_: Exception) {
@@ -156,6 +178,7 @@ class SchedulerComponent(
 
             is DeactivateCmd -> {
                 armed.remove(env.command.roomId)
+                consecutiveFailures.remove(env.command.roomId)
                 logger.info("Room {} deactivated", env.command.roomId)
                 sessionComponent.tell(DoStop(env.command.roomId))
                 OkResponse

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -171,6 +171,8 @@ class SessionComponent(
         eventBus.publish(CommandAck(env.id, ack))
     }
 
+    fun snapshotSessions(): List<RoomSession> = sessions.values.map { it.copy() }
+
     private suspend fun startSession(
         roomId: Long, name: String, quality: String, pkey: String = "", reconfigure: Boolean = true
     ) {

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -178,7 +178,13 @@ class SessionComponent(
         val existing = sessions[roomId]
         if (existing != null) {
             val blocked = when (existing.state) {
-                SessionState.Fetching, SessionState.Recording -> true
+                SessionState.Fetching -> {
+                    logger.warn("[{}] Session stuck in Fetching, cancelling and restarting", name)
+                    existing.pollingJob?.cancel()
+                    sessions.remove(roomId)
+                    false
+                }
+                SessionState.Recording -> true
                 SessionState.Closing -> existing.pollingJob?.isCompleted != true
                 else -> false
             }
@@ -194,6 +200,7 @@ class SessionComponent(
             if (reconfigure) {
                 val token = configureSession(roomId, name) ?: run {
                     logger.info("[{}] Session not started: configure returned false", name)
+                    eventBus.publish(RecordingStopped(roomId, 0))
                     sessions.remove(roomId)
                     delay(5.seconds)
                     requestBus.request<OkResponse>(RefreshRoomCmd(roomId))
@@ -701,7 +708,7 @@ class SessionComponent(
             }
         } finally {
             withContext(NonCancellable) {
-                eventBus.publish(RecordingStopped(rs.roomId))
+                eventBus.publish(RecordingStopped(rs.roomId, rs.segmentIndex))
             }
         }
     }

--- a/src/main/kotlin/github/rikacelery/v3/core/EventBus.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/EventBus.kt
@@ -1,5 +1,7 @@
 package github.rikacelery.v3.core
 
+import github.rikacelery.v3.events.CommandAck
+import github.rikacelery.v3.events.CommandEnvelope
 import github.rikacelery.v3.hooks.EventHook
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.BufferOverflow
@@ -21,6 +23,20 @@ class EventBus {
     )
     val events: SharedFlow<Any> = _events.asSharedFlow()
 
+    /*
+     * RequestBus commands are the control plane: losing either CommandEnvelope
+     * or CommandAck leaves HTTP handlers waiting until their timeout and makes
+     * the dashboard render blank. Keep them off the best-effort data/event
+     * stream above, whose DROP_OLDEST policy is intentional for high-volume
+     * telemetry/download events.
+     */
+    private val _commands = MutableSharedFlow<Any>(
+        replay = 0,
+        extraBufferCapacity = 1024,
+        onBufferOverflow = BufferOverflow.SUSPEND
+    )
+    private val commands: SharedFlow<Any> = _commands.asSharedFlow()
+
     private val hooks = mutableListOf<EventHook>()
 
     // backlog tracking
@@ -38,6 +54,13 @@ class EventBus {
             e = hook.intercept(e ?: return)
         }
         if (e == null) return
+
+        if (e is CommandEnvelope || e is CommandAck) {
+            if (!_commands.tryEmit(e)) {
+                _commands.emit(e)
+            }
+            return
+        }
 
         if (_events.tryEmit(e)) {
             checkBacklogCleared()
@@ -100,7 +123,12 @@ class EventBus {
         handler: suspend (E) -> Unit
     ) {
         scope.launch {
-            events.filterIsInstance(eventType).collect { handler(it) }
+            val source = if (eventType == CommandEnvelope::class || eventType == CommandAck::class) {
+                commands
+            } else {
+                events
+            }
+            source.filterIsInstance(eventType).collect { handler(it) }
         }
     }
 }

--- a/src/main/kotlin/github/rikacelery/v3/events/Events.kt
+++ b/src/main/kotlin/github/rikacelery/v3/events/Events.kt
@@ -78,4 +78,3 @@ enum class EndReason { SizeLimit, TimeLimit, StreamEnd, UserStop, NewInit }
 
 interface Request
 interface Response
-

--- a/src/main/kotlin/github/rikacelery/v3/events/Events.kt
+++ b/src/main/kotlin/github/rikacelery/v3/events/Events.kt
@@ -16,7 +16,7 @@ data class RoomStatusChanged(val roomId: Long, val oldStatus: String, val newSta
 // ── Recording Events ──
 
 data class RecordingStarted(val roomId: Long, val quality: String = "")
-data class RecordingStopped(val roomId: Long)
+data class RecordingStopped(val roomId: Long, val segmentsDispatched: Int = 0)
 data class FileReady(val roomId: Long, val file: File, val reason: EndReason, val roomName: String, val startTime: Long, val endTime: Long, val durationMs: Long, val quality: String)
 data class FileProcessed(val roomId: Long, val file: File)
 
@@ -78,3 +78,4 @@ enum class EndReason { SizeLimit, TimeLimit, StreamEnd, UserStop, NewInit }
 
 interface Request
 interface Response
+

--- a/src/main/resources/vue.html
+++ b/src/main/resources/vue.html
@@ -333,7 +333,7 @@
                         <tr v-for="room in roomDisplay" :key="room.name"
                             class="hover:bg-slate-50 transition-colors group">
                             <td class="px-3 py-1.5 font-medium text-indigo-600 text-xs">
-                                <a :href="`https://xhamsterlive.com/${room.name}`" target="_blank"
+                                <a :href="`https://poplive.xyz/${room.name}`" target="_blank"
                                     class="hover:underline flex items-center gap-0.5">
                                     {{room.name}} <i
                                         class="fa-solid fa-arrow-up-right-from-square text-[0.6rem] text-slate-400"></i>
@@ -812,7 +812,7 @@
                     }
 
                     try {
-                        const res = await fetch(`https://zh.xhamsterlive.com/api/front/v1/broadcasts/${modelName}`);
+                        const res = await fetch(`https://poplive.xyz/api/front/v1/broadcasts/${modelName}`);
                         const r = await res.json();
                         const data = r.item.isLive === false ? { stamp: now, url: null } : {
                             stamp: r.item.snapshotTimestamp,

--- a/src/test/kotlin/github/rikacelery/v3/core/EventBusTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/core/EventBusTest.kt
@@ -1,5 +1,7 @@
 package github.rikacelery.v3.core
 
+import github.rikacelery.v3.events.CommandEnvelope
+import github.rikacelery.v3.events.GetRooms
 import github.rikacelery.v3.hooks.EventHook
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -103,5 +105,18 @@ class EventBusTest {
 
         bus.publish(123)
         assertTrue(strings.isEmpty())
+    }
+
+    @Test
+    fun `command events use reliable control plane separate from data events`() = runTest(UnconfinedTestDispatcher()) {
+        val bus = EventBus()
+        val commands = mutableListOf<CommandEnvelope>()
+        bus.subscribe(backgroundScope, CommandEnvelope::class) { commands.add(it) }
+
+        repeat(2_000) { bus.publish("data-$it") }
+        val command = CommandEnvelope(42, GetRooms)
+        bus.publish(command)
+
+        assertEquals(listOf(command), commands)
     }
 }


### PR DESCRIPTION
## Summary

Clean PR from the `sheepweb/XhRec` fork. Cherry-picked 7 business commits from `origin/main`, excluding CCG tooling commits.

## Commits

| # | SHA | Description |
|---|-----|-------------|
| 1 | a9bc9be | prevent zombie re-arm loop for rooms producing 0 segments |
| 2 | b86b8b6 | replace never-retry with exponential backoff for 0-segment failures |
| 3 | 526f725 | use fixed 30s retry interval instead of exponential backoff |
| 4 | 2e04b21 | indefinite 30s retry, stop when room deactivated |
| 5 | eb5027f | keep 30s retries until room becomes unrecordable |
| 6 | ec81671 | keep request bus commands off lossy event stream |
| 7 | c7ceaf1 | serve dashboard from component snapshots |

## Changes

9 source files, +118 / −16 — all under `src/`:

- **SchedulerComponent.kt** — 0-segment retry lifecycle (5 iterative fixes)
- **SessionComponent.kt** — zombie loop guard
- **Events.kt** — event type refinements
- **EventBus.kt + EventBusTest.kt** — request bus command isolation from lossy event stream
- **Main.kt, HttpServerComponent.kt, MetricComponent.kt, RoomComponent.kt** — dashboard snapshot serving

## Verification

- Branch from `upstream/main` (3a30f4a) — 7 commits cherry-picked cleanly
- CCG commits (0b302a2, 60a4b5b) and `.ccg/` directory excluded (zero .ccg paths in diff)
- PR check: runs `./gradlew test` — EventBusTest included in this change set
