### PR TITLE
Subscribe to CommandEnvelope onStart AuthComponent

### DIFF
--- a/src/main/kotlin/github/rikacelery/v3/components/AuthComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/AuthComponent.kt
@@ -26,6 +26,7 @@ class AuthComponent(
     override suspend fun onStart(scope: CoroutineScope) {
         subscribe<AuthExpired>(AuthExpired::class)
         subscribe<PersistConfig>(PersistConfig::class)
+        subscribe<CommandEnvelope>(CommandEnvelope::class)
     }
 
     override suspend fun wrapEvent(event: Any): AuthMsg? = when (event) {


### PR DESCRIPTION
Related to issue https://github.com/RikaCelery/XhRec/issues/87#issuecomment-5517709868

Details as I commented in the issue:

I was able to replicate this using the latest main. I do recall I had the same issue when i first started using this at bb5afb2. I'm curious which version/commit/date you were using when it used to work for you.  I think it only took this to fix it in AuthComponent:

```
    override suspend fun onStart(scope: CoroutineScope) {
        subscribe<AuthExpired>(AuthExpired::class)
        subscribe<PersistConfig>(PersistConfig::class)
        subscribe<CommandEnvelope>(CommandEnvelope::class)
    }
```

I have been using this in my custom branch for some time. I also just tested this making this change from main. And it seems to work:
```
xhrec  | 09-03 11:48:25 DEBUG LiveEventSource - WS room/model status: roomId=00000000, public -> private ::dispatch
xhrec  | 09-03 11:48:25 DEBUG RoomComponent - Room 00000000 status: public -> private ::handle
xhrec  | 09-03 11:48:28 ERROR SessionComponent - [f4ab94be] Client request error in polling: status=403  ::pollingLoop
xhrec  | 09-03 11:48:29 WARN  SessionComponent - [f4ab94be] No account has free spy access for this room ::configureSession
xhrec  | 09-03 11:48:29 WARN  SessionComponent - [f4ab94be] Room not enable autopay (private) ::configureSession
xhrec  | 09-03 11:48:29 INFO  SessionComponent - [STOP] [f4ab94be] Room off or non-public (403) ::pollingLoop
xhrec  | 09-03 11:48:29 INFO  DownloaderComponent - CutPoint roomId=00000000, index=365, reason=UserStop ::handleCutPoint
xhrec  | 09-03 11:48:29 INFO  SchedulerComponent - Recording stopped for armed room 00000000 (f4ab94be), re-arming after delay ::handleEvent
xhrec  | 09-03 11:48:29 INFO  WriterComponent - Closed file: /app/tmp/f4ab94be-2026-09-03-113630-11m59s.mp4, reason=UserStop ::invokeSuspend
xhrec  | 09-03 11:48:29 INFO  PostProcessorComponent - processing tmp/f4ab94be-2026-09-03-113630-11m59s.mp4 ::invokeSuspend
xhrec  | 09-03 11:48:29 INFO  PostProcessorComponent - [ShellProcessor] running f4ab94be-2026-09-03-113630-11m59s.mp4 ::processFile
xhrec  | 09-03 11:48:29 DEBUG g.r.v.p.ShellProcessor - run: rm /app/tmp/f4ab94be-2026-09-03-113630-11m59s.mp4 ::process
xhrec  | 09-03 11:48:29 INFO  PostProcessorComponent - process ok tmp/f4ab94be-2026-09-03-113630-11m59s.mp4 ::invokeSuspend
xhrec  | 09-03 11:48:29 DEBUG SessionComponent - Cleaned up stale session for room 00000000 ::cleanStaleSessions
```