### PR TITLE
refactor(v3): FSM-driven Session and Scheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ users.txt
 xhrec.keystore
 
 *.jsonl
+
+/tmp/
+/doc/

--- a/src/main/kotlin/github/rikacelery/v3/Main.kt
+++ b/src/main/kotlin/github/rikacelery/v3/Main.kt
@@ -11,17 +11,11 @@ import github.rikacelery.v3.data.HostsConfig
 import github.rikacelery.v3.data.SystemConfig
 import github.rikacelery.v3.hooks.EventHook
 import github.rikacelery.v3.m3u8.M3u8Parser
-import github.rikacelery.v3.utils.CdnSelector
 import github.rikacelery.v3.ml.PredictionEngine
+import github.rikacelery.v3.utils.CdnSelector
 import github.rikacelery.v3.utils.PredictionStore
 import github.rikacelery.v3.utils.SensitiveStringRegistry
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineName
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.*
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -117,8 +111,8 @@ fun main(vararg args: String) {
         dataChannel.installHook(mseStore)
         eventBus.installHook(object : EventHook {
             override suspend fun intercept(event: Any): Any {
-                if (mainLogger.isTraceEnabled){
-                    mainLogger.trace("[BUS] {}",event)
+                if (mainLogger.isTraceEnabled) {
+                    mainLogger.trace("[BUS] {}", event)
                 }
                 return event
             }
@@ -148,12 +142,17 @@ fun main(vararg args: String) {
             downloaderComponent,
             M3u8Parser,
             requestBus,
+            eventBus,
+            appScope
+        )
+        val schedulerComponent = SchedulerComponent(
+            requestBus,
+            sessionComponent,
             ApiClient,
             config.streamAuthKey,
             eventBus,
             appScope
         )
-        val schedulerComponent = SchedulerComponent(requestBus, sessionComponent, eventBus, appScope, config.streamAuthKey)
 
         // Prediction persistence (loads on init, auto-saves periodically, saves on stop)
         val predictionStore = PredictionStore(

--- a/src/main/kotlin/github/rikacelery/v3/components/DownloaderComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/DownloaderComponent.kt
@@ -35,7 +35,7 @@ data class ActiveDownload(
     val semaphore: Semaphore,
     val runningJobs: MutableSet<Job> = ConcurrentHashMap.newKeySet(),
     var idx: AtomicInteger = AtomicInteger(-1),
-    @Volatile var generation: Int = 0,
+    @Volatile var generation: Long = 0L,
     @Volatile var active: Boolean = true
 )
 
@@ -70,6 +70,7 @@ class DownloaderComponent(
         }
         if (!active.active) return
         active.generation = cmd.generation
+        val gen = cmd.generation   // capture the batch generation so workers never read a newer one at completion
 
         // Fire probe round on the first segment of each batch, then throttle by time.
         val probeBaseUrl = cmd.urls.firstOrNull()?.url ?: ""
@@ -110,7 +111,7 @@ class DownloaderComponent(
                         when (result) {
                             is DownloadResult.Success -> {
                                 eventBus.publish(SegmentDownloaded(cmd.roomId, idx, seg.url,
-                                    result.meta.fetchDurationMs, result.meta.proxied, result.data.size, active.generation))
+                                    result.meta.fetchDurationMs, result.meta.proxied, result.data.size, gen))
                             }
                             is DownloadResult.Failed -> {
                                 eventBus.publish(DownloadError(cmd.roomId, idx, seg.url, result.reason))
@@ -140,7 +141,9 @@ class DownloaderComponent(
         val active = rooms[cut.roomId] ?: return
         val idx = active.idx.incrementAndGet().toLong()
         logger.info("CutPoint roomId={}, index={}, reason={}", cut.roomId, cut.index, cut.reason)
-        active.emitter.complete(idx,  DownloadResult.CutPoint(cut))
+        // once complete returns, StreamEnd is in the DataChannel FIFO; Session restart is safe only after that
+        active.emitter.complete(idx, DownloadResult.CutPoint(cut))
+        eventBus.publish(CutPointDone(cut.roomId, cut.generation, cut.reason))
     }
 
     private val raceThresholdMs: Long = 15_000

--- a/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
@@ -157,8 +157,8 @@ class HttpServerComponent(
                     call.respondTextWriter {
                         write("Stopping server...\n"); flush()
 
-                        requestBus.request<OkResponse>(ShutdownCmd)
-                        write("Canceled scheduler.\n"); flush()
+                        eventBus.publish(StopEvent)
+                        write("Stop event published.\n"); flush()
 
                         val sessions = requestBus.request<List<RoomSession>>(GetSessions)
                             .filter { it.state == SessionState.Recording || it.state == SessionState.Fetching }
@@ -166,10 +166,24 @@ class HttpServerComponent(
                         if (sessions.isNotEmpty()) {
                             for (s in sessions) {
                                 write("Waiting ${s.roomName}.\n"); flush()
-                                requestBus.request<OkResponse>(DeactivateCmd(s.roomId))
                             }
                             waitSessionsDone(sessions, "Exited", 120_000L) { write(it); flush() }
                         }
+
+                        // let the final FileReady reach the post-processor, then wait for its queue to drain
+                        delay(0.5.seconds)
+                        try {
+                            withTimeout(3.minutes.inWholeMilliseconds.milliseconds) {
+                                while (postProcessorComponent.jobs.any { !it.value.isCompleted }) {
+                                    delay(0.5.seconds)
+                                }
+                            }
+                            write("Post-processing drained.\n"); flush()
+                        } catch (e: TimeoutCancellationException) {
+                            logger.error("Timeout waiting for post-processing")
+                            write("Timeout waiting for post-processing.\n"); flush()
+                        }
+
                         write("OK\n"); flush()
                     }
                     engine.stop(1000, 5000)
@@ -573,8 +587,8 @@ class HttpServerComponent(
                     call.respondTextWriter {
                         write("Stopping server...\n"); flush()
 
-                        requestBus.request<OkResponse>(ShutdownCmd)
-                        write("Canceled scheduler.\n"); flush()
+                        eventBus.publish(StopEvent)
+                        write("Stop event published.\n"); flush()
 
                         val sessions = requestBus.request<List<RoomSession>>(GetSessions)
                             .filter { it.state == SessionState.Recording || it.state == SessionState.Fetching }

--- a/src/main/kotlin/github/rikacelery/v3/components/RoomComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/RoomComponent.kt
@@ -59,6 +59,7 @@ class RoomComponent(
         subscribe<PersistConfig>(PersistConfig::class)
         subscribe<WsDisconnected>(WsDisconnected::class)
         subscribe<WsReconnected>(WsReconnected::class)
+        subscribe<StopEvent>(StopEvent::class)
         scope.launch {
             tell(RefreshRooms)
             while (isActive && !stopRefresh) {
@@ -73,6 +74,7 @@ class RoomComponent(
         is PersistConfig -> OnRoomEvent(event)
         is WsDisconnected -> OnRoomEvent(event)
         is WsReconnected -> OnRoomEvent(event)
+        is StopEvent -> OnRoomEvent(event)
         else -> null
     }
 
@@ -102,6 +104,11 @@ class RoomComponent(
                         delay(refreshDebounceMs)
                         tell(RefreshRooms)
                     }
+                }
+
+                is StopEvent -> {
+                    logger.info("Stop event received: room refresh stopped")
+                    stopRefresh = true
                 }
 
                 else -> {}

--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -484,6 +484,10 @@ private fun buildSchedulerFsm(ctx: SchedulerEntry) =
                 }
             }
             on(SchedulerEvent.SessionExit) to KEEP action { d ->
+                if (component.gracefulStop) {
+                    self(SchedulerEvent.BackToArmed)
+                    return@action
+                }
                 lastIndex = d?.lastIndex
                 val reason = d?.exitReason ?: EndReason.UserStop
                 when (reason) {
@@ -509,6 +513,10 @@ private fun buildSchedulerFsm(ctx: SchedulerEntry) =
 
         state(SchedulerState.Stopping) {
             on(SchedulerEvent.SessionExit) to KEEP action { d ->
+                if (component.gracefulStop) {
+                    self(SchedulerEvent.BackToArmed)
+                    return@action
+                }
                 lastIndex = d?.lastIndex
                 val reason = d?.exitReason ?: EndReason.UserStop
                 when (reason) {
@@ -556,7 +564,7 @@ class SchedulerComponent(
 ) : Actor<SchedulerMsg>("SchedulerComponent", eventBus, parentScope) {
 
     private val entries = ConcurrentHashMap<Long, SchedulerEntry>()
-    private var gracefulStop = false
+    internal var gracefulStop = false
 
     override suspend fun onStart(scope: CoroutineScope) {
         subscribe<RoomStatusChanged>(RoomStatusChanged::class)
@@ -566,6 +574,7 @@ class SchedulerComponent(
         subscribe<CommandEnvelope>(CommandEnvelope::class)
         subscribe<WriterFatal>(WriterFatal::class)
         subscribe<AuthExpired>(AuthExpired::class)
+        subscribe<StopEvent>(StopEvent::class)
     }
 
     override suspend fun wrapEvent(event: Any): SchedulerMsg? = when (event) {
@@ -576,6 +585,7 @@ class SchedulerComponent(
         is CommandEnvelope -> SchedulerHandleCommand(event)
         is WriterFatal -> SchedulerBus(event)
         is AuthExpired -> SchedulerBus(event)
+        is StopEvent -> SchedulerBus(event)
         else -> null
     }
 
@@ -598,6 +608,17 @@ class SchedulerComponent(
                 entries.remove(event.roomId)?.scope?.cancel()
             }
             is AuthExpired -> logger.warn("Auth expired user {}", event.userId)
+            is StopEvent -> {
+                if (gracefulStop) return
+                gracefulStop = true
+                logger.info("Stop event received: scheduler will not start new recordings")
+                entries.values.forEach { e ->
+                    when (e.fsm.currentState) {
+                        SchedulerState.Armed, SchedulerState.Preconfiguring -> e.scope.cancel()
+                        else -> {}   // Recording/Stopping sessions stop themselves
+                    }
+                }
+            }
         }
     }
 

--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.JsonObject
 import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
@@ -198,6 +199,9 @@ class SchedulerEntry(
             val keyName = matchPkey(master)
             val variant = selectVariant(master, targetQuality)
             val url = resolveVariantUrl(variant, keyName, token)
+            if (!playlistUsable(url)) {
+                return SchedulerSignal(roomId, SchedulerEvent.PreconfigFailed, SchedulerDriveData(failReason = "playlist unusable"))
+            }
             SchedulerSignal(
                 roomId, SchedulerEvent.PreconfigDone,
                 SchedulerDriveData(playlistUrl = url, quality = variant.name, token = token, pkey = keyName)
@@ -375,6 +379,21 @@ class SchedulerEntry(
             token?.takeIf { it.isNotEmpty() }?.let { parameters["aclAuth"] = it }
         }.toString()
         return CdnSelector.resolve(url)
+    }
+
+    /** Verify the resolved variant playlist is actually fetchable before handing it to the Session. */
+    private suspend fun playlistUsable(url: String): Boolean {
+        return try {
+            withTimeout(5.seconds) {
+                val client = ClientManager.getProxiedClient("preconfig_$roomId")
+                val response = withRetry(2) { client.get(url) }
+                response.status.value in 200..299
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            false
+        }
     }
 }
 

--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -1,244 +1,674 @@
 package github.rikacelery.v3.components
 
+import github.rikacelery.v3.api.ApiClient
 import github.rikacelery.v3.core.Actor
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
+import github.rikacelery.v3.data.Hosts
 import github.rikacelery.v3.data.RoomStatus
+import github.rikacelery.v3.data.User
 import github.rikacelery.v3.events.*
+import github.rikacelery.v3.fsm.KEEP
+import github.rikacelery.v3.fsm.LoopTimer
+import github.rikacelery.v3.fsm.StateMachine
+import github.rikacelery.v3.fsm.buildFsm
+import github.rikacelery.v3.m3u8.M3u8Parser
+import github.rikacelery.v3.m3u8.MasterPlaylist
+import github.rikacelery.v3.m3u8.VariantStream
+import github.rikacelery.v3.utils.CdnSelector
 import github.rikacelery.v3.utils.ClientManager
-import github.rikacelery.v3.utils.StreamProbe
+import github.rikacelery.v3.utils.PathSingle
+import github.rikacelery.v3.utils.PathSingleOrNull
+import github.rikacelery.v3.utils.asInt
+import github.rikacelery.v3.utils.asString
+import github.rikacelery.v3.utils.withRetry
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.request.*
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.*
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.JsonObject
+import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.time.Duration.Companion.milliseconds
+import kotlin.math.abs
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
-sealed interface SchedulerMsg
-data class OnSchedulerEvent(val event: Any) : SchedulerMsg
-data class SchedulerHandleCommand(val env: CommandEnvelope) : SchedulerMsg
+// ============================================================
+// Scheduler FSM definitions
+// ============================================================
 
-data class ArmedRoom(
-    val roomId: Long,
-    val roomName: String,
-    val quality: String,
-    val pkey: String = "",
-    val autoPayTicket: Boolean = false,
-    val autoPaySpy: Boolean = false
+enum class SchedulerState { Armed, Preconfiguring, Recording, Stopping }
+
+enum class SchedulerEvent {
+    RoomStatusChanged, StreamStatusChanged, ChangeQuality, SessionExit,
+    PreconfigDone, PreconfigFailed,
+    BeginPreconfig, RestartRecording, BackToArmed, StopAndWait,
+}
+
+data class SchedulerDriveData(
+    val roomStatus: String? = null,
+    val streamStatus: String? = null,
+    val newQuality: String? = null,
+    val lastIndex: Long? = null,
+    val exitReason: EndReason? = null,
+    val playlistUrl: String? = null,
+    val quality: String? = null,
+    val token: String? = null,
+    val pkey: String? = null,
+    val failReason: String? = null,
+    val stopReason: EndReason? = null,
 )
 
+// ============================================================
+// Messages
+// ============================================================
+
+sealed interface SchedulerMsg
+
+data class SchedulerBus(val event: Any) : SchedulerMsg
+
+data class SchedulerSignal(val roomId: Long, val event: SchedulerEvent, val data: SchedulerDriveData?) : SchedulerMsg
+
+data class SchedulerHandleCommand(val env: CommandEnvelope) : SchedulerMsg
+
+// ============================================================
+// Entry
+// ============================================================
+
+private val schedulerLogger = LoggerFactory.getLogger("v3.SchedulerEntry")
+
+class SchedulerEntry(
+    val roomId: Long,
+    var roomName: String,
+    internal val component: SchedulerComponent
+) {
+    // —— Armed configuration ——
+    var targetQuality: String = "highest"
+    var pkey: String = ""
+    var autoPayTicket: Boolean = false
+    var autoPaySpy: Boolean = false
+    var timeLimit: Duration = Duration.INFINITE
+    var sizeLimitBytes: Long = 0L
+
+    // —— Status ——
+    var roomStatus: String = ""
+    var streamStatus: String = ""
+    var currentKind: String = ""       // kind of the current recording: public / groupShow / private
+
+    // —— Preconfiguration results ——
+    var playlistUrl: String = ""
+    var configuredQuality: String = ""
+    var configuredToken: String? = null
+    var configuredPkey: String = ""
+
+    // —— Resume state ——
+    var lastIndex: Long? = null
+    var lastFailReason: String? = null
+
+    val scope = CoroutineScope(
+        component.ioScope.coroutineContext + SupervisorJob(component.ioScope.coroutineContext[Job])
+    )
+    val preconfigLoop = LoopTimer<Unit>(scope)
+
+    val fsm: StateMachine<SchedulerState, SchedulerEvent, SchedulerDriveData, SchedulerEntry> =
+        buildSchedulerFsm(this)
+
+    fun launch(block: suspend () -> Unit) {
+        scope.launch {
+            try {
+                block()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                schedulerLogger.error("Scheduler entry effect failed roomId={}", roomId, e)
+            }
+        }
+    }
+
+    internal fun canRecord(status: String): Boolean = when {
+        RoomStatus.isPublic(status) -> true
+        RoomStatus.isGroupShow(status) -> autoPayTicket
+        RoomStatus.isPrivate(status) -> autoPaySpy
+        else -> false
+    }
+
+    internal fun kindOf(status: String): String = when {
+        RoomStatus.isPublic(status) -> "public"
+        RoomStatus.isGroupShow(status) -> "groupShow"
+        RoomStatus.isPrivate(status) -> "private"
+        else -> "offline"
+    }
+
+    internal fun self(event: SchedulerEvent, data: SchedulerDriveData? = null) {
+        launch { component.tell(SchedulerSignal(roomId, event, data)) }
+    }
+
+    /** Start the fixed-delay preconfig loop: first attempt immediately, then 15s after each completion. */
+    internal fun startPreconfigLoop() {
+        preconfigLoop.start(15.seconds) { component.tell(preconfigSignal()) }
+    }
+
+    internal fun stopPreconfigLoop() {
+        preconfigLoop.cancel()
+    }
+
+    internal fun restartRecording() {
+        launch {
+            component.sessionComponent.tell(
+                StartRecording(
+                    roomId = roomId,
+                    roomName = roomName,
+                    playlistUrl = playlistUrl,
+                    pkey = configuredPkey,
+                    quality = configuredQuality,
+                    startIndex = lastIndex?.plus(1),
+                    timeLimit = timeLimit,
+                    sizeLimitBytes = sizeLimitBytes,
+                )
+            )
+        }
+    }
+
+    internal fun stopSession(reason: EndReason) {
+        launch { component.sessionComponent.tell(StopRecording(roomId, reason)) }
+    }
+
+    // ---- Preconfiguration ----
+
+    internal suspend fun preconfigSignal(): SchedulerMsg {
+        return try {
+            val config = component.requestBus.request<RoomConfigResponse>(GetRoomConfig(roomId))
+            timeLimit = config.timeLimit
+            sizeLimitBytes = config.sizeLimitBytes
+            targetQuality = config.quality
+            autoPayTicket = config.autoPayTicket
+            autoPaySpy = config.autoPaySpy
+            pkey = config.pkey.ifBlank { component.streamAuthKey }
+
+            val token = fetchToken(config)
+                ?: return SchedulerSignal(roomId, SchedulerEvent.PreconfigFailed, SchedulerDriveData(failReason = lastFailReason ?: "no token"))
+            val master = fetchMaster(token)
+            val keyName = matchPkey(master)
+            val variant = selectVariant(master, targetQuality)
+            val url = resolveVariantUrl(variant, keyName, token)
+            SchedulerSignal(
+                roomId, SchedulerEvent.PreconfigDone,
+                SchedulerDriveData(playlistUrl = url, quality = variant.name, token = token, pkey = keyName)
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            SchedulerSignal(roomId, SchedulerEvent.PreconfigFailed, SchedulerDriveData(failReason = e.message))
+        }
+    }
+
+    private suspend fun fetchToken(config: RoomConfigResponse): String? {
+        val info = component.apiClient.roomFetchBroadcastInfo(roomName)
+        val status = info.PathSingle("item.status").asString()
+        roomStatus = status
+        return when {
+            RoomStatus.isPublic(status) -> ""
+            RoomStatus.isGroupShow(status) -> fetchGroupToken(config)
+            RoomStatus.isPrivate(status) -> fetchPrivateToken(config)
+            else -> {
+                lastFailReason = "status $status"
+                null
+            }
+        }
+    }
+
+    private suspend fun fetchGroupToken(config: RoomConfigResponse): String? {
+        if (!config.autoPayTicket) {
+            lastFailReason = "autopay disabled"
+            return null
+        }
+        val camInfo = component.apiClient.roomFetchCamInfo(roomId, "")
+        val price = camInfo.PathSingle("user.user.ticketRate").asInt()
+        val users = component.requestBus.request<List<User>>(GetValidPaymentAccount(price.toLong()))
+        val u = users.firstOrNull()
+        if (u == null) {
+            lastFailReason = "no account"
+            return null
+        }
+        var token = component.apiClient.roomFetchModelToken(roomId, u)
+        if (token == null) {
+            component.apiClient.roomRequestGroupShow(roomId, u)
+            component.requestBus.request<OkResponse>(DeductCoins(u.userId, price.toLong()))
+            delay(1.seconds)
+            token = component.apiClient.roomFetchModelToken(roomId, u)
+        }
+        if (token == null) {
+            lastFailReason = "no token"
+            return null
+        }
+        return token
+    }
+
+    private suspend fun fetchPrivateToken(config: RoomConfigResponse): String? {
+        val users = component.requestBus.request<List<User>>(GetValidPaymentAccount(0))
+        val freeUser = users.firstOrNull { component.apiClient.hasFreeSpyAccess(roomId, it) }
+        if (freeUser != null) {
+            val cam = component.apiClient.roomFetchCamInfo(roomId, freeUser.cookie)
+            val token = cam.PathSingle("cam.modelToken").asString().ifBlank { null }
+            if (token == null) lastFailReason = "no token"
+            return token
+        }
+        lastFailReason = "no free spy access"
+        if (!config.autoPaySpy) {
+            lastFailReason = "autopay disabled"
+            return null
+        }
+        val paidUser = users.firstOrNull()
+        if (paidUser == null) {
+            lastFailReason = "no account"
+            return null
+        }
+        val paidCam = component.apiClient.roomFetchCamInfo(roomId, paidUser.cookie)
+        val price = paidCam.PathSingleOrNull("user.user.privateRate")?.asInt()
+        if (price == null) {
+            lastFailReason = "price unavailable"
+            return null
+        }
+        if (paidUser.coins < price) {
+            lastFailReason = "insufficient balance"
+            return null
+        }
+        var token = paidCam.PathSingle("cam.modelToken").asString().ifBlank { null }
+        if (token == null) {
+            component.apiClient.roomRequestSpyShow(roomId, paidUser)
+            for (attempt in 1..4) {
+                delay(if (attempt == 1) 500L else 1500L)
+                val cam = component.apiClient.roomFetchCamInfo(roomId, paidUser.cookie)
+                token = cam.PathSingle("cam.modelToken").asString().ifBlank { null }
+                if (token != null) break
+            }
+        }
+        if (token == null) {
+            lastFailReason = "no token"
+            return null
+        }
+        return token
+    }
+
+    private suspend fun fetchMaster(token: String?): MasterPlaylist {
+        val client = ClientManager.getProxiedClient("master_$roomId")
+        val hosts = (listOf(Hosts.current.hlsMasterHost) + Hosts.current.hlsHosts).distinct()
+        var lastErr: Throwable? = null
+        for (host in hosts) {
+            val url = buildMasterUrl(host, token)
+            try {
+                val response = withRetry(3) { client.get(url) }
+                return M3u8Parser.parseMaster(response.bodyAsText())
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: ClientRequestException) {
+                lastErr = e
+                CdnSelector.recordFailure(host)
+                schedulerLogger.warn("master playlist business error on {}: {}", host, e.response.status)
+            } catch (e: Exception) {
+                lastErr = e
+                CdnSelector.recordFailure(host)
+                schedulerLogger.warn("master playlist fetch failed on {}: {}", host, e.message)
+            }
+        }
+        throw lastErr ?: IllegalStateException("master playlist unavailable")
+    }
+
+    private suspend fun matchPkey(master: MasterPlaylist): String {
+        val keyIds = master.pschKeys.map { it.substringAfter(":") }
+        val match = component.requestBus.request<DecryptKeyMatch>(MatchDecryptKeys(keyIds))
+        require(match.decryptKey.isNotEmpty()) {
+            "No PSCH key from master playlist matched. keys=$keyIds"
+        }
+        return match.keyName
+    }
+
+    private fun buildMasterUrl(host: String, token: String?): String = buildUrl {
+        protocol = URLProtocol.HTTPS
+        this.host = host
+        encodedPath = "/hls/$roomId/master/${roomId}_auto.m3u8"
+        parameters["psch"] = "v2"
+        parameters["pkey"] = pkey
+        token?.takeIf { it.isNotEmpty() }?.let { parameters["aclAuth"] = it }
+    }.toString()
+
+    private fun selectVariant(master: MasterPlaylist, requested: String): VariantStream {
+        val variant = if (requested == "highest") {
+            master.variants.maxByOrNull { it.bandwidth }
+        } else {
+            val matched = selectQuality(master.variants.map { it.name }, requested)
+            master.variants.find { it.name == matched }
+        }
+        return variant ?: master.variants.maxByOrNull { it.bandwidth }!!
+    }
+
+    private fun selectQuality(available: List<String>, requested: String): String {
+        if (requested == "highest") return "highest"
+        val clean = available.filterNot { it.contains("blurred") }
+        if (clean.isEmpty()) return requested
+        if (requested in available) return requested
+        val reqParts = requested.split("p").filterNot(String::isEmpty)
+        val final = clean.minByOrNull { q ->
+            val qParts = q.split("p").filterNot(String::isEmpty)
+            if (reqParts.size == 2) {
+                abs((qParts[0].toIntOrNull() ?: 0) - (reqParts[0].toIntOrNull() ?: 0)) +
+                        abs((reqParts[1].toIntOrNull() ?: 30) - (qParts.getOrElse(1) { "30" }.toIntOrNull() ?: 30))
+            } else {
+                abs((qParts[0].toIntOrNull() ?: 0) - (reqParts[0].toIntOrNull() ?: 0))
+            }
+        } ?: requested
+        return final
+    }
+
+    private fun resolveVariantUrl(variant: VariantStream, keyName: String, token: String?): String {
+        val url = buildUrl {
+            takeFrom(variant.url)
+            parameters["psch"] = "v2"
+            parameters["pkey"] = keyName
+            token?.takeIf { it.isNotEmpty() }?.let { parameters["aclAuth"] = it }
+        }.toString()
+        return CdnSelector.resolve(url)
+    }
+}
+
+// ============================================================
+// Scheduler FSM matrix
+// ============================================================
+
+private fun buildSchedulerFsm(ctx: SchedulerEntry) =
+    buildFsm<SchedulerState, SchedulerEvent, SchedulerDriveData, SchedulerEntry>(ctx) {
+
+        initial(SchedulerState.Armed)
+
+        state(SchedulerState.Armed) {
+            on(SchedulerEvent.RoomStatusChanged) to KEEP action { d ->
+                val st = d?.roomStatus ?: return@action
+                roomStatus = st
+                if (canRecord(st)) self(SchedulerEvent.BeginPreconfig)
+            }
+            on(SchedulerEvent.StreamStatusChanged) to KEEP action { d ->
+                streamStatus = d?.streamStatus ?: return@action
+                if (canRecord(roomStatus) && streamStatus == "distributing") self(SchedulerEvent.BeginPreconfig)
+            }
+            on(SchedulerEvent.ChangeQuality) to KEEP action { d ->
+                if (d?.newQuality != null) targetQuality = d.newQuality
+            }
+            on(SchedulerEvent.SessionExit) to KEEP
+            on(SchedulerEvent.BeginPreconfig) to SchedulerState.Preconfiguring action { startPreconfigLoop() }
+            on(SchedulerEvent.RestartRecording) to KEEP
+            on(SchedulerEvent.BackToArmed) to KEEP
+            on(SchedulerEvent.StopAndWait) to KEEP
+        }
+
+        state(SchedulerState.Preconfiguring) {
+            on(SchedulerEvent.PreconfigDone) to SchedulerState.Recording action { d ->
+                preconfigLoop.cancel()
+                playlistUrl = d?.playlistUrl ?: return@action
+                configuredQuality = d.quality ?: ""
+                configuredToken = d.token
+                configuredPkey = d.pkey ?: pkey
+                currentKind = kindOf(roomStatus)
+                lastFailReason = null
+                launch {
+                    component.sessionComponent.tell(
+                        StartRecording(
+                            roomId = roomId,
+                            roomName = roomName,
+                            playlistUrl = playlistUrl,
+                            pkey = configuredPkey,
+                            quality = configuredQuality,
+                            startIndex = lastIndex?.plus(1),
+                            timeLimit = timeLimit,
+                            sizeLimitBytes = sizeLimitBytes,
+                        )
+                    )
+                }
+            }
+            on(SchedulerEvent.PreconfigFailed) to KEEP action { d ->
+                // stay in Preconfiguring; the 15s ticker retries automatically
+                if (lastFailReason != d?.failReason) {
+                    schedulerLogger.warn("Preconfig failed room={}: {}", roomId, d?.failReason)
+                    lastFailReason = d?.failReason
+                }
+            }
+            on(SchedulerEvent.RoomStatusChanged) to KEEP action { d ->
+                if (d?.roomStatus != null) {
+                    roomStatus = d.roomStatus
+                    if (!canRecord(roomStatus)) self(SchedulerEvent.BackToArmed)
+                }
+            }
+            on(SchedulerEvent.StreamStatusChanged) to KEEP action { d ->
+                if (d?.streamStatus != null) streamStatus = d.streamStatus
+            }
+            on(SchedulerEvent.ChangeQuality) to KEEP action { d ->
+                if (d?.newQuality != null) targetQuality = d.newQuality
+            }
+            on(SchedulerEvent.BeginPreconfig) to KEEP
+            on(SchedulerEvent.BackToArmed) to SchedulerState.Armed action { stopPreconfigLoop() }
+            on(SchedulerEvent.RestartRecording) to KEEP
+            on(SchedulerEvent.StopAndWait) to KEEP
+        }
+
+        state(SchedulerState.Recording) {
+            on(SchedulerEvent.RoomStatusChanged) to KEEP action { d ->
+                val st = d?.roomStatus ?: return@action
+                val oldKind = currentKind
+                roomStatus = st
+                if (kindOf(st) != oldKind) {
+                    val reason = when {
+                        RoomStatus.isOffline(st) -> EndReason.StreamEnd
+                        canRecord(st) -> EndReason.StatusChanged
+                        else -> EndReason.StreamEnd
+                    }
+                    self(SchedulerEvent.StopAndWait, SchedulerDriveData(stopReason = reason))
+                }
+            }
+            on(SchedulerEvent.StreamStatusChanged) to KEEP action { d ->
+                streamStatus = d?.streamStatus ?: return@action
+                if (streamStatus == "finished") {
+                    self(SchedulerEvent.StopAndWait, SchedulerDriveData(stopReason = EndReason.StreamEnd))
+                }
+            }
+            on(SchedulerEvent.ChangeQuality) to KEEP action { d ->
+                val q = d?.newQuality ?: return@action
+                if (q != targetQuality) {
+                    targetQuality = q
+                    self(SchedulerEvent.StopAndWait, SchedulerDriveData(stopReason = EndReason.NewInit))
+                }
+            }
+            on(SchedulerEvent.SessionExit) to KEEP action { d ->
+                lastIndex = d?.lastIndex
+                val reason = d?.exitReason ?: EndReason.UserStop
+                when (reason) {
+                    EndReason.TimeLimit, EndReason.SizeLimit -> self(SchedulerEvent.RestartRecording)
+                    else -> {
+                        if (canRecord(roomStatus)) self(SchedulerEvent.BeginPreconfig)
+                        else self(SchedulerEvent.BackToArmed)
+                    }
+                }
+            }
+            on(SchedulerEvent.RestartRecording) to KEEP action { restartRecording() }
+            on(SchedulerEvent.BeginPreconfig) to SchedulerState.Preconfiguring action { startPreconfigLoop() }
+            on(SchedulerEvent.BackToArmed) to SchedulerState.Armed action {
+                currentKind = ""
+                lastIndex = null
+            }
+            on(SchedulerEvent.StopAndWait) to SchedulerState.Stopping action { d ->
+                stopSession(d?.stopReason ?: EndReason.UserStop)
+            }
+            on(SchedulerEvent.PreconfigDone) to KEEP
+            on(SchedulerEvent.PreconfigFailed) to KEEP
+        }
+
+        state(SchedulerState.Stopping) {
+            on(SchedulerEvent.SessionExit) to KEEP action { d ->
+                lastIndex = d?.lastIndex
+                val reason = d?.exitReason ?: EndReason.UserStop
+                when (reason) {
+                    EndReason.TimeLimit, EndReason.SizeLimit -> self(SchedulerEvent.RestartRecording)
+                    EndReason.NewInit -> self(SchedulerEvent.BeginPreconfig)
+                    EndReason.StatusChanged -> {
+                        if (canRecord(roomStatus)) self(SchedulerEvent.BeginPreconfig)
+                        else self(SchedulerEvent.BackToArmed)
+                    }
+                    else -> self(SchedulerEvent.BackToArmed)
+                }
+            }
+            on(SchedulerEvent.RestartRecording) to SchedulerState.Recording action { restartRecording() }
+            on(SchedulerEvent.BeginPreconfig) to SchedulerState.Preconfiguring action { startPreconfigLoop() }
+            on(SchedulerEvent.BackToArmed) to SchedulerState.Armed action {
+                currentKind = ""
+                lastIndex = null
+            }
+            on(SchedulerEvent.RoomStatusChanged) to KEEP action { d ->
+                if (d?.roomStatus != null) roomStatus = d.roomStatus
+            }
+            on(SchedulerEvent.StreamStatusChanged) to KEEP action { d ->
+                if (d?.streamStatus != null) streamStatus = d.streamStatus
+            }
+            on(SchedulerEvent.ChangeQuality) to KEEP action { d ->
+                if (d?.newQuality != null) targetQuality = d.newQuality
+            }
+            on(SchedulerEvent.StopAndWait) to KEEP
+            on(SchedulerEvent.PreconfigDone) to KEEP
+            on(SchedulerEvent.PreconfigFailed) to KEEP
+        }
+    }
+
+// ============================================================
+// Actor
+// ============================================================
+
 class SchedulerComponent(
-    private val requestBus: RequestBus,
-    private val sessionComponent: SessionComponent,
+    internal val requestBus: RequestBus,
+    internal val sessionComponent: SessionComponent,
+    internal val apiClient: ApiClient,
+    internal val streamAuthKey: String,
     eventBus: EventBus,
-    parentScope: CoroutineScope,
-    private val streamAuthKey: String = ""
+    parentScope: CoroutineScope
 ) : Actor<SchedulerMsg>("SchedulerComponent", eventBus, parentScope) {
 
-    private val armed = ConcurrentHashMap<Long, ArmedRoom>()
+    private val entries = ConcurrentHashMap<Long, SchedulerEntry>()
     private var gracefulStop = false
-
-    // latest known room status (public/groupShow/off/idle...) and stream lifecycle status
-    private val roomStatuses = ConcurrentHashMap<Long, String>()
-    private val streamStatuses = ConcurrentHashMap<Long, String>()
-    // fallback start jobs scheduled when a room goes public but the stream event is late/missed
-    private val pendingStarts = ConcurrentHashMap<Long, Job>()
-    private val streamReadyTimeoutMs = 15_000L
 
     override suspend fun onStart(scope: CoroutineScope) {
         subscribe<RoomStatusChanged>(RoomStatusChanged::class)
         subscribe<StreamStatusChanged>(StreamStatusChanged::class)
-        subscribe<RecordingStopped>(RecordingStopped::class)
-        subscribe<DownloadError>(DownloadError::class)
+        subscribe<SessionExit>(SessionExit::class)
+        subscribe<QualityChangeRequested>(QualityChangeRequested::class)
+        subscribe<CommandEnvelope>(CommandEnvelope::class)
         subscribe<WriterFatal>(WriterFatal::class)
         subscribe<AuthExpired>(AuthExpired::class)
-        subscribe<CommandEnvelope>(CommandEnvelope::class)
-
     }
 
     override suspend fun wrapEvent(event: Any): SchedulerMsg? = when (event) {
-        is RoomStatusChanged -> OnSchedulerEvent(event)
-        is StreamStatusChanged -> OnSchedulerEvent(event)
-        is RecordingStopped -> OnSchedulerEvent(event)
-        is DownloadError -> OnSchedulerEvent(event)
-        is WriterFatal -> OnSchedulerEvent(event)
-        is AuthExpired -> OnSchedulerEvent(event)
+        is RoomStatusChanged -> SchedulerBus(event)
+        is StreamStatusChanged -> SchedulerBus(event)
+        is SessionExit -> SchedulerBus(event)
+        is QualityChangeRequested -> SchedulerBus(event)
         is CommandEnvelope -> SchedulerHandleCommand(event)
+        is WriterFatal -> SchedulerBus(event)
+        is AuthExpired -> SchedulerBus(event)
         else -> null
     }
 
     override suspend fun handle(msg: SchedulerMsg) {
         when (msg) {
-            is OnSchedulerEvent -> handleEvent(msg.event)
-            is SchedulerHandleCommand -> {
-                handleCommand(msg.env)
-            }
-
+            is SchedulerBus -> onBus(msg.event)
+            is SchedulerSignal -> driveFsm(msg)
+            is SchedulerHandleCommand -> handleCommand(msg.env)
         }
     }
 
-    private suspend fun handleEvent(event: Any) {
+    private suspend fun onBus(event: Any) {
         when (event) {
-            is RoomStatusChanged -> {
-                if (gracefulStop) return
-                val a = armed[event.roomId] ?: return
-                roomStatuses[event.roomId] = event.newStatus
-                val recordable = RoomStatus.isPublic(event.newStatus) ||
-                    (RoomStatus.isGroupShow(event.newStatus) && a.autoPayTicket) ||
-                    (RoomStatus.isPrivate(event.newStatus) && a.autoPaySpy)
-                if (recordable) {
-                    logger.debug("Armed room {} ({}) became {}, waiting for stream", event.roomId, a.roomName, event.newStatus)
-                    val streamStatus = streamStatuses[event.roomId]
-                    when {
-                        // stream already distributing → start immediately
-                        streamStatus == "distributing" -> tryStartRecording(event.roomId, a)
-                        // private shows: the anonymous probe can never succeed (master needs the
-                        // show token) and configureSession itself acquires the token, so start
-                        // directly and let configureSession gate readiness
-                        RoomStatus.isPrivate(event.newStatus) -> tryStartRecording(event.roomId, a)
-                        // stream status unknown (e.g. first boot: already streaming, no event will come)
-                        // → probe the master playlist; start at once when it is reachable
-                        streamStatus == null -> probeAndStart(event.roomId, a)
-                        // known but not distributing yet (probing) → wait for the distributing event
-                        else -> scheduleStart(event.roomId, a)
-                    }
-                } else {
-                    cancelPendingStart(event.roomId)
-                }
-            }
-
-            is StreamStatusChanged -> {
-                streamStatuses[event.roomId] = event.newStatus
-                if (gracefulStop) return
-                val a = armed[event.roomId] ?: return
-                if (event.newStatus == "distributing" && canRecord(event.roomId, a)) {
-                    cancelPendingStart(event.roomId)
-                    tryStartRecording(event.roomId, a)
-                }
-            }
-
-            is RecordingStopped -> {
-                if (gracefulStop) return
-                val a = armed[event.roomId]
-                if (a != null) {
-                    logger.info(
-                        "Recording stopped for armed room {} ({}), re-arming after delay",
-                        event.roomId,
-                        a.roomName
-                    )
-                    scope.launch {
-                        delay(30.seconds)
-                        sessionComponent.tell(DoStart(event.roomId, a.roomName, a.quality, a.pkey))
-                    }
-                } else {
-                    logger.debug("Recording stopped for room {}", event.roomId)
-                }
-            }
-
-            is DownloadError -> logger.warn("Download error room ${event.roomId}: ${event.reason}")
+            is RoomStatusChanged -> driveFsm(event.roomId, SchedulerEvent.RoomStatusChanged, SchedulerDriveData(roomStatus = event.newStatus))
+            is StreamStatusChanged -> driveFsm(event.roomId, SchedulerEvent.StreamStatusChanged, SchedulerDriveData(streamStatus = event.newStatus))
+            is SessionExit -> driveFsm(event.roomId, SchedulerEvent.SessionExit, SchedulerDriveData(lastIndex = event.lastIndex, exitReason = event.reason))
+            is QualityChangeRequested -> driveFsm(event.roomId, SchedulerEvent.ChangeQuality, SchedulerDriveData(newQuality = event.newQuality))
             is WriterFatal -> {
-                logger.error("Writer fatal room ${event.roomId}: ${event.error}"); armed.remove(event.roomId)
+                logger.error("Writer fatal room {}: {}", event.roomId, event.error)
+                entries.remove(event.roomId)?.scope?.cancel()
             }
-
-            is AuthExpired -> logger.warn("Auth expired user ${event.userId}")
-            else -> {}
+            is AuthExpired -> logger.warn("Auth expired user {}", event.userId)
         }
     }
 
-    /** True when the armed room is currently recordable (public / groupShow with ticket autopay / paid with private autopay). */
-    private fun canRecord(roomId: Long, a: ArmedRoom): Boolean {
-        val status = roomStatuses[roomId] ?: return false
-        return when {
-            RoomStatus.isPublic(status) -> true
-            RoomStatus.isGroupShow(status) -> a.autoPayTicket
-            RoomStatus.isPrivate(status) -> a.autoPaySpy
-            else -> false
-        }
+    private suspend fun driveFsm(sig: SchedulerSignal) {
+        val e = entries[sig.roomId] ?: return
+        e.fsm.driveCatch(sig.event, sig.data)?.let { logger.error("Scheduler FSM drive failed", it) }
     }
 
-    /** Start recording now (guard: graceful stop / room recordable). */
-    private suspend fun tryStartRecording(roomId: Long, a: ArmedRoom) {
-        if (gracefulStop) return
-        if (!canRecord(roomId, a)) return
-        logger.debug("Starting recording for {} ({})", a.roomName, roomId)
-        sessionComponent.tell(DoStart(roomId, a.roomName, a.quality, a.pkey))
+    private suspend fun driveFsm(roomId: Long, event: SchedulerEvent, data: SchedulerDriveData?) {
+        val e = entries[roomId] ?: return
+        e.fsm.driveCatch(event, data)?.let { logger.error("Scheduler FSM drive failed", it) }
     }
 
-    /** Probe stream readiness (first boot / unknown status): start now if ready, else wait. */
-    private fun probeAndStart(roomId: Long, a: ArmedRoom) {
-        if (pendingStarts.containsKey(roomId)) return
-        val job = scope.launch {
-            // direct concurrent probe — no session-mailbox round trip, no request timeout
-            val ready = StreamProbe.masterReady(roomId, a.pkey.ifBlank { streamAuthKey })
-            pendingStarts.remove(roomId)
-            if (ready) {
-                tryStartRecording(roomId, a)
-            } else {
-                // not ready yet — wait for the distributing event or the timeout fallback
-                scheduleStart(roomId, a)
+    /** Used by Bootstrap to arm rooms loaded from list.conf */
+    fun internalAdd(room: Long, name: String, quality: String, pkey: String, isArmed: Boolean, autoPayTicket: Boolean, autoPaySpy: Boolean) {
+        if (!isArmed) return
+        entries.getOrPut(room) {
+            SchedulerEntry(room, name, this).apply {
+                targetQuality = quality
+                this.pkey = pkey.ifBlank { streamAuthKey }
+                this.autoPayTicket = autoPayTicket
+                this.autoPaySpy = autoPaySpy
             }
         }
-        pendingStarts[roomId] = job
-    }
-
-    /** Arm a fallback start after [streamReadyTimeoutMs] in case the stream event is late or missed. */
-    private fun scheduleStart(roomId: Long, a: ArmedRoom) {
-        if (pendingStarts.containsKey(roomId)) return
-        val job = scope.launch {
-            delay(streamReadyTimeoutMs.milliseconds)
-            pendingStarts.remove(roomId)
-            tryStartRecording(roomId, a)
-        }
-        pendingStarts[roomId] = job
-    }
-
-    private fun cancelPendingStart(roomId: Long) {
-        pendingStarts.remove(roomId)?.cancel()
-    }
-
-    fun internalAdd(room: Long, name1: String, quality: String, pkey: String, isArmed: Boolean, autoPayTicket: Boolean, autoPaySpy: Boolean) {
-        armed[room] = ArmedRoom(room, name1, quality, pkey, autoPayTicket, autoPaySpy)
-        if (isArmed) logger.info("Room {} ({}) armed and waiting", name1, room)
+        logger.info("Room {} ({}) armed and waiting", name, room)
     }
 
     private suspend fun handleCommand(env: CommandEnvelope) {
-        val ack = when (env.command) {
+        val ack = when (val cmd = env.command) {
             is ActivateRecordingCmd -> {
-                if (armed.contains(env.command.roomId)) {
-                    logger.info("Room {} ({}) already activated (armed)", name, env.command.roomId)
-                } else {
-                    val name = requestBus.request<RoomNameResponse>(GetRoomName(env.command.roomId)).name
-                    val config = requestBus.request<RoomConfigResponse>(GetRoomConfig(env.command.roomId))
-                    armed[env.command.roomId] =
-                        ArmedRoom(env.command.roomId, name, config.quality, config.pkey, config.autoPayTicket, config.autoPaySpy)
-                    logger.info("Room {} ({}) activated (armed)", name, env.command.roomId)
-                    requestBus.request<OkResponse>(RefreshRoomCmd(env.command.roomId))
+                try {
+                    val name = requestBus.request<RoomNameResponse>(GetRoomName(cmd.roomId)).name
+                    val config = requestBus.request<RoomConfigResponse>(GetRoomConfig(cmd.roomId))
+                    entries.getOrPut(cmd.roomId) {
+                        SchedulerEntry(cmd.roomId, name, this).apply {
+                            targetQuality = config.quality
+                            pkey = config.pkey.ifBlank { streamAuthKey }
+                            autoPayTicket = config.autoPayTicket
+                            autoPaySpy = config.autoPaySpy
+                            timeLimit = config.timeLimit
+                            sizeLimitBytes = config.sizeLimitBytes
+                        }
+                    }
+                    logger.info("Room {} ({}) activated (armed)", name, cmd.roomId)
+                    requestBus.request<OkResponse>(RefreshRoomCmd(cmd.roomId))
+                } catch (_: Exception) {
                 }
                 OkResponse
             }
 
             is DeactivateCmd -> {
-                armed.remove(env.command.roomId)
-                cancelPendingStart(env.command.roomId)
-                logger.info("Room {} deactivated", env.command.roomId)
-                sessionComponent.tell(DoStop(env.command.roomId))
-                ClientManager.removeRoomClients(env.command.roomId)
+                entries.remove(cmd.roomId)?.scope?.cancel()
+                sessionComponent.tell(StopRecording(cmd.roomId, EndReason.UserStop))
+                logger.info("Room {} deactivated", cmd.roomId)
                 OkResponse
             }
 
             is BreakCmd -> {
-                sessionComponent.tell(DoBreak(env.command.roomId, env.command.reason))
+                sessionComponent.tell(StopRecording(cmd.roomId, cmd.reason))
                 OkResponse
             }
 
-            is GetArmedRoomIds -> armed.keys().toList()
+            is GetArmedRoomIds -> entries.keys().toList()
+
             is ShutdownCmd -> {
                 gracefulStop = true
-                armed.forEach { (id, _) ->
-                    sessionComponent.tell(DoBreak(id, EndReason.UserStop))
-                    ClientManager.removeRoomClients(id)
+                entries.forEach { (id, e) ->
+                    sessionComponent.tell(StopRecording(id, EndReason.UserStop))
+                    e.scope.cancel()
                 }
+                entries.clear()
                 OkResponse
             }
 
@@ -246,5 +676,4 @@ class SchedulerComponent(
         }
         eventBus.publish(CommandAck(env.id, ack))
     }
-
 }

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -291,6 +291,7 @@ private fun buildSessionFsm(ctx: SessionEntry) =
             on(RecordingEvent.CutPointDone) to RecordingState.Idle action { d ->
                 launch {
                     component.publish(SessionExit(roomId, lastSegmentId, d?.stopReason ?: EndReason.UserStop))
+                    component.publish(RecordingStopped(roomId))
                 }
             }
             on(RecordingEvent.StartRecording) to KEEP
@@ -324,12 +325,14 @@ class SessionComponent(
         subscribe(SegmentDownloaded::class)
         subscribe(CutPointDone::class)
         subscribe(CommandEnvelope::class)
+        subscribe(StopEvent::class)
     }
 
     override suspend fun wrapEvent(event: Any): SessionMsg? = when (event) {
         is SegmentDownloaded -> SessionBus(event)
         is CutPointDone -> SessionBus(event)
         is CommandEnvelope -> SessionHandleCommand(event)
+        is StopEvent -> SessionBus(event)
         else -> null
     }
 
@@ -408,6 +411,15 @@ class SessionComponent(
                     RecordingEvent.CutPointDone,
                     RecordingDriveData(segGeneration = event.generation, stopReason = event.reason)
                 )?.let { logger.error("Session FSM drive failed", it) }
+            }
+            is StopEvent -> {
+                logger.info("Stop event received: stopping all active sessions")
+                entries.values.forEach { e ->
+                    if (e.fsm.currentState == RecordingState.Recording) {
+                        e.fsm.driveCatch(RecordingEvent.StopRecording, RecordingDriveData(stopReason = EndReason.UserStop))
+                            ?.let { logger.error("Session FSM drive failed", it) }
+                    }
+                }
             }
         }
     }

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -14,8 +14,10 @@ import github.rikacelery.v3.m3u8.M3u8Parser
 import github.rikacelery.v3.m3u8.ParsedPlaylist
 import github.rikacelery.v3.utils.ClientManager
 import github.rikacelery.v3.utils.withRetry
+import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
+import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.*
 import org.slf4j.LoggerFactory
 import java.security.SecureRandom
@@ -44,7 +46,7 @@ data class RoomSession(
 
 enum class RecordingEvent {
     StartRecording, StopRecording,
-    PlaylistFetched, PlaylistFetchFailed,
+    PlaylistFetched, PlaylistFetchFailed, PlaylistUnusable,
     PlaylistRetryExhausted,
     SegmentDownloaded, CutPointDone, LimitReached, InitChanged,
 }
@@ -207,6 +209,13 @@ class SessionEntry(
             }
         } catch (e: TimeoutCancellationException) {
             SessionSignal(roomId, RecordingEvent.PlaylistFetchFailed, RecordingDriveData(failReason = "timeout"))
+        } catch (e: ClientRequestException) {
+            if (e.response.status == HttpStatusCode.NotFound || e.response.status == HttpStatusCode.Forbidden) {
+                // playlist is no longer usable: end the session, the scheduler will reconfigure
+                SessionSignal(roomId, RecordingEvent.PlaylistUnusable, RecordingDriveData(failReason = e.response.status.toString()))
+            } else {
+                SessionSignal(roomId, RecordingEvent.PlaylistFetchFailed, RecordingDriveData(failReason = e.message))
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -281,6 +290,9 @@ private fun buildSessionFsm(ctx: SessionEntry) =
             }
             on(RecordingEvent.InitChanged) to RecordingState.Closing action {
                 cutFile(EndReason.NewInit)
+            }
+            on(RecordingEvent.PlaylistUnusable) to RecordingState.Closing action {
+                cutFile(EndReason.StreamEnd)
             }
             on(RecordingEvent.PlaylistRetryExhausted) to RecordingState.Closing action {
                 cutFile(EndReason.StreamEnd)

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -7,8 +7,8 @@ import github.rikacelery.v3.core.RequestBus
 import github.rikacelery.v3.data.StreamStart
 import github.rikacelery.v3.events.*
 import github.rikacelery.v3.fsm.KEEP
+import github.rikacelery.v3.fsm.LoopTimer
 import github.rikacelery.v3.fsm.StateMachine
-import github.rikacelery.v3.fsm.Timer
 import github.rikacelery.v3.fsm.buildFsm
 import github.rikacelery.v3.m3u8.M3u8Parser
 import github.rikacelery.v3.m3u8.ParsedPlaylist
@@ -44,7 +44,7 @@ data class RoomSession(
 
 enum class RecordingEvent {
     StartRecording, StopRecording,
-    FetchPlaylist, PlaylistFetched, PlaylistFetchFailed, PlaylistFetchTimeout,
+    PlaylistFetched, PlaylistFetchFailed,
     PlaylistRetryExhausted,
     SegmentDownloaded, CutPointDone, LimitReached, InitChanged,
 }
@@ -76,7 +76,7 @@ data class StartRecording(
 
 data class StopRecording(val roomId: Long, val reason: EndReason) : SessionMsg
 
-/** Timer async-result envelope fed back into the mailbox */
+/** Async-result envelope fed back into the mailbox */
 data class SessionSignal(val roomId: Long, val event: RecordingEvent, val data: RecordingDriveData?) : SessionMsg
 
 /** Wrapper for bus events */
@@ -126,13 +126,11 @@ class SessionEntry(
     var retryCount: Int = 0
     val circleCache = CircleCache(100)
 
-    // —— scope / timer ——
+    // —— scope / loop timer ——
     val scope = CoroutineScope(
         component.ioScope.coroutineContext + SupervisorJob(component.ioScope.coroutineContext[Job])
     )
-    val playlistTicker = Timer<Unit>(scope)
-    val playlistFetcher = Timer<Unit>(scope)
-    val playlistWatchdog = Timer<Unit>(scope)
+    val playlistLoop = LoopTimer<Unit>(scope)
 
     // —— fsm ——
     val fsm: StateMachine<RecordingState, RecordingEvent, RecordingDriveData, SessionEntry> =
@@ -151,9 +149,7 @@ class SessionEntry(
     }
 
     internal fun cutFile(reason: EndReason) {
-        playlistTicker.cancel()
-        playlistFetcher.cancel()
-        playlistWatchdog.cancel()
+        playlistLoop.cancel()
         launch {
             component.downloader.tell(
                 DoCutPoint(CutPoint(roomId, segmentIndex - 1, roomName, Instant.now(), reason, quality, generation))
@@ -197,13 +193,20 @@ class SessionEntry(
 
     internal suspend fun fetchPlaylistSignal(): SessionMsg {
         return try {
-            val client = ClientManager.getProxiedClient("m3u8_$roomId")
-            val response = withRetry(3) { client.get(playlistUrl) }
-            val text = response.bodyAsText()
-            val key = (component.requestBus.request<ConfigResponse>(GetDecryptKey(pkey)).value as? String)
-                ?: return SessionSignal(roomId, RecordingEvent.PlaylistFetchFailed, RecordingDriveData(failReason = "no decrypt key"))
-            val parsed = component.m3u8Parser.parse(text, key)
-            SessionSignal(roomId, RecordingEvent.PlaylistFetched, RecordingDriveData(playlist = parsed))
+            withTimeout(10.seconds) {
+                val client = ClientManager.getProxiedClient("m3u8_$roomId")
+                val response = withRetry(3) { client.get(playlistUrl) }
+                val text = response.bodyAsText()
+                val key = (component.requestBus.request<ConfigResponse>(GetDecryptKey(pkey)).value as? String)
+                    ?: return@withTimeout SessionSignal(
+                        roomId, RecordingEvent.PlaylistFetchFailed,
+                        RecordingDriveData(failReason = "no decrypt key")
+                    )
+                val parsed = component.m3u8Parser.parse(text, key)
+                SessionSignal(roomId, RecordingEvent.PlaylistFetched, RecordingDriveData(playlist = parsed))
+            }
+        } catch (e: TimeoutCancellationException) {
+            SessionSignal(roomId, RecordingEvent.PlaylistFetchFailed, RecordingDriveData(failReason = "timeout"))
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -229,7 +232,7 @@ private fun buildSessionFsm(ctx: SessionEntry) =
                 retryCount = 0
                 circleCache.clear()   // a new file must re-download the init; media segments are skipped via the lastSegmentId threshold
                 launch { component.dataChannel.send(StreamStart(roomId, roomName, startTime, quality)) }
-                playlistTicker.start(Duration.ZERO) { component.tell(SessionSignal(roomId, RecordingEvent.FetchPlaylist, null)) }
+                playlistLoop.start(3.seconds) { component.tell(fetchPlaylistSignal()) }
             }
             on(RecordingEvent.StopRecording) to KEEP
             on(RecordingEvent.SegmentDownloaded) to KEEP
@@ -237,15 +240,8 @@ private fun buildSessionFsm(ctx: SessionEntry) =
         }
 
         state(RecordingState.Recording) {
-            on(RecordingEvent.FetchPlaylist) to KEEP action {
-                playlistTicker.start(3.seconds) { component.tell(SessionSignal(roomId, RecordingEvent.FetchPlaylist, null)) }
-                if (playlistFetcher.isRunning) return@action
-                playlistWatchdog.start(10.seconds) { component.tell(SessionSignal(roomId, RecordingEvent.PlaylistFetchTimeout, null)) }
-                playlistFetcher.start(Duration.ZERO) { component.tell(fetchPlaylistSignal()) }
-            }
             on(RecordingEvent.PlaylistFetched) to KEEP action { d ->
                 retryCount = 0
-                playlistWatchdog.cancel()
                 val parsed = d?.playlist ?: return@action
                 val initUrl = parsed.initUrl
                 if (lastInitUrl != null && initUrl != null && lastInitUrl != initUrl) {
@@ -268,19 +264,12 @@ private fun buildSessionFsm(ctx: SessionEntry) =
                 }
             }
             on(RecordingEvent.PlaylistFetchFailed) to KEEP action { d ->
-                playlistWatchdog.cancel()
                 if (++retryCount >= MAX_PLAYLIST_RETRY) {
                     launch {
                         component.tell(
                             SessionSignal(roomId, RecordingEvent.PlaylistRetryExhausted, RecordingDriveData(failReason = d?.failReason))
                         )
                     }
-                }
-            }
-            on(RecordingEvent.PlaylistFetchTimeout) to KEEP action {
-                playlistFetcher.cancel()
-                if (++retryCount >= MAX_PLAYLIST_RETRY) {
-                    launch { component.tell(SessionSignal(roomId, RecordingEvent.PlaylistRetryExhausted, null)) }
                 }
             }
             on(RecordingEvent.SegmentDownloaded) to KEEP action { d -> onSegment(d) }

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -1,910 +1,425 @@
 package github.rikacelery.v3.components
 
-import github.rikacelery.v3.api.ApiClient
 import github.rikacelery.v3.core.Actor
 import github.rikacelery.v3.core.DataChannel
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
-import github.rikacelery.v3.data.Hosts
-import github.rikacelery.v3.data.RoomStatus
-import github.rikacelery.v3.data.StreamEvent
 import github.rikacelery.v3.data.StreamStart
-import github.rikacelery.v3.data.User
 import github.rikacelery.v3.events.*
-import kotlinx.serialization.json.*
+import github.rikacelery.v3.fsm.KEEP
+import github.rikacelery.v3.fsm.StateMachine
+import github.rikacelery.v3.fsm.Timer
+import github.rikacelery.v3.fsm.buildFsm
 import github.rikacelery.v3.m3u8.M3u8Parser
-import github.rikacelery.v3.m3u8.MasterPlaylist
-import github.rikacelery.v3.utils.*
-import io.ktor.client.plugins.*
+import github.rikacelery.v3.m3u8.ParsedPlaylist
+import github.rikacelery.v3.utils.ClientManager
+import github.rikacelery.v3.utils.withRetry
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
-import io.ktor.http.*
 import kotlinx.coroutines.*
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
+import org.slf4j.LoggerFactory
+import java.security.SecureRandom
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.math.abs
-import kotlin.random.Random
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import java.time.Duration as JavaDuration
 
-sealed interface SessionMsg
-data class OnSessionEvent(val event: Any) : SessionMsg
-data class DoStart(val roomId: Long, val roomName: String, val quality: String, val pkey: String = "") : SessionMsg
-data class DoStop(val roomId: Long) : SessionMsg
-data class DoBreak(val roomId: Long, val reason: EndReason) : SessionMsg
-data class DoCutPointDone(val roomId: Long) : SessionMsg
-data class HandleSessionCommand(val env: CommandEnvelope) : SessionMsg
+// ============================================================
+// Session FSM definitions
+// ============================================================
 
+enum class RecordingState { Idle, Recording, Closing }
+
+/** Session-state view kept for HTTP API compatibility */
 enum class SessionState { Idle, Armed, Fetching, Recording, Closing }
 
 data class RoomSession(
     val roomId: Long,
-    @Volatile var roomName: String,
-    @Volatile var quality: String,
-    @Volatile var targetquality: String,
-    val mutex: Mutex = Mutex(),
-    @Volatile var state: SessionState = SessionState.Idle,
-    @Volatile var playlistUrl: String = "",
-    @Volatile var initUrl: String? = null,
-    @Volatile var token: String? = null,
-    @Volatile var pkey: String = "",
-    @Volatile var segmentIndex: Int = 0,
-    @Volatile var generation: Int = 0,
-    val circleCache: CircleCache = CircleCache(100),
-    @Volatile var startTime: Instant = Instant.now(),
-    @Volatile var totalBytes: Long = 0,
-    @Volatile var timeLimit: Duration = Duration.INFINITE,
-    @Volatile var sizeLimitBytes: Long = 0,
-    @Volatile var pollingJob: Job? = null,
-    @Volatile var masterPlaylist: MasterPlaylist? = null
+    val roomName: String,
+    val quality: String,
+    val state: SessionState,
+    val startTime: Instant
 )
+
+enum class RecordingEvent {
+    StartRecording, StopRecording,
+    FetchPlaylist, PlaylistFetched, PlaylistFetchFailed, PlaylistFetchTimeout,
+    PlaylistRetryExhausted,
+    SegmentDownloaded, CutPointDone, LimitReached, InitChanged,
+}
+
+data class RecordingDriveData(
+    val playlist: ParsedPlaylist? = null,
+    val failReason: String? = null,
+    val segBytes: Long? = null,
+    val segGeneration: Long? = null,
+    val stopReason: EndReason? = null,
+)
+
+// ============================================================
+// Messages
+// ============================================================
+
+sealed interface SessionMsg
+
+data class StartRecording(
+    val roomId: Long,
+    val roomName: String,
+    val playlistUrl: String,
+    val pkey: String,
+    val quality: String,
+    val startIndex: Long?,
+    val timeLimit: Duration,
+    val sizeLimitBytes: Long,
+) : SessionMsg
+
+data class StopRecording(val roomId: Long, val reason: EndReason) : SessionMsg
+
+/** Timer async-result envelope fed back into the mailbox */
+data class SessionSignal(val roomId: Long, val event: RecordingEvent, val data: RecordingDriveData?) : SessionMsg
+
+/** Wrapper for bus events */
+data class SessionBus(val event: Any) : SessionMsg
+
+data class SessionHandleCommand(val env: CommandEnvelope) : SessionMsg
+
+// ============================================================
+// Entry
+// ============================================================
+
+private val sessionLogger = LoggerFactory.getLogger("v3.SessionEntry")
 
 class CircleCache(private val capacity: Int) {
     private val set = LinkedHashSet<String>()
     @Synchronized fun add(url: String): Boolean {
         if (set.size >= capacity) {
-            set.clear(); return true
+            set.clear()
+            return true
         }
         return set.add(url)
     }
-
     @Synchronized fun remove(url: String) = set.remove(url)
     @Synchronized fun clear() = set.clear()
 }
 
-class SessionComponent(
-    private val dataChannel: DataChannel,
-    private val downloader: DownloaderComponent,
-    private val m3u8Parser: M3u8Parser,
-    private val requestBus: RequestBus,
-    private val apiClient: ApiClient,
-    private val streamAuthKey: String,
-    eventBus: EventBus,
-    parentScope: CoroutineScope
-) : Actor<SessionMsg>("SessionComponent", eventBus, parentScope) {
+class SessionEntry(
+    val roomId: Long,
+    var roomName: String,
+    internal val component: SessionComponent
+) {
+    // —— Preconfigured fields from StartRecording ——
+    var playlistUrl: String = ""
+    var pkey: String = ""
+    var quality: String = ""
+    var startIndex: Long? = null
+    var timeLimit: Duration = Duration.INFINITE
+    var sizeLimitBytes: Long = 0L
+    var generation: Long = SecureRandom().nextLong()
 
-    private val sessions = ConcurrentHashMap<Long, RoomSession>()
-    private val lastBlockReason = ConcurrentHashMap<Long, String>()
-    private val decryptKeyCache = ConcurrentHashMap<String, String>()
-    // per-room throttle for WS-triggered quality re-checks (ms)
-    private val lastQualityCheck = ConcurrentHashMap<Long, Long>()
-    private val qualityHintMinIntervalMs = 30_000L
+    // —— Runtime state ——
+    var lastSegmentId: Long? = null
+    var lastInitUrl: String? = null
+    var segmentIndex: Int = 0
+    var totalBytes: Long = 0L
+    var startTime: Instant = Instant.now()
+    var retryCount: Int = 0
+    val circleCache = CircleCache(100)
 
-    override suspend fun onStart(scope: CoroutineScope) {
-        subscribe<RoomStatusChanged>(RoomStatusChanged::class)
-        subscribe<LiveMessage>(LiveMessage::class)
-        subscribe<QualitiesAvailable>(QualitiesAvailable::class)
-        subscribe<SegmentDownloaded>(SegmentDownloaded::class)
-        subscribe<CommandEnvelope>(CommandEnvelope::class)
-        subscribe<QualityChangeRequested>(QualityChangeRequested::class)
-        subscribe<RoomTimeLimitChanged>(RoomTimeLimitChanged::class)
-        subscribe<RoomSizeLimitChanged>(RoomSizeLimitChanged::class)
-        subscribe<QualityChangeHint>(QualityChangeHint::class)
+    // —— scope / timer ——
+    val scope = CoroutineScope(
+        component.ioScope.coroutineContext + SupervisorJob(component.ioScope.coroutineContext[Job])
+    )
+    val playlistTicker = Timer<Unit>(scope)
+    val playlistFetcher = Timer<Unit>(scope)
+    val playlistWatchdog = Timer<Unit>(scope)
 
-        eventBus.subscribe(scope, PersistConfig::class) {
-            decryptKeyCache.clear()
-        }
+    // —— fsm ——
+    val fsm: StateMachine<RecordingState, RecordingEvent, RecordingDriveData, SessionEntry> =
+        buildSessionFsm(this)
 
+    fun launch(block: suspend () -> Unit) {
         scope.launch {
-            // quality rarely changes — poll infrequently to save network
-            while (isActive) {
-                delay(5.minutes)
-                pollQualities()
-            }
-        }
-        scope.launch {
-            while (isActive) {
-                delay(30.seconds)
-                cleanStaleSessions()
+            try {
+                block()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                sessionLogger.error("Session entry effect failed roomId={}", roomId, e)
             }
         }
     }
 
+    internal fun cutFile(reason: EndReason) {
+        playlistTicker.cancel()
+        playlistFetcher.cancel()
+        playlistWatchdog.cancel()
+        launch {
+            component.downloader.tell(
+                DoCutPoint(CutPoint(roomId, segmentIndex - 1, roomName, Instant.now(), reason, quality, generation))
+            )
+        }
+    }
+
+    internal fun onSegment(d: RecordingDriveData?) {
+        val gen = d?.segGeneration ?: return
+        if (gen != generation) return
+        totalBytes += d.segBytes ?: 0L
+        if (sizeLimitBytes > 0 && totalBytes >= sizeLimitBytes) {
+            launch {
+                component.tell(
+                    SessionSignal(roomId, RecordingEvent.LimitReached, RecordingDriveData(stopReason = EndReason.SizeLimit))
+                )
+            }
+        }
+    }
+
+    internal fun computeUnseen(parsed: ParsedPlaylist): List<Segment> {
+        val unseen = mutableListOf<Segment>()
+        parsed.initUrl?.let { init ->
+            if (circleCache.add(init)) {
+                unseen.add(Segment(init, -1))
+            }
+        }
+        for (seg in parsed.segments) {
+            val segId = component.m3u8Parser.segmentIDFromUrl(seg.url)?.toLong()
+            if (segId != null) {
+                val threshold = lastSegmentId
+                if (threshold != null && segId <= threshold) continue
+            }
+            if (circleCache.add(seg.url)) {
+                unseen.add(seg)
+                if (segId != null) lastSegmentId = segId
+            }
+        }
+        return unseen
+    }
+
+    internal suspend fun fetchPlaylistSignal(): SessionMsg {
+        return try {
+            val client = ClientManager.getProxiedClient("m3u8_$roomId")
+            val response = withRetry(3) { client.get(playlistUrl) }
+            val text = response.bodyAsText()
+            val key = (component.requestBus.request<ConfigResponse>(GetDecryptKey(pkey)).value as? String)
+                ?: return SessionSignal(roomId, RecordingEvent.PlaylistFetchFailed, RecordingDriveData(failReason = "no decrypt key"))
+            val parsed = component.m3u8Parser.parse(text, key)
+            SessionSignal(roomId, RecordingEvent.PlaylistFetched, RecordingDriveData(playlist = parsed))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            SessionSignal(roomId, RecordingEvent.PlaylistFetchFailed, RecordingDriveData(failReason = e.message))
+        }
+    }
+}
+
+// ============================================================
+// Session FSM matrix
+// ============================================================
+
+private fun buildSessionFsm(ctx: SessionEntry) =
+    buildFsm<RecordingState, RecordingEvent, RecordingDriveData, SessionEntry>(ctx) {
+
+        initial(RecordingState.Idle)
+
+        state(RecordingState.Idle) {
+            on(RecordingEvent.StartRecording) to RecordingState.Recording action {
+                startTime = Instant.now()
+                segmentIndex = 0
+                totalBytes = 0L
+                retryCount = 0
+                circleCache.clear()   // a new file must re-download the init; media segments are skipped via the lastSegmentId threshold
+                launch { component.dataChannel.send(StreamStart(roomId, roomName, startTime, quality)) }
+                playlistTicker.start(Duration.ZERO) { component.tell(SessionSignal(roomId, RecordingEvent.FetchPlaylist, null)) }
+            }
+            on(RecordingEvent.StopRecording) to KEEP
+            on(RecordingEvent.SegmentDownloaded) to KEEP
+            on(RecordingEvent.CutPointDone) to KEEP
+        }
+
+        state(RecordingState.Recording) {
+            on(RecordingEvent.FetchPlaylist) to KEEP action {
+                playlistTicker.start(3.seconds) { component.tell(SessionSignal(roomId, RecordingEvent.FetchPlaylist, null)) }
+                if (playlistFetcher.isRunning) return@action
+                playlistWatchdog.start(10.seconds) { component.tell(SessionSignal(roomId, RecordingEvent.PlaylistFetchTimeout, null)) }
+                playlistFetcher.start(Duration.ZERO) { component.tell(fetchPlaylistSignal()) }
+            }
+            on(RecordingEvent.PlaylistFetched) to KEEP action { d ->
+                retryCount = 0
+                playlistWatchdog.cancel()
+                val parsed = d?.playlist ?: return@action
+                val initUrl = parsed.initUrl
+                if (lastInitUrl != null && initUrl != null && lastInitUrl != initUrl) {
+                    launch { component.tell(SessionSignal(roomId, RecordingEvent.InitChanged, null)) }
+                    return@action
+                }
+                if (initUrl != null) lastInitUrl = initUrl
+                val unseen = computeUnseen(parsed)
+                segmentIndex += unseen.size
+                if (unseen.isNotEmpty()) {
+                    launch { component.downloader.tell(DoDownload(Download(roomId, unseen, segmentIndex, generation))) }
+                }
+                val elapsedMs = JavaDuration.between(startTime, Instant.now()).toMillis()
+                if (timeLimit != Duration.INFINITE && elapsedMs >= timeLimit.inWholeMilliseconds) {
+                    launch {
+                        component.tell(
+                            SessionSignal(roomId, RecordingEvent.LimitReached, RecordingDriveData(stopReason = EndReason.TimeLimit))
+                        )
+                    }
+                }
+            }
+            on(RecordingEvent.PlaylistFetchFailed) to KEEP action { d ->
+                playlistWatchdog.cancel()
+                if (++retryCount >= MAX_PLAYLIST_RETRY) {
+                    launch {
+                        component.tell(
+                            SessionSignal(roomId, RecordingEvent.PlaylistRetryExhausted, RecordingDriveData(failReason = d?.failReason))
+                        )
+                    }
+                }
+            }
+            on(RecordingEvent.PlaylistFetchTimeout) to KEEP action {
+                playlistFetcher.cancel()
+                if (++retryCount >= MAX_PLAYLIST_RETRY) {
+                    launch { component.tell(SessionSignal(roomId, RecordingEvent.PlaylistRetryExhausted, null)) }
+                }
+            }
+            on(RecordingEvent.SegmentDownloaded) to KEEP action { d -> onSegment(d) }
+            on(RecordingEvent.StopRecording) to RecordingState.Closing action { d ->
+                cutFile(d?.stopReason ?: EndReason.UserStop)
+            }
+            on(RecordingEvent.LimitReached) to RecordingState.Closing action { d ->
+                cutFile(d?.stopReason ?: EndReason.SizeLimit)
+            }
+            on(RecordingEvent.InitChanged) to RecordingState.Closing action {
+                cutFile(EndReason.NewInit)
+            }
+            on(RecordingEvent.PlaylistRetryExhausted) to RecordingState.Closing action {
+                cutFile(EndReason.StreamEnd)
+            }
+        }
+
+        state(RecordingState.Closing) {
+            on(RecordingEvent.CutPointDone) to RecordingState.Idle action { d ->
+                launch {
+                    component.publish(SessionExit(roomId, lastSegmentId, d?.stopReason ?: EndReason.UserStop))
+                }
+            }
+            on(RecordingEvent.StartRecording) to KEEP
+            on(RecordingEvent.StopRecording) to KEEP
+            on(RecordingEvent.SegmentDownloaded) to KEEP
+            on(RecordingEvent.LimitReached) to KEEP
+            on(RecordingEvent.PlaylistRetryExhausted) to KEEP
+        }
+    }
+
+private const val MAX_PLAYLIST_RETRY = 5
+
+// ============================================================
+// Actor
+// ============================================================
+
+class SessionComponent(
+    internal val dataChannel: DataChannel,
+    internal val downloader: DownloaderComponent,
+    internal val m3u8Parser: M3u8Parser,
+    internal val requestBus: RequestBus,
+    eventBus: EventBus,
+    parentScope: CoroutineScope
+) : Actor<SessionMsg>("SessionComponent", eventBus, parentScope) {
+
+    private val entries = ConcurrentHashMap<Long, SessionEntry>()
+
+    internal suspend fun publish(event: Any) = eventBus.publish(event)
+
+    override suspend fun onStart(scope: CoroutineScope) {
+        subscribe(SegmentDownloaded::class)
+        subscribe(CutPointDone::class)
+        subscribe(CommandEnvelope::class)
+    }
+
     override suspend fun wrapEvent(event: Any): SessionMsg? = when (event) {
-        is RoomStatusChanged -> OnSessionEvent(event)
-        is LiveMessage -> OnSessionEvent(event)
-        is QualitiesAvailable -> OnSessionEvent(event)
-        is SegmentDownloaded -> OnSessionEvent(event)
-        is QualityChangeRequested -> OnSessionEvent(event)
-        is RoomTimeLimitChanged -> OnSessionEvent(event)
-        is RoomSizeLimitChanged -> OnSessionEvent(event)
-        is QualityChangeHint -> OnSessionEvent(event)
-        is CommandEnvelope -> HandleSessionCommand(event)
+        is SegmentDownloaded -> SessionBus(event)
+        is CutPointDone -> SessionBus(event)
+        is CommandEnvelope -> SessionHandleCommand(event)
         else -> null
     }
 
     override suspend fun handle(msg: SessionMsg) {
         when (msg) {
-            is DoStart -> startSession(msg.roomId, msg.roomName, msg.quality, msg.pkey)
-            is DoStop -> stopSession(msg.roomId)
-            is DoBreak -> {
-                val rs = sessions[msg.roomId] ?: return
-                when (rs.state) {
-                    SessionState.Recording -> {
-                        if (msg.reason == EndReason.UserStop) {
-                            stopSession(msg.roomId)
-                        } else {
-                            downloader.tell(
-                                DoCutPoint(
-                                    CutPoint(
-                                        msg.roomId,
-                                        rs.segmentIndex - 1,
-                                        rs.roomName,
-                                        Instant.now(),
-                                        msg.reason,
-                                        rs.quality
-                                    )
-                                )
-                            )
-                            rs.startTime = Instant.now()
-                            rs.generation += 1
-                            rs.totalBytes = 0
-                            rs.segmentIndex = 0
-                            rs.initUrl?.let { rs.circleCache.remove(it) }
-                        }
-                    }
-
-                    SessionState.Fetching -> {
-                        stopSession(msg.roomId)
-                    }
-
-                    else -> {} // Armed, Closing, Idle — nothing to do
-                }
-            }
-
-            is OnSessionEvent -> handleEvent(msg.event)
-            is DoCutPointDone -> onCutPointDone(msg.roomId)
-            is HandleSessionCommand -> {
-                handleCommand(msg.env)
-            }
+            is StartRecording -> onStartRecording(msg)
+            is StopRecording -> onStopRecording(msg)
+            is SessionSignal -> driveFsm(msg)
+            is SessionBus -> onBus(msg.event)
+            is SessionHandleCommand -> handleCommand(msg.env)
         }
     }
 
     private suspend fun handleCommand(env: CommandEnvelope) {
         val ack = when (env.command) {
-            is GetSessions -> sessions.values.map { it.copy() }
+            is GetSessions -> entries.values.map { e ->
+                RoomSession(
+                    roomId = e.roomId,
+                    roomName = e.roomName,
+                    quality = e.quality,
+                    state = when (e.fsm.currentState) {
+                        RecordingState.Recording -> SessionState.Recording
+                        RecordingState.Closing -> SessionState.Closing
+                        else -> SessionState.Idle
+                    },
+                    startTime = e.startTime
+                )
+            }
             else -> return
         }
         eventBus.publish(CommandAck(env.id, ack))
     }
 
-    private suspend fun startSession(
-        roomId: Long, name: String, quality: String, pkey: String = "", reconfigure: Boolean = true
-    ) {
-        SensitiveStringRegistry.mask(name)
-        val existing = sessions[roomId]
-        if (existing != null) {
-            val blocked = when (existing.state) {
-                SessionState.Fetching, SessionState.Recording -> true
-                SessionState.Closing -> existing.pollingJob?.isCompleted != true
-                else -> false
-            }
-            if (blocked) return
+    private fun onStartRecording(msg: StartRecording) {
+        val e = entries.getOrPut(msg.roomId) { SessionEntry(msg.roomId, msg.roomName, this) }
+        if (e.fsm.currentState != RecordingState.Idle) {
+            logger.warn("StartRecording ignored: room {} in state {}", msg.roomId, e.fsm.currentState)
+            return
         }
-        // Register session synchronously so DoStop/DoBreak can find it
-        val rs = RoomSession(roomId, name, quality, quality, pkey = pkey.ifBlank { streamAuthKey })
-        sessions[roomId] = rs
-        rs.state = SessionState.Fetching
-        rs.startTime = Instant.now()
-
-        scope.launch {
-            if (reconfigure) {
-                val token = configureSession(roomId, name) ?: run {
-                    logger.info("[{}] Session not started: configure returned false", name)
-                    sessions.remove(roomId)
-                    delay(5.seconds)
-                    requestBus.request<OkResponse>(RefreshRoomCmd(roomId))
-                    return@launch
-                }
-                rs.token = token.takeIf { it.isNotEmpty() }
-                lastBlockReason.remove(roomId)
-            }
-
-            if (sessions[roomId] !== rs || rs.state == SessionState.Closing) return@launch
-
-            val config = requestBus.request<RoomConfigResponse>(GetRoomConfig(roomId))
-            if (sessions[roomId] !== rs || rs.state == SessionState.Closing) return@launch
-            rs.timeLimit = config.timeLimit
-            rs.sizeLimitBytes = config.sizeLimitBytes
-            try {
-                rs.masterPlaylist = fetchAndCacheMasterPlaylist(rs)
-                val availableNames = rs.masterPlaylist!!.variants.map { it.name }
-                rs.quality = selectQuality(availableNames, rs.targetquality)
-                rs.playlistUrl = resolveVariantUrl(rs)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                if (e is ResponseException) {
-                    logger.warn("[{}] Master playlist failed: status={}", rs.roomName, e.response.status)
-                } else {
-                    logger.error("[{}] Master playlist failed: {}", rs.roomName, e.message, e)
-                }
-                sessions.remove(roomId)
-                delay(5.seconds)
-                requestBus.request<OkResponse>(RefreshRoomCmd(roomId))
-                return@launch
-            }
-
-            if (sessions[roomId] !== rs || rs.state == SessionState.Closing) return@launch
-
-            // Commit atomically with stopSession so a stop cannot be interleaved
-            // between StreamStart and polling-loop registration.
-            rs.mutex.withLock {
-                if (sessions[roomId] !== rs || rs.state == SessionState.Closing) return@launch
-                logger.info("Session starting: roomId={}, name={}, quality={}", roomId, name, rs.quality)
-                dataChannel.send(StreamStart(roomId, name, rs.startTime, rs.quality))
-                rs.pollingJob = launch { pollingLoop(rs) }
-                eventBus.publish(RecordingStarted(roomId, rs.quality))
-            }
-        }
+        e.roomName = msg.roomName
+        e.playlistUrl = msg.playlistUrl
+        e.pkey = msg.pkey
+        e.quality = msg.quality
+        e.startIndex = msg.startIndex
+        e.timeLimit = msg.timeLimit
+        e.sizeLimitBytes = msg.sizeLimitBytes
+        e.generation = SecureRandom().nextLong()
+        e.lastSegmentId = msg.startIndex?.minus(1)
+        e.lastInitUrl = null
+        e.fsm.driveCatch(RecordingEvent.StartRecording)?.let { logger.error("Session FSM drive failed", it) }
     }
 
-    private suspend fun stopSession(roomId: Long) {
-        val rs = sessions[roomId] ?: return
-        rs.mutex.withLock {
-            logger.info("Session stopping: roomId={}, name={}, state={}", roomId, rs.roomName, rs.state)
-            rs.state = SessionState.Closing
-            rs.pollingJob?.cancel()
-            downloader.tell(
-                DoCutPoint(
-                    CutPoint(
-                        roomId,
-                        rs.segmentIndex,
-                        rs.roomName,
-                        Instant.now(),
-                        EndReason.UserStop,
-                        rs.quality
-                    )
-                )
-            )
-        }
+    private fun onStopRecording(msg: StopRecording) {
+        val e = entries[msg.roomId] ?: return
+        e.fsm.driveCatch(RecordingEvent.StopRecording, RecordingDriveData(stopReason = msg.reason))
+            ?.let { logger.error("Session FSM drive failed", it) }
     }
 
-    private suspend fun handleEvent(event: Any) {
+    private fun driveFsm(sig: SessionSignal) {
+        val e = entries[sig.roomId] ?: return
+        e.fsm.driveCatch(sig.event, sig.data)?.let { logger.error("Session FSM drive failed", it) }
+    }
+
+    private fun onBus(event: Any) {
         when (event) {
-            is RoomStatusChanged -> {
-                val rs = sessions[event.roomId] ?: return
-                if (RoomStatus.isPublic(event.newStatus) || RoomStatus.isGroupShow(event.newStatus) ||
-                    RoomStatus.isPrivate(event.newStatus)
-                ) {
-                    if (rs.state == SessionState.Armed) {
-                        if (RoomStatus.isGroupShow(event.newStatus) || RoomStatus.isPrivate(event.newStatus)) {
-                            // SchedulerComponent handles paid/private shows via DoStart→startSession→configureSession
-                            return
-                        }
-                        startSession(event.roomId, rs.roomName, rs.quality, rs.pkey)
-                    }
-
-                } else if (RoomStatus.isOffline(event.newStatus)) {
-                    if (rs.state == SessionState.Recording) {
-                        rs.state = SessionState.Closing
-                        rs.pollingJob?.cancel()
-                        rs.generation += 1
-                        downloader.tell(
-                            DoCutPoint(
-                                CutPoint(
-                                    event.roomId,
-                                    rs.segmentIndex,
-                                    rs.roomName,
-                                    Instant.now(),
-                                    EndReason.StreamEnd,
-                                    rs.quality
-                                )
-                            )
-                        )
-                    }
-                }
-            }
-
-            is LiveMessage -> {
-                // record the event type alongside its payload in the .event file
-                val json = buildJsonObject {
-                    put("type", event.type)
-                    put("data", event.body)
-                }.toString()
-                dataChannel.send(StreamEvent(event.roomId, Instant.now(), json))
-            }
-
-            is QualitiesAvailable -> {
-                val rs = sessions[event.roomId] ?: return
-                if (rs.state != SessionState.Recording) return
-                val newQuality = selectQuality(event.qualities, rs.targetquality)
-                if (newQuality != rs.quality) {
-                    logger.info(
-                        "Quality switched for {}: {} -> {} (available: {})",
-                        rs.roomName,
-                        rs.quality,
-                        newQuality,
-                        event.qualities
-                    )
-                    rs.quality = newQuality
-                    val resolved = resolveVariantUrl(rs)
-                    if (rs.playlistUrl != resolved)
-                        logger.debug("[{}] playlist url changed {} -> {}", rs.roomName, rs.playlistUrl, resolved)
-                    rs.playlistUrl = resolved
-                } else {
-//                    logger.debug(
-//                        "Quality unchanged for {}: {} (available: {})", rs.roomName, rs.quality, event.qualities
-//                    )
-                }
-            }
-
-            is QualityChangeRequested -> {
-                val rs = sessions[event.roomId] ?: return
-                logger.info("Quality change requested for {}: {} -> {}", rs.roomName, rs.quality, event.newQuality)
-                rs.targetquality = event.newQuality
-                if (rs.state == SessionState.Recording || rs.state == SessionState.Fetching) {
-                    pollQualityForRoom(rs)
-                }
-            }
-
-            is QualityChangeHint -> {
-                // WS reported a settings/stream change — re-check quality (throttled)
-                val rs = sessions[event.roomId] ?: return
-                if (rs.state != SessionState.Recording) return
-                val now = System.currentTimeMillis()
-                val last = lastQualityCheck[event.roomId] ?: 0L
-                if (now - last < qualityHintMinIntervalMs) return
-                lastQualityCheck[event.roomId] = now
-                pollQualityForRoom(rs, force = true)
-            }
-
-            is RoomTimeLimitChanged -> {
-                val rs = sessions[event.roomId] ?: return
-                logger.info("Time limit changed for {}: {} -> {}", rs.roomName, rs.timeLimit, event.limit)
-                rs.timeLimit = event.limit
-            }
-
-            is RoomSizeLimitChanged -> {
-                val rs = sessions[event.roomId] ?: return
-                logger.info("Size limit changed for {}: {} -> {}", rs.roomName, rs.sizeLimitBytes, event.limitBytes)
-                rs.sizeLimitBytes = event.limitBytes
-            }
-
             is SegmentDownloaded -> {
-                val rs = sessions[event.roomId] ?: return
-                if (event.generation != rs.generation) return
-                rs.totalBytes += event.bytes
+                val e = entries[event.roomId] ?: return
+                e.fsm.driveCatch(
+                    RecordingEvent.SegmentDownloaded,
+                    RecordingDriveData(segBytes = event.bytes.toLong(), segGeneration = event.generation)
+                )?.let { logger.error("Session FSM drive failed", it) }
             }
-
-            else -> {}
-        }
-    }
-
-    private fun selectQuality(available: List<String>, requested: String): String {
-        if (requested == "highest") return "highest"
-        val clean = available.filterNot { it.contains("blurred") }
-        if (clean.isEmpty()) return requested
-        if (requested in available) return requested
-        val reqParts = requested.split("p").filterNot(String::isEmpty)
-        val final = clean.minByOrNull { q ->
-            val qParts = q.split("p").filterNot(String::isEmpty)
-            if (reqParts.size == 2) {
-                abs((qParts[0].toIntOrNull() ?: 0) - (reqParts[0].toIntOrNull() ?: 0)) + abs(
-                    (reqParts[1].toIntOrNull() ?: 30) - (qParts.getOrElse(1) { "30" }.toIntOrNull() ?: 30)
-                )
-            } else {
-                abs((qParts[0].toIntOrNull() ?: 0) - (reqParts[0].toIntOrNull() ?: 0))
-            }
-        } ?: requested
-        return final
-    }
-
-    private suspend fun pollQualities() {
-        for (rs in sessions.values) {
-            if (rs.state != SessionState.Recording) continue
-            // already recording at the requested quality — nothing to chase; settings
-            // changes are caught by the WS QualityChangeHint instead
-            if (rs.quality == rs.targetquality) continue
-            pollQualityForRoom(rs)
-        }
-    }
-
-    private suspend fun pollQualityForRoom(rs: RoomSession, force: Boolean = false) {
-        // Already on the user-requested quality: keep the periodic loop alive but
-        // do nothing to avoid unnecessary master playlist requests. A forced check
-        // (WS settings-change hint) still re-fetches.
-        if (!force && rs.quality == rs.targetquality) return
-
-        try {
-            val master = fetchAndCacheMasterPlaylist(rs)
-            val availableNames = master.variants.map { it.name }
-            if (availableNames.isNotEmpty()) {
-                eventBus.publish(QualitiesAvailable(rs.roomId, availableNames))
-            }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: ResponseException) {
-            logger.warn("[{}] Master playlist quality poll failed: status={}", rs.roomName, e.response.status)
-        } catch (e: Exception) {
-            logger.error("[{}] Master playlist quality poll failed: {}", rs.roomName, e.message, e)
-        }
-    }
-
-    private fun cleanStaleSessions() {
-        val toRemove = sessions.filter { (_, rs) ->
-            rs.state == SessionState.Idle || (rs.state == SessionState.Closing && rs.pollingJob?.isCompleted == true)
-        }
-        for (roomId in toRemove.keys) {
-            sessions.remove(roomId)
-            logger.debug("Cleaned up stale session for room {}", roomId)
-        }
-    }
-
-    /** Returns model token for groupShow, empty string for public, null if can't record */
-    private suspend fun configureSession(roomId: Long, roomName: String): String? {
-        try {
-            val info = apiClient.roomFetchBroadcastInfo(roomName)
-            val status = info.PathSingle("item.status").asString()
-            when {
-                RoomStatus.isPublic(status) -> return ""
-                RoomStatus.isGroupShow(status) -> {
-                    val config = requestBus.request<RoomConfigResponse>(GetRoomConfig(roomId))
-                    sessions[roomId]?.let { rs ->
-                        rs.timeLimit = config.timeLimit
-                        rs.sizeLimitBytes = config.sizeLimitBytes
-                    }
-                    if (!config.autoPayTicket) {
-                        val reason = "autopay disabled"
-                        if (lastBlockReason.put(roomId, reason) != reason)
-                            logger.warn("[{}] Room not enable autopay", roomName)
-                        return null
-                    }
-                    val camInfo = apiClient.roomFetchCamInfo(roomId, "")
-                    val price = camInfo.PathSingle("user.user.ticketRate").asInt()
-                    val users = requestBus.request<List<User>>(GetValidPaymentAccount(price.toLong()))
-                    val u = users.firstOrNull()
-                    if (u == null) {
-                        val reason = "insufficient balance"
-                        if (lastBlockReason.put(roomId, reason) != reason)
-                            logger.warn("[{}] No account to pay. price={}", roomName, price)
-                        return null
-                    }
-                    var token = apiClient.roomFetchModelToken(roomId, u)
-                    if (token == null) {
-                        apiClient.roomRequestGroupShow(roomId, u)
-                        requestBus.request<OkResponse>(DeductCoins(u.userId, price.toLong()))
-                        delay(1.seconds)
-                        token = apiClient.roomFetchModelToken(roomId, u)
-                    }
-                    if (token == null) {
-                        logger.warn("[{}] Failed to get model token", roomName)
-                        return null
-                    }
-                    return token
-                }
-
-                // paid/private shows (private/p2p/virtualPrivate/...): price and token are only
-                // visible on AUTHENTICATED camInfo (anonymous user == null for these rooms)
-                RoomStatus.isPrivate(status) -> {
-                    val config = requestBus.request<RoomConfigResponse>(GetRoomConfig(roomId))
-                    sessions[roomId]?.let { rs ->
-                        rs.timeLimit = config.timeLimit
-                        rs.sizeLimitBytes = config.sizeLimitBytes
-                    }
-
-                    val (user, camInfo) = run {
-                        val users = requestBus.request<List<User>>(GetValidPaymentAccount(0))
-                        val freeUser = users.firstOrNull { apiClient.hasFreeSpyAccess(roomId, it) }
-
-                        if (freeUser != null) {
-                            val info = apiClient.roomFetchCamInfo(roomId, freeUser.cookie)
-                            return@run Pair(freeUser, info)
-                        }
-
-                        // --- No free user, evaluate payment fallback ---
-                        val freeReason = "no free spy access"
-                        if (lastBlockReason.put(roomId, freeReason) != freeReason) {
-                            logger.warn("[{}] No account has free spy access for this room", roomName)
-                        }
-
-                        if (!config.autoPaySpy) {
-                            val reason = "autopay disabled"
-                            if (lastBlockReason.put(roomId, reason) != reason) {
-                                logger.warn("[{}] Room not enable autopay (private)", roomName)
-                            }
-                            return null // Exits the parent function early
-                        }
-
-                        val paidUser = users.firstOrNull()
-                        if (paidUser == null) {
-                            val reason = "no account"
-                            if (lastBlockReason.put(roomId, reason) != reason) {
-                                logger.warn("[{}] No user account to use for private show", roomName)
-                            }
-                            return null
-                        }
-
-                        val paidCamInfo = apiClient.roomFetchCamInfo(roomId, paidUser.cookie)
-                        val price = paidCamInfo.PathSingleOrNull("user.user.privateRate")?.asInt() ?: run {
-                            val reason = "price unavailable"
-                            if (lastBlockReason.put(roomId, reason) != reason) {
-                                logger.warn("[{}] privateRate not found in authenticated camInfo", roomName)
-                            }
-                            return null
-                        }
-
-                        if (paidUser.coins < price) {
-                            val reason = "insufficient balance"
-                            if (lastBlockReason.put(roomId, reason) != reason) {
-                                logger.warn("[{}] No account to pay. price={}", roomName, price)
-                            }
-                            return null
-                        }
-
-                        Pair(paidUser, paidCamInfo)
-                    }
-
-                    var token = camInfo.PathSingle("cam.modelToken").asString().ifBlank { null }
-                    if (token == null) {
-                        apiClient.roomRequestSpyShow(roomId, user)
-                        for (attempt in 1..4) {
-                            delay(if (attempt == 1) 500L else 1500L)
-                            val cam = apiClient.roomFetchCamInfo(roomId, user.cookie)
-                            token = cam.PathSingle("cam.modelToken").asString().ifBlank { null }
-                            if (token != null) break
-                        }
-                    }
-                    if (token == null) {
-                        val reason = "no token"
-                        if (lastBlockReason.put(roomId, reason) != reason)
-                            logger.warn("[{}] Failed to get private-show model token", roomName)
-                        return null
-                    }
-                    return token
-                }
-
-                else -> {
-                    logger.trace("[{}] -> false, status={}", roomName, status)
-                    return null
-                }
-            }
-        } catch (e: ClientRequestException) {
-            logger.error("Room configure failed for {}: client error {}", roomName, e.message, e)
-        } catch (e: Exception) {
-            logger.error("Room configure failed for {}: {}", roomName, e.message, e)
-        }
-
-        return null
-    }
-
-    private fun buildMasterUrl(rs: RoomSession, host: String = Hosts.current.hlsMasterHost): String =
-        buildUrl {
-            protocol = URLProtocol.HTTPS
-            this.host = host
-            encodedPath = "/hls/${rs.roomId}/master/${rs.roomId}_auto.m3u8"
-            parameters["psch"] = "v2"
-            parameters["pkey"] = rs.pkey
-            rs.token?.takeIf { it.isNotEmpty() }?.let { parameters["aclAuth"] = it }
-        }.toString()
-
-    private suspend fun fetchAndCacheMasterPlaylist(rs: RoomSession): MasterPlaylist {
-        val client = ClientManager.getProxiedClient("master_" + rs.roomId)
-        val hosts = (listOf(Hosts.current.hlsMasterHost) + Hosts.current.hlsHosts).distinct()
-        var lastErr: Throwable? = null
-        for (host in hosts) {
-            val url = buildMasterUrl(rs, host)
-            try {
-                val response = withRetry(3) { client.get(url) }
-                val text = response.bodyAsText()
-                val master = m3u8Parser.parseMaster(text)
-                rs.masterPlaylist = master
-                val keyIds = master.pschKeys.map { it.substringAfter(":") }
-                val match = requestBus.request<DecryptKeyMatch>(MatchDecryptKeys(keyIds))
-                require(match.decryptKey.isNotEmpty()) {
-                    "[" + rs.roomName + "] No PSCH key from master playlist matched in persistedDecryptKeys. keys=" + keyIds
-                }
-                rs.pkey = match.keyName
-                return master
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: ClientRequestException) {
-                if (e.response.status.value in 400..499) {
-                    logger.warn("[{}] master playlist business error on {}: {}", rs.roomName, host, e.response.status)
-                    throw e
-                }
-                lastErr = e
-                CdnSelector.recordFailure(host)
-                logger.warn("[{}] master playlist fetch failed on {}: {}", rs.roomName, host, e.message)
-            } catch (e: Exception) {
-                lastErr = e
-                CdnSelector.recordFailure(host)
-                logger.warn("[{}] master playlist fetch failed on {}: {}", rs.roomName, host, e.message)
+            is CutPointDone -> {
+                val e = entries[event.roomId] ?: return
+                e.fsm.driveCatch(
+                    RecordingEvent.CutPointDone,
+                    RecordingDriveData(segGeneration = event.generation, stopReason = event.reason)
+                )?.let { logger.error("Session FSM drive failed", it) }
             }
         }
-        throw lastErr ?: IllegalStateException("master playlist unavailable")
-    }
-
-    private fun resolveVariantUrl(rs: RoomSession): String {
-        val mp = rs.masterPlaylist!!
-        val variant = if (rs.quality == "highest") {
-            mp.variants.maxByOrNull { it.bandwidth }
-        } else {
-            val availableNames = mp.variants.map { it.name }
-            val matched = selectQuality(availableNames, rs.quality)
-            mp.variants.find { it.name == matched }
-        }
-        val baseUrl = variant?.url ?: mp.variants.maxByOrNull { it.bandwidth }!!.url
-        val url = buildUrl {
-            takeFrom(baseUrl)
-            parameters["psch"] = "v2"
-            parameters["pkey"] = rs.pkey
-            rs.token?.takeIf { it.isNotEmpty() }?.let { parameters["aclAuth"] = it }
-        }.toString()
-        // rewrite the playlist host to the currently selected (fastest) CDN host
-        return CdnSelector.resolve(url)
-    }
-
-    private fun createDiscontinuityCounter(): suspend (List<Int>) -> Int {
-        var lastMax: Int? = null
-        var totalGaps = 0
-        val lock = Mutex()
-        return counter@{ numbers: List<Int> ->
-            lock.withLock {
-                val filtered = numbers.filter { it != 0 }
-                if (filtered.isEmpty()) return@counter totalGaps
-
-                val currentMin = filtered.first()
-                val currentMax = filtered.last()
-
-                if (lastMax != null) {
-                    val gap = currentMin - lastMax!! - 1
-                    if (gap > 0) {
-                        totalGaps += gap
-                    }
-                }
-
-                lastMax = currentMax
-                totalGaps
-            }
-        }
-    }
-
-    private suspend fun CoroutineScope.pollingLoop(rs: RoomSession) {
-        try {
-            val counter = createDiscontinuityCounter()
-            var firstPoll = true
-            while (isActive && (rs.state == SessionState.Fetching || rs.state == SessionState.Recording)) {
-                logger.trace("[{}] poll", rs.roomName)
-                val pollDelay = if (firstPoll) {
-                    3.seconds + Random.nextLong(-500, 500).milliseconds
-                } else {
-                    3.seconds
-                }
-                firstPoll = false
-                delay(pollDelay)
-                try {
-                    val client = ClientManager.getProxiedClient("m3u8_${rs.roomId}")
-                    val fetchStart = System.currentTimeMillis()
-                    val response = withRetry(3) {
-                        client.get(rs.playlistUrl)
-                    }
-                    val fetchLatency = System.currentTimeMillis() - fetchStart
-                    val text = response.bodyAsText()
-
-                    val key = decryptKeyCache[rs.pkey] ?: run {
-                        val result = (requestBus.request<ConfigResponse>(GetDecryptKey(rs.pkey)).value as? String)
-                        if (result != null) decryptKeyCache[rs.pkey] = result
-                        result
-                    } ?: run {
-                        logger.error("No decrypt key for room ${rs.roomId}")
-                        delay(5.seconds)
-                        continue
-                    }
-                    val parsed = m3u8Parser.parse(text, key)
-                    val maxSegId = parsed.segments.maxOfOrNull { m3u8Parser.segmentIDFromUrl(it.url) ?: 0 } ?: 0
-                    eventBus.publish(PlaylistRefreshed(rs.roomId, fetchLatency, maxSegId))
-                    requireNotNull(parsed.initUrl)
-
-                    if (parsed.initUrl != rs.initUrl) {
-                        downloader.tell(
-                            DoCutPoint(
-                                CutPoint(
-                                    rs.roomId,
-                                    rs.segmentIndex - 1,
-                                    rs.roomName,
-                                    Instant.now(),
-                                    EndReason.NewInit,
-                                    rs.quality
-                                )
-                            )
-                        )
-                        rs.generation += 1
-                        rs.segmentIndex = 0
-                        rs.circleCache.clear()
-                        rs.initUrl = parsed.initUrl
-                    }
-                    if (rs.circleCache.add(parsed.initUrl)) {
-                        downloader.tell(
-                            DoDownload(
-                                Download(
-                                    rs.roomId, listOf(Segment(parsed.initUrl, -1)), rs.segmentIndex, rs.generation
-                                )
-                            )
-                        )
-                        rs.segmentIndex += 1
-                    }
-                    val unseen = parsed.segments.filter { rs.circleCache.add(it.url) }
-                    if (unseen.isNotEmpty()) {
-                        val gap = counter(unseen.map {
-                            m3u8Parser.segmentIDFromUrl(it.url)
-                        }.filterNotNull())
-                        if (gap > 0) {
-                            eventBus.publish(SegmentGapDetected(rs.roomId, gap))
-                        }
-                        logger.debug("[{}] fetched {} segments", rs.roomName, unseen.size)
-                        eventBus.publish(NewSegments(rs.roomId, unseen))
-                        downloader.tell(DoDownload(Download(rs.roomId, unseen, rs.segmentIndex, rs.generation)))
-                        rs.segmentIndex += unseen.size
-                    }
-
-                    val limitMs =
-                        if (rs.timeLimit != Duration.INFINITE) rs.timeLimit.inWholeMilliseconds else Long.MAX_VALUE
-                    val elapsed = java.time.Duration.between(rs.startTime, Instant.now()).toMillis()
-                    if (elapsed >= limitMs || (rs.sizeLimitBytes > 0 && rs.totalBytes >= rs.sizeLimitBytes)) {
-                        val reason = if (elapsed >= limitMs) EndReason.TimeLimit else EndReason.SizeLimit
-                        downloader.tell(
-                            DoCutPoint(
-                                CutPoint(
-                                    rs.roomId, rs.segmentIndex - 1, rs.roomName, Instant.now(), reason, rs.quality
-                                )
-                            )
-                        )
-                        rs.startTime = Instant.now()
-                        rs.generation += 1
-                        rs.totalBytes = 0
-                        rs.segmentIndex = 0
-                        rs.circleCache.remove(parsed.initUrl)
-                    }
-
-                    if (rs.state == SessionState.Fetching) {
-                        synchronized(rs) {
-                            if (rs.state == SessionState.Fetching) rs.state = SessionState.Recording
-                        }
-                    }
-
-                } catch (e: CancellationException) {
-                    if (e is TimeoutCancellationException) {
-                        logger.error("[{}] Refresh list timeout", rs.roomName, e)
-                        if (configureSession(rs.roomId, rs.roomName) == null) {
-                            logger.info("[STOP] [{}] Room off or non-public after timeout", rs.roomName)
-                            rs.state = SessionState.Closing
-                            downloader.tell(
-                                DoCutPoint(
-                                    CutPoint(
-                                        rs.roomId,
-                                        rs.segmentIndex - 1,
-                                        rs.roomName,
-                                        Instant.now(),
-                                        EndReason.UserStop, rs.quality
-                                    )
-                                )
-                            )
-                            break
-                        }
-                        rs.playlistUrl = resolveVariantUrl(rs)
-                        continue
-                    }
-                    throw e
-                } catch (e: ClientRequestException) {
-                    logger.error("[${rs.roomName}] Client request error in polling: status=${e.response.status}")
-                    if (e.response.status == HttpStatusCode.Forbidden) {
-                        val token = configureSession(rs.roomId, rs.roomName)
-                        if (token != null) {
-                            rs.token = token.takeIf { it.isNotEmpty() }
-                            rs.playlistUrl = resolveVariantUrl(rs)
-                            continue
-                        }
-                        logger.info("[STOP] [{}] Room off or non-public (403)", rs.roomName)
-                        rs.state = SessionState.Closing
-                        downloader.tell(
-                            DoCutPoint(
-                                CutPoint(
-                                    rs.roomId,
-                                    rs.segmentIndex - 1,
-                                    rs.roomName,
-                                    Instant.now(),
-                                    EndReason.UserStop
-                                )
-                            )
-                        )
-                        break
-                    } else if (e.response.status == HttpStatusCode.NotFound) {
-                        logger.info("[STOP] [{}] Stream url returns 404", rs.roomName)
-                        rs.state = SessionState.Closing
-                        downloader.tell(
-                            DoCutPoint(
-                                CutPoint(
-                                    rs.roomId,
-                                    rs.segmentIndex - 1,
-                                    rs.roomName,
-                                    Instant.now(),
-                                    EndReason.UserStop
-                                )
-                            )
-                        )
-                        break
-                    } else {
-                        logger.error("Polling error room ${rs.roomId}: ${e.message}")
-                        rs.state = SessionState.Closing
-                        downloader.tell(
-                            DoCutPoint(
-                                CutPoint(
-                                    rs.roomId,
-                                    rs.segmentIndex - 1,
-                                    rs.roomName,
-                                    Instant.now(),
-                                    EndReason.UserStop
-                                )
-                            )
-                        )
-                        break
-                    }
-                } catch (e: Exception) {
-                    logger.error("[{}] Unexpected error in polling", rs.roomName, e)
-                    CdnSelector.recordFailure(CdnSelector.hostOf(rs.playlistUrl))
-                    if (configureSession(rs.roomId, rs.roomName) == null) {
-                        logger.info("[STOP] [{}] Room off or non-public", rs.roomName)
-                        rs.state = SessionState.Closing
-                        downloader.tell(
-                            DoCutPoint(
-                                CutPoint(
-                                    rs.roomId,
-                                    rs.segmentIndex - 1,
-                                    rs.roomName,
-                                    Instant.now(),
-                                    EndReason.UserStop,
-                                    rs.quality
-                                )
-                            )
-                        )
-                        break
-                    }
-                    try {
-                        rs.masterPlaylist = fetchAndCacheMasterPlaylist(rs)
-                        rs.playlistUrl = resolveVariantUrl(rs)
-                    } catch (e2: Exception) {
-                        logger.error("[{}] Failed to refresh master playlist during recovery", rs.roomName, e2)
-                        continue
-                    }
-                }
-            }
-        } catch (e: Exception) {
-            logger.error("[{}] polling failed", rs.roomName, e)
-        } finally {
-            rs.state = SessionState.Closing
-            withContext(NonCancellable) {
-                eventBus.publish(RecordingStopped(rs.roomId))
-            }
-        }
-    }
-
-    private fun onCutPointDone(roomId: Long) {
-        val rs = sessions[roomId] ?: return
-        rs.pollingJob = scope.launch { pollingLoop(rs) }
     }
 }

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -352,7 +352,7 @@ class SessionComponent(
                     quality = e.quality,
                     state = when (e.fsm.currentState) {
                         RecordingState.Recording -> SessionState.Recording
-                        RecordingState.Closing -> SessionState.Closing
+                        RecordingState.Closing -> SessionState.Recording   // still active until CutPointDone
                         else -> SessionState.Idle
                     },
                     startTime = e.startTime

--- a/src/main/kotlin/github/rikacelery/v3/core/Actor.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/Actor.kt
@@ -14,9 +14,14 @@ abstract class Actor<T : Any>(
 ) {
     private val mailbox = Channel<T>(capacity = mailboxCapacity)
     protected val logger = LoggerFactory.getLogger(name)
-    protected val scope =
+    internal val scope =
         parentScope + SupervisorJob() + CoroutineName(name) + CoroutineExceptionHandler { context, throwable ->
             logger.error("Unhandled exception {}",context[CoroutineName.Key], throwable)
+        }
+    /** Component-level async scope: FSM entries derive their Timer / launch helpers from here */
+    internal val ioScope =
+        parentScope + SupervisorJob() + CoroutineName("$name-io") + CoroutineExceptionHandler { context, throwable ->
+            logger.error("Unhandled io exception in {}", context[CoroutineName.Key], throwable)
         }
 
     private var started = false

--- a/src/main/kotlin/github/rikacelery/v3/core/OrderedEmitter.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/OrderedEmitter.kt
@@ -48,10 +48,9 @@ class OrderedEmitter(
             }
 
             is DownloadResult.CutPoint -> {
+                // New architecture: CutPoint only closes the old file; the next StartRecording's StreamStart opens the new one
                 val cut = result.cut
                 output(StreamEnd(roomId, cut.reason))
-                if (cut.reason != EndReason.UserStop)
-                    output(StreamStart(roomId, cut.roomName, cut.startTime, cut.quality))
             }
         }
     }

--- a/src/main/kotlin/github/rikacelery/v3/events/Commands.kt
+++ b/src/main/kotlin/github/rikacelery/v3/events/Commands.kt
@@ -71,7 +71,7 @@ data class Download(
     val roomId: Long,
     val urls: List<Segment>,
     val startIndex: Int,
-    val generation: Int
+    val generation: Long
 ) {
     override fun toString() = "Download(roomId=$roomId, idx=$startIndex, gen=$generation, count=${urls.size})"
 }
@@ -82,9 +82,10 @@ data class CutPoint(
     val roomName: String,
     val startTime: java.time.Instant,
     val reason: EndReason,
-    val quality: String = ""
+    val quality: String = "",
+    val generation: Long = 0L
 ) {
-    override fun toString() = "CutPoint(roomId=$roomId, idx=$index, reason=$reason)"
+    override fun toString() = "CutPoint(roomId=$roomId, idx=$index, reason=$reason, gen=$generation)"
 }
 
 // ── Scheduler commands ──

--- a/src/main/kotlin/github/rikacelery/v3/events/Events.kt
+++ b/src/main/kotlin/github/rikacelery/v3/events/Events.kt
@@ -129,6 +129,10 @@ object WsDisconnected {
 object WsReconnected {
     override fun toString() = "WsReconnected"
 }
+/** Published when a graceful shutdown is requested; every component starts its stop flow */
+object StopEvent {
+    override fun toString() = "StopEvent"
+}
 /** Published when the WS reports a broadcast-settings / stream change — a hint to re-check quality */
 data class QualityChangeHint(val roomId: Long) {
     override fun toString() = "QualityChangeHint(roomId=$roomId)"

--- a/src/main/kotlin/github/rikacelery/v3/events/Events.kt
+++ b/src/main/kotlin/github/rikacelery/v3/events/Events.kt
@@ -35,6 +35,14 @@ data class RecordingStarted(val roomId: Long, val quality: String = "") {
 data class RecordingStopped(val roomId: Long) {
     override fun toString() = "RecordingStopped(roomId=$roomId)"
 }
+/** Session exit report: lastIndex is the highest written HLS segment id; the Scheduler derives the resume point from it */
+data class SessionExit(val roomId: Long, val lastIndex: Long?, val reason: EndReason) {
+    override fun toString() = "SessionExit(roomId=$roomId, lastIndex=$lastIndex, reason=$reason)"
+}
+/** Downloader cut-point confirmation: the StreamEnd has entered the DataChannel FIFO */
+data class CutPointDone(val roomId: Long, val generation: Long, val reason: EndReason) {
+    override fun toString() = "CutPointDone(roomId=$roomId, gen=$generation, reason=$reason)"
+}
 data class FileReady(val roomId: Long, val file: File, val reason: EndReason, val roomName: String, val startTime: Long, val endTime: Long, val durationMs: Long, val quality: String) {
     override fun toString() = "FileReady(roomId=$roomId, file=${file.name}, reason=$reason, duration=${durationMs}ms)"
 }
@@ -62,7 +70,7 @@ data class SegmentDownloaded(
     val durationMs: Long,
     val proxied: Boolean,
     val bytes: Int,
-    val generation: Int
+    val generation: Long
 ) {
     override fun toString() = "SegmentDownloaded(roomId=$roomId, idx=$idx, bytes=$bytes, duration=${durationMs}ms, gen=$generation)"
 }
@@ -138,7 +146,7 @@ data class RoomSizeLimitChanged(val roomId: Long, val limitBytes: Long) {
 
 // ── Misc ──
 
-enum class EndReason { SizeLimit, TimeLimit, StreamEnd, UserStop, NewInit }
+enum class EndReason { SizeLimit, TimeLimit, StreamEnd, UserStop, NewInit, StatusChanged }
 
 interface Request
 interface Response

--- a/src/main/kotlin/github/rikacelery/v3/fsm/Fsm.kt
+++ b/src/main/kotlin/github/rikacelery/v3/fsm/Fsm.kt
@@ -1,0 +1,272 @@
+package github.rikacelery.v3.fsm
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import kotlin.time.Duration
+
+// ==========================================
+// 1. Exceptions
+// ==========================================
+sealed class FsmException(message: String, cause: Throwable? = null) : RuntimeException(message, cause) {
+    /** Illegal transition (undefined event / explicit ERROR / re-entrant drive) */
+    class IllegalTransition(message: String) : FsmException(message)
+
+    /** Action threw while executing */
+    class ActionFail(message: String, cause: Throwable) : FsmException(message, cause)
+}
+
+// ==========================================
+// 2. Transition target and history record
+// ==========================================
+sealed interface Target<out S>
+object KEEP : Target<Nothing>
+object ERROR : Target<Nothing>
+data class NextState<S>(val state: S) : Target<S>
+
+data class TransitionRecord<S, E>(
+    val timestamp: String,
+    val fromState: S,
+    val event: E,
+    val data: Any?,
+    val target: Target<S>
+) {
+    override fun toString(): String {
+        val targetStr = when (target) {
+            is ERROR -> "ERROR"
+            is KEEP -> "KEEP"
+            is NextState -> "-> ${(target as NextState<S>).state}"
+        }
+        val dataStr = if (data != null) " [data=$data]" else ""
+        return "[$timestamp] $fromState --($event)--> $targetStr$dataStr"
+    }
+}
+
+// ==========================================
+// 3. State machine core engine
+// ==========================================
+class StateMachine<S, E, D, C>(
+    initialState: S,
+    private val matrix: Map<S, Map<E, Transition<S, E, D, C>>>,
+    private val context: C,
+    private val maxHistorySize: Int = 10
+) {
+    var currentState: S = initialState
+        private set
+
+    private var driving = false
+    private val _history = ArrayDeque<TransitionRecord<S, E>>(maxHistorySize)
+
+    val history: List<TransitionRecord<S, E>>
+        get() = _history.toList()
+
+    private val traceLogger = LoggerFactory.getLogger("v3.Fsm")
+
+    /** Transition-legality gate: the event exists and its target is not ERROR */
+    fun canDrive(event: E): Boolean {
+        val t = matrix[currentState]?.get(event) ?: return false
+        return t.target !is ERROR
+    }
+
+    fun drive(event: E, data: D? = null) {
+        if (driving) {
+            dumpHistoryAndThrow(
+                FsmException.IllegalTransition("Re-entrant drive: action for state [$currentState] event [$event] must not call drive again")
+            )
+        }
+        driving = true
+        try {
+            val transition = matrix[currentState]?.get(event)
+                ?: dumpHistoryAndThrow(
+                    FsmException.IllegalTransition("No transition defined for state [$currentState] event [$event]")
+                )
+
+            recordTransition(currentState, event, data, transition.target)
+
+            val effectiveNewState = when (val target = transition.target) {
+                is NextState -> target.state
+                else -> currentState
+            }
+            traceLogger.trace(
+                "EVT: {}  {} -> {} / action={}",
+                event, currentState, effectiveNewState, transition.hasAction
+            )
+
+            when (val target = transition.target) {
+                is ERROR -> dumpHistoryAndThrow(
+                    FsmException.IllegalTransition("State [$currentState] explicitly rejected event [$event]")
+                )
+                is KEEP -> transition.invoke(context, data)
+                is NextState -> {
+                    transition.invoke(context, data)
+                    currentState = target.state
+                }
+            }
+        } finally {
+            driving = false
+        }
+    }
+
+    fun driveCatch(event: E, data: D? = null): FsmException? = try {
+        drive(event, data)
+        null
+    } catch (e: FsmException) {
+        e
+    }
+
+    private fun recordTransition(from: S, event: E, data: Any?, target: Target<S>) {
+        if (_history.size >= maxHistorySize) {
+            _history.removeFirst()
+        }
+        val time = LocalDateTime.now().format(DateTimeFormatter.ofPattern("HH:mm:ss.SSS"))
+        _history.addLast(TransitionRecord(time, from, event, data, target))
+    }
+
+    private fun dumpHistoryAndThrow(exception: FsmException): Nothing {
+        val sb = StringBuilder()
+        sb.appendLine("=".repeat(60))
+        val title = if (exception is FsmException.ActionFail) "ACTION CRASH" else "FSM ILLEGAL TRANSITION"
+        sb.appendLine("$title: ${exception.message}")
+        sb.appendLine("recent ${_history.size} transitions:")
+        if (_history.isEmpty()) {
+            sb.appendLine("   (no history, failed at initial state)")
+        } else {
+            _history.forEachIndexed { index, record ->
+                sb.appendLine("   ${index + 1}. $record")
+            }
+        }
+        sb.appendLine("=".repeat(60))
+        LoggerFactory.getLogger("v3.Fsm").error(sb.toString())
+        throw exception
+    }
+}
+
+// ==========================================
+// 4. DSL builders
+// ==========================================
+class Transition<S, E, D, C> {
+    var target: Target<S> = ERROR
+        private set
+
+    private var action: ((C, D?) -> Unit)? = null
+
+    internal val hasAction: Boolean get() = action != null
+
+    infix fun to(state: S): Transition<S, E, D, C> = apply { target = NextState(state) }
+    infix fun to(target: Target<S>): Transition<S, E, D, C> = apply { this.target = target }
+
+    /** action: `this` = context (entry), parameter = common D (null when no data) */
+    infix fun action(block: C.(D?) -> Unit): Transition<S, E, D, C> {
+        this.action = { ctx, d -> ctx.block(d) }
+        return this
+    }
+
+    internal fun invoke(ctx: C, data: D?) {
+        try {
+            action?.invoke(ctx, data)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            throw FsmException.ActionFail(e.message ?: e.javaClass.simpleName, e)
+        }
+    }
+}
+
+class StateBuilder<S, E, D, C> {
+    internal val transitions = mutableMapOf<E, Transition<S, E, D, C>>()
+    fun on(event: E): Transition<S, E, D, C> {
+        val transition = Transition<S, E, D, C>()
+        transitions[event] = transition
+        return transition
+    }
+}
+
+class FsmBuilder<S, E, D, C> {
+    private var initialState: S? = null
+    private var historySize: Int = 10
+    private val matrix = mutableMapOf<S, MutableMap<E, Transition<S, E, D, C>>>()
+
+    fun initial(state: S) { this.initialState = state }
+    fun historySize(size: Int) { this.historySize = size }
+
+    fun state(state: S, init: StateBuilder<S, E, D, C>.() -> Unit) {
+        val builder = StateBuilder<S, E, D, C>()
+        builder.init()
+        matrix[state] = builder.transitions
+    }
+
+    internal fun build(context: C): StateMachine<S, E, D, C> {
+        requireNotNull(initialState) { "initial state must be specified" }
+        return StateMachine(initialState!!, matrix, context, historySize)
+    }
+}
+
+fun <S, E, D, C> buildFsm(context: C, init: FsmBuilder<S, E, D, C>.() -> Unit): StateMachine<S, E, D, C> {
+    val builder = FsmBuilder<S, E, D, C>()
+    builder.init()
+    return builder.build(context)
+}
+
+// ==========================================
+// 5. Timer: single-shot delayed task owned by an entry
+// ==========================================
+class Timer<T>(
+    private val scope: CoroutineScope,
+) {
+    @Volatile
+    private var job: Job? = null
+
+    /** Single-shot: cancels any previous task, waits [delay], then invokes [onTimeout]. */
+    fun start(delay: Duration = Duration.ZERO, onTimeout: suspend () -> T) {
+        cancel()
+        job = scope.launch {
+            kotlinx.coroutines.delay(delay)
+            onTimeout()
+        }
+    }
+
+    fun cancel() {
+        job?.cancel()
+        job = null
+    }
+
+    val isRunning: Boolean get() = job?.isActive == true
+}
+
+// ==========================================
+// 6. LoopTimer: fixed-delay loop timer
+// ==========================================
+class LoopTimer<T>(
+    private val scope: CoroutineScope,
+) {
+    @Volatile
+    private var job: Job? = null
+
+    /**
+     * Starts a fixed-delay loop: invokes [onTimeout], then sleeps [interval] before the next
+     * iteration. The next run starts only after the previous invocation completed, so the
+     * observed interval between runs is interval + callback execution time.
+     */
+    fun start(interval: Duration, onTimeout: suspend () -> T) {
+        cancel()
+        job = scope.launch {
+            while (isActive) {
+                onTimeout()
+                delay(interval)
+            }
+        }
+    }
+
+    fun cancel() {
+        job?.cancel()
+        job = null
+    }
+
+    val isRunning: Boolean get() = job?.isActive == true
+}

--- a/src/test/kotlin/github/rikacelery/v3/core/OrderedEmitterTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/core/OrderedEmitterTest.kt
@@ -61,18 +61,18 @@ class OrderedEmitterTest {
     }
 
     @Test
-    fun `CutPoint triggers StreamEnd and StreamStart`() = runTest(UnconfinedTestDispatcher()) {
+    fun `CutPoint emits only StreamEnd`() = runTest(UnconfinedTestDispatcher()) {
         val emitted = mutableListOf<DataChannelMsg>()
         val emitter = OrderedEmitter(42) { emitted.add(it) }
 
         emitter.complete(0, success(42, 0))
         emitter.complete(1, cutPoint(42, EndReason.NewInit))
 
-        assertEquals(3, emitted.size)
+        assertEquals(2, emitted.size)
         assertEquals(0, (emitted[0] as StreamData).segmentIndex)
         assertTrue(emitted[1] is StreamEnd)
         assertEquals(EndReason.NewInit, (emitted[1] as StreamEnd).reason)
-        assertTrue(emitted[2] is StreamStart)
+        // New architecture: the next StartRecording's StreamStart opens the new file; CutPoint no longer auto-opens one
     }
 
     @Test

--- a/src/test/kotlin/github/rikacelery/v3/utils/ExportVerifyTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/utils/ExportVerifyTest.kt
@@ -11,17 +11,17 @@ class ExportVerifyTest {
         val zone = ZoneId.systemDefault()
         val now = ZonedDateTime.of(2024, 1, 15, 10, 30, 0, 0, zone).toInstant().toEpochMilli()
         CdnSelector.reset()
-        // 记录数据（包含大量槽位，触发EWMA数组序列化）
+        // Record data (many slots, triggers EWMA array serialization)
         repeat(5) {
             CdnSelector.record("cdn-a.com", 200, now = now)
             CdnSelector.record("cdn-b.com", 500, now = now)
         }
         CdnSelector.recordFailure("cdn-a.com", now)
-        // 导出不应抛出异常
+        // Export must not throw
         val json = CdnSelector.exportState()
         assertTrue(json.isNotEmpty())
         assertTrue(json.contains("slotEwma"))
-        assertTrue(json.contains("-1.0"), "NaN应该导出为-1.0哨兵")
+        assertTrue(json.contains("-1.0"), "NaN should be exported as the -1.0 sentinel")
         println("EXPORT_OK, json length: " + json.length)
     }
 

--- a/src/test/kotlin/github/rikacelery/v3/utils/ScheduleApiVerifyTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/utils/ScheduleApiVerifyTest.kt
@@ -14,13 +14,13 @@ class ScheduleApiVerifyTest {
         val zone = ZoneId.systemDefault()
         val now = ZonedDateTime.of(2024, 1, 15, 10, 30, 0, 0, zone).toInstant().toEpochMilli()
         ModelSchedule.reset()
-        // 记录数据产生分布
+        // Record a distribution of observations
         repeat(3) { ModelSchedule.record(55L, now) }
         val later = ZonedDateTime.of(2024, 1, 15, 14, 0, 0, 0, zone).toInstant().toEpochMilli()
         ModelSchedule.record(55L, later)
 
         val snapshot = ModelSchedule.snapshot(55L)!!
-        // 复刻 /model/schedule 的 buildJsonObject 序列化
+        // Replicate the /model/schedule buildJsonObject serialization
         val json = buildJsonObject {
             put("roomId", JsonPrimitive(snapshot.roomId))
             put("totalRecordings", JsonPrimitive(snapshot.totalCount))


### PR DESCRIPTION
- add generic FSM framework: StateMachine + DSL + Timer/LoopTimer
- Session FSM: Idle/Recording/Closing; polls a fixed playlist URL and exits with SessionExit(lastIndex)
- Scheduler FSM: Armed/Preconfiguring/Recording/Stopping; owns preconfiguration (token, quality, playlist URL) and restart decisions
- CutPoint now emits only StreamEnd; the next StartRecording opens the new file
- Downloader publishes CutPointDone after StreamEnd enters the FIFO
- add session/scheduler sequence diagrams