### PR TITLE
fix: refresh room status when playlist becomes unavailable

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
 
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+    testImplementation("io.ktor:ktor-client-mock-jvm:3.4.1")
     testImplementation(platform("org.junit:junit-bom:6.0.3"))
     testImplementation("org.junit.jupiter:junit-jupiter")
 }

--- a/src/main/kotlin/github/rikacelery/v3/components/RoomComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/RoomComponent.kt
@@ -33,7 +33,10 @@ class RoomComponent(
     eventBus: EventBus,
     parentScope: CoroutineScope,
     /** Slow catch-up cadence; live status changes arrive via WebSocket */
-    private val refreshInterval: Duration = 5.minutes
+    private val refreshInterval: Duration = 5.minutes,
+    private val roomStatusFetcher: suspend (String) -> String = { roomName ->
+        apiClient.roomFetchBroadcastInfo(roomName).PathSingle("item.status").asString()
+    }
 ) : Actor<RoomMsg>("RoomComponent", eventBus, parentScope) {
 
     private val rooms = ConcurrentHashMap<Long, Room>()
@@ -114,7 +117,14 @@ class RoomComponent(
                 else -> {}
             }
 
-            is HandleRoomCommand -> {
+            is HandleRoomCommand -> if (msg.env.command is RefreshRoomCmd) {
+                try {
+                    handleCommand(msg.env)
+                } catch (e: Exception) {
+                    logger.error("handleCommand failed for ${msg.env.command}", e)
+                    eventBus.publish(CommandAck(msg.env.id, ErrorResponse(e.message ?: "error")))
+                }
+            } else {
                 scope.launch {
                     try {
                         handleCommand(msg.env)
@@ -226,19 +236,9 @@ class RoomComponent(
 
             is GetRooms -> rooms.values.map { it.copy() }
             is RefreshRoomCmd -> {
-                scope.launch {
-                    val room = rooms[cmd.roomId] ?: return@launch
-                    try {
-                        val info = apiClient.roomFetchBroadcastInfo(room.name)
-                        val status = info.PathSingle("item.status").asString()
-                        if (status != room.status) {
-                            rooms[room.id] = room.copy(status = status)
-                        }
-                        eventBus.publish(RoomStatusChanged(room.id, room.status, status))
-                    } catch (e: Exception) {
-                        logger.error("Failed to refresh status for room ${cmd.roomId}", e)
-                    }
-                }
+                val room = rooms[cmd.roomId]
+                    ?: throw NoSuchElementException("room ${cmd.roomId} not found")
+                refreshRoomStatus(room)
                 OkResponse
             }
 
@@ -250,6 +250,16 @@ class RoomComponent(
             else -> return
         }
         eventBus.publish(CommandAck(env.id, ack))
+    }
+
+    private suspend fun refreshRoomStatus(room: Room) {
+        val status = roomStatusFetcher(room.name)
+        val current = rooms[room.id] ?: return
+        if (status != current.status) {
+            rooms[room.id] = current.copy(status = status)
+            eventBus.publish(RoomStatusChanged(room.id, current.status, status))
+            logger.debug("refreshRoom: room {} status {} -> {}", room.id, current.status, status)
+        }
     }
 
     private val refreshLock = Mutex()

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -211,7 +211,7 @@ class SessionEntry(
             SessionSignal(roomId, RecordingEvent.PlaylistFetchFailed, RecordingDriveData(failReason = "timeout"))
         } catch (e: ClientRequestException) {
             if (e.response.status == HttpStatusCode.NotFound || e.response.status == HttpStatusCode.Forbidden) {
-                // playlist is no longer usable: end the session, the scheduler will reconfigure
+                refreshRoomStatus()
                 SessionSignal(roomId, RecordingEvent.PlaylistUnusable, RecordingDriveData(failReason = e.response.status.toString()))
             } else {
                 SessionSignal(roomId, RecordingEvent.PlaylistFetchFailed, RecordingDriveData(failReason = e.message))
@@ -220,6 +220,16 @@ class SessionEntry(
             throw e
         } catch (e: Exception) {
             SessionSignal(roomId, RecordingEvent.PlaylistFetchFailed, RecordingDriveData(failReason = e.message))
+        }
+    }
+
+    private suspend fun refreshRoomStatus() {
+        try {
+            component.requestBus.request<OkResponse>(RefreshRoomCmd(roomId))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            sessionLogger.warn("Playlist unavailable and room status refresh failed roomId={}: {}", roomId, e.message)
         }
     }
 }

--- a/src/test/kotlin/github/rikacelery/v3/components/RoomComponentTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/RoomComponentTest.kt
@@ -1,0 +1,86 @@
+package github.rikacelery.v3.components
+
+import github.rikacelery.v3.api.ApiClient
+import github.rikacelery.v3.core.EventBus
+import github.rikacelery.v3.core.RequestBus
+import github.rikacelery.v3.events.CommandAck
+import github.rikacelery.v3.events.CommandEnvelope
+import github.rikacelery.v3.events.OkResponse
+import github.rikacelery.v3.events.RefreshRoomCmd
+import github.rikacelery.v3.events.RoomStatusChanged
+import github.rikacelery.v3.hooks.EventHook
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import kotlin.test.assertEquals
+import kotlin.time.Duration
+
+class RoomComponentTest {
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun `refresh publishes changed status before acknowledging request`() = runTest(UnconfinedTestDispatcher()) {
+        val mockServer = HttpClient(MockEngine { request ->
+            assertEquals("https://mock.platform/broadcasts/model", request.url.toString())
+            respond(
+                content = """{"item":{"status":"p2p"}}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        })
+        val eventBus = EventBus()
+        val requestBus = RequestBus(eventBus, backgroundScope)
+        val observed = mutableListOf<Any>()
+        eventBus.installHook(object : EventHook {
+            override suspend fun intercept(event: Any): Any? {
+                observed += event
+                return event
+            }
+        })
+
+        val component = RoomComponent(
+            apiClient = ApiClient,
+            listConfPath = Files.createTempFile("xhrec-room-test", ".conf").toString(),
+            requestBus = requestBus,
+            eventBus = eventBus,
+            parentScope = backgroundScope,
+            refreshInterval = Duration.INFINITE,
+            roomStatusFetcher = { roomName ->
+                mockServer.get("https://mock.platform/broadcasts/$roomName").bodyAsText()
+                    .substringAfter("\"status\":\"").substringBefore('"')
+            }
+        )
+        component.start()
+        advanceUntilIdle()
+        component.internalAdd(1, "model", "highest", Duration.INFINITE, 0, false, false)
+        eventBus.publish(RoomStatusChanged(1, "", "public"))
+        advanceUntilIdle()
+        observed.clear()
+
+        component.handle(HandleRoomCommand(CommandEnvelope(1, RefreshRoomCmd(1))))
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf(
+                RoomStatusChanged(1, "public", "p2p"),
+                CommandAck(1, OkResponse)
+            ),
+            observed
+        )
+        component.stop()
+        mockServer.close()
+    }
+}


### PR DESCRIPTION
When a playlist returns 403 or 404, refresh the room broadcast status before ending the session. RefreshRoomCmd now publishes a RoomStatusChanged event before its acknowledgement, so Scheduler reconfiguration observes current room state. Includes a MockEngine regression test for p2p transition and event ordering.

Validation: targeted RoomComponent and ConfigComponent tests pass.