### PR TITLE
test: mock-platform integration suite for room/status/websocket/download flows

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
 
     implementation("io.ktor:ktor-server-core-jvm:3.5.2")
     implementation("io.ktor:ktor-server-netty-jvm:3.5.2")
+    implementation("io.ktor:ktor-server-websockets-jvm:3.5.2")
     implementation("io.ktor:ktor-network-tls-certificates-jvm:3.5.2")
     implementation("io.ktor:ktor-server-cors:3.5.2")
     implementation("io.ktor:ktor-server-content-negotiation-jvm:3.5.2")
@@ -40,6 +41,7 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
     testImplementation("io.ktor:ktor-client-mock-jvm:3.5.2")
+    testImplementation("io.ktor:ktor-server-test-host-jvm:3.5.2")
     testImplementation(platform("org.junit:junit-bom:6.0.3"))
     testImplementation("org.junit.jupiter:junit-jupiter")
 }

--- a/src/main/kotlin/github/rikacelery/v3/Main.kt
+++ b/src/main/kotlin/github/rikacelery/v3/Main.kt
@@ -99,7 +99,7 @@ fun main(vararg args: String) {
 
         // Apply persisted runtime config before components start making API calls
         Hosts.current = persisted.hosts
-        ApiClient.applyHosts(persisted.hosts.platformHosts)
+        val apiClient = ApiClient(persisted.hosts.platformHosts)
         CdnSelector.updateHosts(persisted.hosts.hlsHosts)
         SensitiveStringRegistry.enabled = persisted.maskSensitiveLogs
 
@@ -121,13 +121,13 @@ fun main(vararg args: String) {
 
         // 2. Components
         val metricComponent = MetricComponent(eventBus, appScope)
-        val configComponent = ConfigComponent(config, eventBus, appScope)
+        val configComponent = ConfigComponent(config, apiClient, eventBus, appScope)
         val authComponent = AuthComponent(cli.getOptionValue("users", "users.txt"), eventBus, appScope)
         val roomComponent =
-            RoomComponent(ApiClient, config.listConfPath, requestBus, eventBus, appScope)
+            RoomComponent(apiClient, config.listConfPath, requestBus, eventBus, appScope)
         // WS auth JWT is fetched dynamically at startup from config/initial (guest session),
         // refreshed on auth failure or after its (unknown) validity window.
-        val liveEventSource = LiveEventSource({ ApiClient.fetchGuestWsToken() }, eventBus, appScope)
+        val liveEventSource = LiveEventSource({ apiClient.fetchGuestWsToken() }, eventBus, appScope)
 
         val downloaderComponent = DownloaderComponent(
             dataChannel, eventBus = eventBus, parentScope = appScope, initialConcurrency = 64
@@ -148,7 +148,7 @@ fun main(vararg args: String) {
         val schedulerComponent = SchedulerComponent(
             requestBus,
             sessionComponent,
-            ApiClient,
+            apiClient,
             config.streamAuthKey,
             eventBus,
             appScope
@@ -190,7 +190,7 @@ fun main(vararg args: String) {
 
         // 4. Bootstrap: load users, processors, rooms from config files
         val bootstrap =
-            Bootstrap(ApiClient, roomComponent, authComponent, postProcessorComponent, schedulerComponent)
+            Bootstrap(apiClient, roomComponent, authComponent, postProcessorComponent, schedulerComponent)
         bootstrap.initialize(args.toList())
 
         // 5. Start HTTP server

--- a/src/main/kotlin/github/rikacelery/v3/Main.kt
+++ b/src/main/kotlin/github/rikacelery/v3/Main.kt
@@ -8,11 +8,13 @@ import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
 import github.rikacelery.v3.data.Hosts
 import github.rikacelery.v3.data.HostsConfig
+import github.rikacelery.v3.data.RuntimeTuning
 import github.rikacelery.v3.data.SystemConfig
 import github.rikacelery.v3.hooks.EventHook
 import github.rikacelery.v3.m3u8.M3u8Parser
 import github.rikacelery.v3.ml.PredictionEngine
 import github.rikacelery.v3.utils.CdnSelector
+import github.rikacelery.v3.utils.DefaultHttpClientProvider
 import github.rikacelery.v3.utils.PredictionStore
 import github.rikacelery.v3.utils.SensitiveStringRegistry
 import kotlinx.coroutines.*
@@ -99,7 +101,9 @@ fun main(vararg args: String) {
 
         // Apply persisted runtime config before components start making API calls
         Hosts.current = persisted.hosts
-        val apiClient = ApiClient(persisted.hosts.platformHosts)
+        val httpClientProvider = DefaultHttpClientProvider
+        val runtimeTuning = RuntimeTuning()
+        val apiClient = ApiClient(persisted.hosts.platformHosts, httpClientProvider)
         CdnSelector.updateHosts(persisted.hosts.hlsHosts)
         SensitiveStringRegistry.enabled = persisted.maskSensitiveLogs
 
@@ -124,13 +128,17 @@ fun main(vararg args: String) {
         val configComponent = ConfigComponent(config, apiClient, eventBus, appScope)
         val authComponent = AuthComponent(cli.getOptionValue("users", "users.txt"), eventBus, appScope)
         val roomComponent =
-            RoomComponent(apiClient, config.listConfPath, requestBus, eventBus, appScope)
+            RoomComponent(apiClient, config.listConfPath, requestBus, eventBus, appScope, runtimeTuning)
         // WS auth JWT is fetched dynamically at startup from config/initial (guest session),
         // refreshed on auth failure or after its (unknown) validity window.
-        val liveEventSource = LiveEventSource({ apiClient.fetchGuestWsToken() }, eventBus, appScope)
+        val liveEventSource = LiveEventSource(
+            { apiClient.fetchGuestWsToken() }, eventBus, appScope,
+            httpClientProvider = httpClientProvider, runtimeTuning = runtimeTuning
+        )
 
         val downloaderComponent = DownloaderComponent(
-            dataChannel, eventBus = eventBus, parentScope = appScope, initialConcurrency = 64
+            dataChannel, eventBus = eventBus, parentScope = appScope, initialConcurrency = 64,
+            httpClientProvider = httpClientProvider, runtimeTuning = runtimeTuning
         )
         val writerComponent = WriterComponent(
             dataChannel, config.tmpDir,
@@ -143,7 +151,9 @@ fun main(vararg args: String) {
             M3u8Parser,
             requestBus,
             eventBus,
-            appScope
+            appScope,
+            httpClientProvider,
+            runtimeTuning
         )
         val schedulerComponent = SchedulerComponent(
             requestBus,
@@ -151,7 +161,9 @@ fun main(vararg args: String) {
             apiClient,
             config.streamAuthKey,
             eventBus,
-            appScope
+            appScope,
+            httpClientProvider,
+            runtimeTuning
         )
 
         // Prediction persistence (loads on init, auto-saves periodically, saves on stop)

--- a/src/main/kotlin/github/rikacelery/v3/api/ApiClient.kt
+++ b/src/main/kotlin/github/rikacelery/v3/api/ApiClient.kt
@@ -48,7 +48,9 @@ class ApiClient(
     }
 
     private val logger = LoggerFactory.getLogger("v3.ApiClient")
-    private val failover = HostFailover(initialHosts.ifEmpty { listOf(DEFAULT_PLATFORM_HOST) })
+    private val failover = HostFailover().apply {
+        updateHosts(initialHosts.ifEmpty { listOf(DEFAULT_PLATFORM_HOST) })
+    }
 
     /**
      * A 4xx response means the platform understood the request and answered with a

--- a/src/main/kotlin/github/rikacelery/v3/api/ApiClient.kt
+++ b/src/main/kotlin/github/rikacelery/v3/api/ApiClient.kt
@@ -38,11 +38,17 @@ internal fun throwBroadcast404(body: String): Nothing {
  * The platform client runs with expectSuccess=false and handles HTTP statuses explicitly
  * so that 404-based business results (model renamed / deleted) can be detected.
  */
-object ApiClient {
-    const val DEFAULT_PLATFORM_HOST = "stripchat.com"
+class ApiClient(
+    initialHosts: List<String> = listOf(DEFAULT_PLATFORM_HOST),
+    private val httpClientProvider: HttpClientProvider = DefaultHttpClientProvider,
+    private val baseUrlBuilder: (String) -> String = { host -> "https://$host" }
+) {
+    companion object {
+        const val DEFAULT_PLATFORM_HOST = "stripchat.com"
+    }
 
     private val logger = LoggerFactory.getLogger("v3.ApiClient")
-    private val failover = HostFailover(listOf(DEFAULT_PLATFORM_HOST))
+    private val failover = HostFailover(initialHosts.ifEmpty { listOf(DEFAULT_PLATFORM_HOST) })
 
     /**
      * A 4xx response means the platform understood the request and answered with a
@@ -61,12 +67,12 @@ object ApiClient {
         logger.info("Platform hosts updated: {}", failover.hosts)
     }
 
-    private val apiClient by lazy { ClientManager.getProxiedClient("api", http1 = true, expectSuccess = false) }
+    private val apiClient by lazy { httpClientProvider.proxied("api", http1 = true, expectSuccess = false) }
 
     private fun apiUrl(host: String, path: String): String {
         val h = host.trim().trimEnd('/')
         require(h.isNotEmpty()) { "platformHost must not be blank" }
-        return "https://" + h + "/" + path
+        return baseUrlBuilder(h).trimEnd('/') + "/" + path
     }
 
     /**

--- a/src/main/kotlin/github/rikacelery/v3/components/ConfigComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/ConfigComponent.kt
@@ -21,6 +21,7 @@ data class HandleConfigQuery(val env: CommandEnvelope) : ConfigMsg
 
 class ConfigComponent(
     val config: SystemConfig,
+    private val apiClient: ApiClient,
     eventBus: EventBus,
     parentScope: CoroutineScope
 ) : Actor<ConfigMsg>("ConfigComponent", eventBus, parentScope) {
@@ -90,7 +91,7 @@ class ConfigComponent(
         val cfg = HostsConfig.sanitize(hostsConfig)
         hostsConfig = cfg
         Hosts.current = cfg
-        ApiClient.applyHosts(cfg.platformHosts)
+        apiClient.applyHosts(cfg.platformHosts)
         CdnSelector.updateHosts(cfg.hlsHosts)
         eventBus.publish(HostsChanged)
         logger.info("Hosts config applied: platform=${cfg.platformHosts}, ws=${cfg.webSocketHosts}, hls=${cfg.hlsHosts}, master=${cfg.hlsMasterHost}")

--- a/src/main/kotlin/github/rikacelery/v3/components/ConfigComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/ConfigComponent.kt
@@ -12,6 +12,8 @@ import github.rikacelery.v3.utils.SensitiveStringRegistry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.*
 import java.io.File
@@ -39,6 +41,8 @@ class ConfigComponent(
     private var maskSensitiveLogs = config.maskSensitiveLogs
     private var apiToken: String = config.apiToken
     private var hostsConfig: HostsConfig = config.hosts
+    /** Serializes writes: the startup save and a config-change save may otherwise interleave. */
+    private val saveLock = Mutex()
 
     private suspend fun loadConfig() {
         if (!configFile.exists()) return
@@ -62,26 +66,30 @@ class ConfigComponent(
     }
 
     private suspend fun saveConfig() {
-        withContext(Dispatchers.IO) {
-            try {
-                val json = Json { prettyPrint = true }
-                configFile.writeText(
-                    json.encodeToString(
-                        JsonElement.serializer(),
-                        buildJsonObject {
-                            put("streamAuthKey", persistedStreamAuthKey)
-                            put("maskSensitiveLogs", maskSensitiveLogs)
-                            put("apiToken", apiToken)
-                            hostsConfig.toJson().forEach { (k, v) -> put(k, v) }
-                            put("decryptKeys", buildJsonObject {
-                                persistedDecryptKeys.forEach { (k, v) -> put(k, v) }
-                            })
-                        }
+        // Serialize saves and read the fields inside the lock: a save that started earlier
+        // must never overwrite a newer state with stale values.
+        saveLock.withLock {
+            withContext(Dispatchers.IO) {
+                try {
+                    val json = Json { prettyPrint = true }
+                    configFile.writeText(
+                        json.encodeToString(
+                            JsonElement.serializer(),
+                            buildJsonObject {
+                                put("streamAuthKey", persistedStreamAuthKey)
+                                put("maskSensitiveLogs", maskSensitiveLogs)
+                                put("apiToken", apiToken)
+                                hostsConfig.toJson().forEach { (k, v) -> put(k, v) }
+                                put("decryptKeys", buildJsonObject {
+                                    persistedDecryptKeys.forEach { (k, v) -> put(k, v) }
+                                })
+                            }
+                        )
                     )
-                )
-                logger.info("Saved config to ${config.configPath}")
-            } catch (e: Exception) {
-                logger.error("Failed to save config to ${config.configPath}: ${e.message}", e)
+                    logger.info("Saved config to ${config.configPath}")
+                } catch (e: Exception) {
+                    logger.error("Failed to save config to ${config.configPath}: ${e.message}", e)
+                }
             }
         }
     }

--- a/src/main/kotlin/github/rikacelery/v3/components/DownloaderComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/DownloaderComponent.kt
@@ -6,10 +6,12 @@ import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.OrderedEmitter
 import github.rikacelery.v3.data.DownloadMeta
 import github.rikacelery.v3.data.DownloadResult
+import github.rikacelery.v3.data.RuntimeTuning
 import github.rikacelery.v3.events.*
 import github.rikacelery.v3.hooks.DownloaderHook
 import github.rikacelery.v3.utils.CdnSelector
-import github.rikacelery.v3.utils.ClientManager
+import github.rikacelery.v3.utils.DefaultHttpClientProvider
+import github.rikacelery.v3.utils.HttpClientProvider
 import io.ktor.client.*
 import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.plugins.ResponseException
@@ -45,7 +47,9 @@ class DownloaderComponent(
     private val hooks: List<DownloaderHook> = emptyList(),
     eventBus: EventBus,
     parentScope: CoroutineScope,
-    private val initialConcurrency: Int = 16
+    private val initialConcurrency: Int = 16,
+    private val httpClientProvider: HttpClientProvider = DefaultHttpClientProvider,
+    private val runtimeTuning: RuntimeTuning = RuntimeTuning()
 ) : Actor<DownloaderMsg>("DownloaderComponent", eventBus, parentScope) {
 
     private val rooms = ConcurrentHashMap<Long, ActiveDownload>()
@@ -147,22 +151,7 @@ class DownloaderComponent(
         eventBus.publish(CutPointDone(cut.roomId, cut.generation, cut.reason))
     }
 
-    /** Start a parallel proxied attempt if the direct attempt hasn't succeeded within this time. */
-    private val raceThresholdMs: Long = 8_000
-    /** Hard cap for a single (host × direct/proxy) attempt. */
-    private val perAttemptTimeoutMs: Long = 25_000
-    /**
-     * Overall budget to obtain a segment before giving up ("尽力获取" window).
-     * A 404 (assignment expired) stops the loop immediately; transport errors / stalls /
-     * 5xx keep cycling through the remaining CDN hosts until the deadline.
-     */
-    private val segmentDeadlineMs: Long = 120_000
-    /** Stall watchdog: abort the attempt when no bytes arrive within this window. */
-    private val stallTimeoutMs: Long = 5_000
-    /** Base backoff between cross-host retries (jittered). */
-    private val retryBaseBackoffMs: Long = 500
-
-    /** Thrown when a download stalls (no bytes for [stallTimeoutMs]); treated as transport error. */
+    /** Thrown when a download stalls; treated as transport error. */
     private class StreamStallException(message: String) : Exception(message)
 
     // ── Probe scheduling ──
@@ -187,6 +176,7 @@ class DownloaderComponent(
      */
     private suspend fun downloadSegment(url: String, idx: Int): DownloadResult {
         val start = System.currentTimeMillis()
+        val segmentDeadlineMs = runtimeTuning.downloaderDeadline.inWholeMilliseconds
         val deadline = start + segmentDeadlineMs
         val tried = LinkedHashSet<String>()
         var lastFail: DownloadResult.Failed? = null
@@ -203,7 +193,7 @@ class DownloaderComponent(
 
             val resolvedUrl = if (CdnSelector.hosts.isNotEmpty()) CdnSelector.rewriteHost(url, host) else url
             val result = try {
-                attemptDownload(resolvedUrl, idx, minOf(perAttemptTimeoutMs, remaining))
+                attemptDownload(resolvedUrl, idx, minOf(runtimeTuning.downloaderAttemptTimeout.inWholeMilliseconds, remaining))
             } catch (e: kotlinx.coroutines.CancellationException) {
                 throw e
             } catch (e: Exception) {
@@ -234,7 +224,12 @@ class DownloaderComponent(
                 else -> { /* CutPoint cannot happen here */ }
             }
 
-            val backoff = retryBaseBackoffMs + Random.nextLong(0, retryBaseBackoffMs)
+            val retryBaseBackoffMs = runtimeTuning.downloaderRetryBackoff.inWholeMilliseconds
+            val backoff = if (retryBaseBackoffMs > 0) {
+                retryBaseBackoffMs + Random.nextLong(0, retryBaseBackoffMs)
+            } else {
+                0
+            }
             if (System.currentTimeMillis() + backoff >= deadline) break
             delay(backoff)
         }
@@ -269,9 +264,10 @@ class DownloaderComponent(
         return withTimeoutOrNull(budgetMs.milliseconds) {
             coroutineScope {
                 val directDeferred = async {
-                    downloadWithClient(ClientManager.getClient("dl_${Random.nextInt(32)}"), resolvedUrl, idx, false)
+                    downloadWithClient(httpClientProvider.direct("dl_${Random.nextInt(32)}"), resolvedUrl, idx, false)
                 }
 
+                val raceThresholdMs = runtimeTuning.downloaderRaceDelay.inWholeMilliseconds
                 val directResult = withTimeoutOrNull(minOf(raceThresholdMs, budgetMs).milliseconds) { directDeferred.await() }
                 if (directResult is DownloadResult.Success) {
                     val dur = System.currentTimeMillis() - start
@@ -284,7 +280,7 @@ class DownloaderComponent(
 
                 logger.debug("Direct download slow/failed for idx={}, falling back to proxy race", idx)
                 val proxyDeferred = async {
-                    downloadWithClient(ClientManager.getProxiedClient("px_${Random.nextInt(5)}"), resolvedUrl, idx, true)
+                    downloadWithClient(httpClientProvider.proxied("px_${Random.nextInt(5)}"), resolvedUrl, idx, true)
                 }
 
                 val result = if (directDeferred.isCompleted) {
@@ -317,18 +313,18 @@ class DownloaderComponent(
     ): DownloadResult {
         return try {
             // Stall watchdog #1: no response headers within stallTimeoutMs → dead path, bail out.
-            val response = withTimeout(stallTimeoutMs.milliseconds) { client.get(url) }
+            val response = withTimeout(runtimeTuning.downloaderStallTimeout) { client.get(url) }
             val stream = response.bodyAsChannel()
             val bos = ByteArrayOutputStream()
             while (!stream.isClosedForRead) {
                 val buf = ByteArray(8192)
                 // Stall watchdog #2: no bytes within stallTimeoutMs → disconnect and retry elsewhere.
                 val read = try {
-                    withTimeout(stallTimeoutMs.milliseconds) { stream.readAvailable(buf) }
+                    withTimeout(runtimeTuning.downloaderStallTimeout) { stream.readAvailable(buf) }
                 } catch (e: TimeoutCancellationException) {
                     // rethrow if the race cancelled us; otherwise it's a genuine stall
                     currentCoroutineContext().ensureActive()
-                    throw StreamStallException("no data for ${stallTimeoutMs}ms")
+                    throw StreamStallException("no data for ${runtimeTuning.downloaderStallTimeout.inWholeMilliseconds}ms")
                 }
                 if (read <= 0) break
                 bos.write(buf, 0, read)
@@ -337,6 +333,7 @@ class DownloaderComponent(
         } catch (e: TimeoutCancellationException) {
             // our own stall watchdog on client.get(); external cancellation is rethrown via ensureActive
             currentCoroutineContext().ensureActive()
+            val stallTimeoutMs = runtimeTuning.downloaderStallTimeout.inWholeMilliseconds
             logger.warn("downloadWithClient stalled: idx=$idx, url=$url, proxied=$proxied (no response within ${stallTimeoutMs}ms)")
             DownloadResult.Failed(idx, url, "stall: no response within ${stallTimeoutMs}ms", transportError = true)
         } catch (e: kotlinx.coroutines.CancellationException) {
@@ -370,7 +367,7 @@ class DownloaderComponent(
             try {
                 val rewritten = CdnSelector.rewriteHost(url, host)
                 val probeStart = System.currentTimeMillis()
-                val client = ClientManager.getClient("probe_" + Random.nextInt(32))
+                val client = httpClientProvider.direct("probe_" + Random.nextInt(32))
                 try {
                     withTimeoutOrNull(5_000) {
                         client.head(rewritten)

--- a/src/main/kotlin/github/rikacelery/v3/components/DownloaderComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/DownloaderComponent.kt
@@ -146,8 +146,8 @@ class DownloaderComponent(
         val active = rooms[cut.roomId] ?: return
         val idx = active.idx.incrementAndGet().toLong()
         logger.info("CutPoint roomId={}, index={}, reason={}", cut.roomId, cut.index, cut.reason)
-        // once complete returns, StreamEnd is in the DataChannel FIFO; Session restart is safe only after that
-        active.emitter.complete(idx, DownloadResult.CutPoint(cut))
+        // once this returns, StreamEnd is in the DataChannel FIFO; Session restart is safe only after that
+        active.emitter.completeAndAwait(idx, DownloadResult.CutPoint(cut))
         eventBus.publish(CutPointDone(cut.roomId, cut.generation, cut.reason))
     }
 

--- a/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
@@ -40,7 +40,8 @@ class HttpServerComponent(
     private val postProcessorComponent: PostProcessorComponent,
     private val scope: CoroutineScope,
     private val mseStore: MseStore = MseStore(),
-    private val apiToken: String = ""
+    private val apiToken: String = "",
+    private val restartDelay: Duration = 500.milliseconds
 ) {
     private val logger = LoggerFactory.getLogger("v3.HttpServer")
     private val stopping = AtomicBoolean(false)
@@ -79,6 +80,19 @@ class HttpServerComponent(
                 keyStorePath = keyStoreFile
             }
         }) {
+            installApplication(this, stopEngine = { engine.stop(1000, 5000) })
+        }
+        engine.start(wait = false)
+        logger.info("HTTP server started on port $port")
+        return engine
+    }
+
+    /**
+     * Installs the shared XhRec control routes. Production passes a real engine stop;
+     * tests pass a no-op so the route table can be driven through Ktor's test host.
+     */
+    fun installApplication(application: Application, stopEngine: suspend () -> Unit) {
+        application.apply {
             if (apiToken.isNotBlank()) {
                 intercept(ApplicationCallPipeline.Plugins) {
                     val path = call.request.uri.substringBefore('?')
@@ -179,7 +193,7 @@ class HttpServerComponent(
 
                         write("OK\n"); flush()
                     }
-                    engine.stop(1000, 5000)
+                    stopEngine()
                     eventBus.publish("ServerShutdown")
                 }
                 get("/remove") {
@@ -197,7 +211,7 @@ class HttpServerComponent(
                         status = HttpStatusCode.BadRequest
                     )
                     requestBus.request<OkResponse>(DeactivateCmd(id))
-                    delay(0.5.seconds)
+                    delay(restartDelay)
                     requestBus.request<OkResponse>(ActivateRecordingCmd(id))
                     call.respondText("Restarted")
                 }
@@ -618,9 +632,6 @@ class HttpServerComponent(
                 }
             }
         }
-        engine.start(wait = false)
-        logger.info("HTTP server started on port $port")
-        return engine
     }
 
 

--- a/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
@@ -4,6 +4,7 @@ import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
 import github.rikacelery.v3.data.HostsConfig
 import github.rikacelery.v3.data.Room
+import github.rikacelery.v3.data.RuntimeTuning
 import github.rikacelery.v3.events.*
 import github.rikacelery.v3.ml.PredictionEngine
 import github.rikacelery.v3.utils.CdnSelector
@@ -41,7 +42,7 @@ class HttpServerComponent(
     private val scope: CoroutineScope,
     private val mseStore: MseStore = MseStore(),
     private val apiToken: String = "",
-    private val restartDelay: Duration = 500.milliseconds
+    private val runtimeTuning: RuntimeTuning = RuntimeTuning()
 ) {
     private val logger = LoggerFactory.getLogger("v3.HttpServer")
     private val stopping = AtomicBoolean(false)
@@ -211,7 +212,7 @@ class HttpServerComponent(
                         status = HttpStatusCode.BadRequest
                     )
                     requestBus.request<OkResponse>(DeactivateCmd(id))
-                    delay(restartDelay)
+                    delay(runtimeTuning.httpRestartDelay)
                     requestBus.request<OkResponse>(ActivateRecordingCmd(id))
                     call.respondText("Restarted")
                 }

--- a/src/main/kotlin/github/rikacelery/v3/components/LiveEventSource.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/LiveEventSource.kt
@@ -181,6 +181,7 @@ class LiveEventSource(
             while (scope.isActive) {
                 val host = wsFailover.currentHost() ?: HostsConfig.DEFAULT_WS_HOST
                 var opened = false
+                var frames = 0
                 try {
                     val token = ensureWsToken()
                     val client = httpClientProvider.proxied("event_$index", http1 = true)
@@ -190,7 +191,6 @@ class LiveEventSource(
                         send(authFrame(token))
                         resubscribeAllForPool(index)
                         eventBus.publish(WsReconnected)
-                        var frames = 0
                         for (frame in incoming) {
                             frames++
                             if (frame is Frame.Text) {
@@ -202,14 +202,35 @@ class LiveEventSource(
                                 }
                             }
                         }
-                        // closed by the server without delivering any frame — almost certainly an
-                        // auth failure (invalid/expired token) → refetch on the next attempt
-                        if (frames == 0) invalidateWsToken()
                     }
-                    wsFailover.markSuccess(host)
-                    backoff = runtimeTuning.webSocketReconnectInitial
+                    if (frames == 0) {
+                        // closed without a single frame — almost certainly an auth rejection
+                        // (invalid/expired token). Refetch the token and back off instead of
+                        // hot-looping against the platform.
+                        invalidateWsToken()
+                        wsFailover.markFailure(host)
+                        logger.warn(
+                            "WS pool {} closed by {} without any frame, retrying in {}ms",
+                            index, host, backoff.inWholeMilliseconds
+                        )
+                        delay(backoff)
+                        backoff = minOf(backoff * 2, runtimeTuning.webSocketReconnectMax)
+                    } else {
+                        wsFailover.markSuccess(host)
+                        backoff = runtimeTuning.webSocketReconnectInitial
+                    }
                 } catch (e: CancellationException) {
-                    throw e
+                    // A server-side close surfaces as CancellationException from send(); only a
+                    // genuine scope cancellation may end the reconnect loop, otherwise a rejected
+                    // or dropped connection would kill it forever.
+                    if (!scope.isActive) throw e
+                    invalidateWsToken()
+                    logger.warn(
+                        "WS pool {} closed while connecting to {}: {}, retrying in {}ms",
+                        index, host, e.message, backoff.inWholeMilliseconds
+                    )
+                    delay(backoff)
+                    backoff = minOf(backoff * 2, runtimeTuning.webSocketReconnectMax)
                 } catch (e: Exception) {
                     invalidateWsToken()
                     wsFailover.markFailure(host)

--- a/src/main/kotlin/github/rikacelery/v3/components/LiveEventSource.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/LiveEventSource.kt
@@ -4,6 +4,7 @@ import github.rikacelery.v3.core.Actor
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.data.Hosts
 import github.rikacelery.v3.data.HostsConfig
+import github.rikacelery.v3.data.RuntimeTuning
 import github.rikacelery.v3.events.HostsChanged
 import github.rikacelery.v3.events.LiveMessage
 import github.rikacelery.v3.events.QualityChangeHint
@@ -15,8 +16,9 @@ import github.rikacelery.v3.events.RoomStatusChanged
 import github.rikacelery.v3.events.StreamStatusChanged
 import github.rikacelery.v3.events.WsDisconnected
 import github.rikacelery.v3.events.WsReconnected
-import github.rikacelery.v3.utils.ClientManager
+import github.rikacelery.v3.utils.DefaultHttpClientProvider
 import github.rikacelery.v3.utils.HostFailover
+import github.rikacelery.v3.utils.HttpClientProvider
 import io.ktor.client.plugins.websocket.*
 import io.ktor.websocket.*
 import kotlinx.coroutines.*
@@ -27,7 +29,6 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.time.Duration.Companion.seconds
 
 sealed interface LiveEventMsg
 data class OnLiveEvent(val event: Any) : LiveEventMsg
@@ -39,7 +40,10 @@ class LiveEventSource(
     private val tokenProvider: suspend () -> String,
     eventBus: EventBus,
     parentScope: CoroutineScope,
-    private val wsPoolCount: Int = 3
+    private val wsPoolCount: Int = 3,
+    private val httpClientProvider: HttpClientProvider = DefaultHttpClientProvider,
+    private val runtimeTuning: RuntimeTuning = RuntimeTuning(),
+    private val wsUrlBuilder: (String) -> String = { host -> "wss://$host/connection/websocket" }
 ) : Actor<LiveEventMsg>("LiveEventSource", eventBus, parentScope) {
 
     private val subscribed = ConcurrentHashMap.newKeySet<Long>()
@@ -171,7 +175,7 @@ class LiveEventSource(
     /** One WebSocket connection handling roughly 1/wsPoolCount of the subscribed rooms. */
     private inner class WsPool(private val index: Int) {
         @Volatile var wsSession: WebSocketSession? = null
-        private var backoff = 1.seconds
+        private var backoff = runtimeTuning.webSocketReconnectInitial
 
         suspend fun connectLoop() {
             while (scope.isActive) {
@@ -179,8 +183,8 @@ class LiveEventSource(
                 var opened = false
                 try {
                     val token = ensureWsToken()
-                    val client = ClientManager.getProxiedClient("event_$index", http1 = true)
-                    client.webSocket("wss://" + host + "/connection/websocket") {
+                    val client = httpClientProvider.proxied("event_$index", http1 = true)
+                    client.webSocket(wsUrlBuilder(host)) {
                         wsSession = this
                         opened = true
                         send(authFrame(token))
@@ -203,7 +207,7 @@ class LiveEventSource(
                         if (frames == 0) invalidateWsToken()
                     }
                     wsFailover.markSuccess(host)
-                    backoff = 1.seconds
+                    backoff = runtimeTuning.webSocketReconnectInitial
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
@@ -211,7 +215,7 @@ class LiveEventSource(
                     wsFailover.markFailure(host)
                     logger.error("WS pool {} error on {}: {}, reconnecting in {}ms", index, host, e.message, backoff.inWholeMilliseconds)
                     delay(backoff)
-                    backoff = minOf(backoff.inWholeSeconds * 2, 30).seconds
+                    backoff = minOf(backoff * 2, runtimeTuning.webSocketReconnectMax)
                 } finally {
                     if (opened) {
                         wsSession = null

--- a/src/main/kotlin/github/rikacelery/v3/components/LiveEventSource.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/LiveEventSource.kt
@@ -293,8 +293,11 @@ class LiveEventSource(
         }
     }
 
+    /** Channels needed only while recording; the status subset stays subscribed for tracked rooms. */
+    private val recordingOnlyChannels: List<String> = roomChannels - statusChannels.toSet()
+
     private suspend fun WebSocketSession.sendRoomFullUnsubscribes(roomId: Long) {
-        roomChannels.forEach { channel ->
+        recordingOnlyChannels.forEach { channel ->
             try {
                 send(Frame.Text(unsubscribeFrame("$channel@$roomId")))
             } catch (e: Exception) {

--- a/src/main/kotlin/github/rikacelery/v3/components/RoomComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/RoomComponent.kt
@@ -6,6 +6,7 @@ import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
 import github.rikacelery.v3.data.Hosts
 import github.rikacelery.v3.data.Room
+import github.rikacelery.v3.data.RuntimeTuning
 import github.rikacelery.v3.events.*
 import github.rikacelery.v3.exceptions.DeletedException
 import github.rikacelery.v3.exceptions.RenameException
@@ -18,7 +19,6 @@ import kotlinx.coroutines.sync.withLock
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 sealed interface RoomMsg
@@ -32,8 +32,7 @@ class RoomComponent(
     private val requestBus: RequestBus,
     eventBus: EventBus,
     parentScope: CoroutineScope,
-    /** Slow catch-up cadence; live status changes arrive via WebSocket */
-    private val refreshInterval: Duration = 5.minutes,
+    private val runtimeTuning: RuntimeTuning = RuntimeTuning(),
     private val roomStatusFetcher: suspend (String) -> String = { roomName ->
         apiClient.roomFetchBroadcastInfo(roomName).PathSingle("item.status").asString()
     }
@@ -44,9 +43,6 @@ class RoomComponent(
     private var saveDebounceJob: Job? = null
     private var refreshDebounceJob: Job? = null
     private val saveLock = Mutex()
-
-    /** Debounce window for WS-triggered status refresh, avoids an API storm when WS flaps. */
-    private val refreshDebounceMs = 1_500L
 
     @Volatile
     private var stopRefresh = false
@@ -66,7 +62,7 @@ class RoomComponent(
         scope.launch {
             tell(RefreshRooms)
             while (isActive && !stopRefresh) {
-                delay(refreshInterval); tell(RefreshRooms)
+                delay(runtimeTuning.roomPollInterval); tell(RefreshRooms)
             }
         }
     }
@@ -104,7 +100,7 @@ class RoomComponent(
                     logger.debug("WS state changed ({}), scheduling debounced refreshAll", event::class.simpleName)
                     refreshDebounceJob?.cancel()
                     refreshDebounceJob = scope.launch {
-                        delay(refreshDebounceMs)
+                        delay(runtimeTuning.roomRefreshDebounce)
                         tell(RefreshRooms)
                     }
                 }

--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -6,6 +6,7 @@ import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
 import github.rikacelery.v3.data.Hosts
 import github.rikacelery.v3.data.RoomStatus
+import github.rikacelery.v3.data.RuntimeTuning
 import github.rikacelery.v3.data.User
 import github.rikacelery.v3.events.*
 import github.rikacelery.v3.fsm.KEEP
@@ -16,7 +17,8 @@ import github.rikacelery.v3.m3u8.M3u8Parser
 import github.rikacelery.v3.m3u8.MasterPlaylist
 import github.rikacelery.v3.m3u8.VariantStream
 import github.rikacelery.v3.utils.CdnSelector
-import github.rikacelery.v3.utils.ClientManager
+import github.rikacelery.v3.utils.DefaultHttpClientProvider
+import github.rikacelery.v3.utils.HttpClientProvider
 import github.rikacelery.v3.utils.PathSingle
 import github.rikacelery.v3.utils.PathSingleOrNull
 import github.rikacelery.v3.utils.asInt
@@ -85,6 +87,18 @@ data class SchedulerHandleCommand(val env: CommandEnvelope) : SchedulerMsg
 
 private val schedulerLogger = LoggerFactory.getLogger("v3.SchedulerEntry")
 
+internal fun productionMasterUrls(roomId: Long, pkey: String, token: String?): List<String> =
+    (listOf(Hosts.current.hlsMasterHost) + Hosts.current.hlsHosts).distinct().map { host ->
+        buildUrl {
+            protocol = URLProtocol.HTTPS
+            this.host = host
+            encodedPath = "/hls/$roomId/master/${roomId}_auto.m3u8"
+            parameters["psch"] = "v2"
+            parameters["pkey"] = pkey
+            token?.takeIf { it.isNotEmpty() }?.let { parameters["aclAuth"] = it }
+        }.toString()
+    }
+
 class SchedulerEntry(
     val roomId: Long,
     var roomName: String,
@@ -151,9 +165,9 @@ class SchedulerEntry(
         launch { component.tell(SchedulerSignal(roomId, event, data)) }
     }
 
-    /** Start the fixed-delay preconfig loop: first attempt immediately, then 15s after each completion. */
+    /** Start the fixed-delay preconfig loop: first attempt immediately, then wait the configured interval. */
     internal fun startPreconfigLoop() {
-        preconfigLoop.start(15.seconds) { component.tell(preconfigSignal()) }
+        preconfigLoop.start(component.runtimeTuning.preconfigRetryInterval) { component.tell(preconfigSignal()) }
     }
 
     internal fun stopPreconfigLoop() {
@@ -302,11 +316,11 @@ class SchedulerEntry(
     }
 
     private suspend fun fetchMaster(token: String?): MasterPlaylist {
-        val client = ClientManager.getProxiedClient("master_$roomId")
-        val hosts = (listOf(Hosts.current.hlsMasterHost) + Hosts.current.hlsHosts).distinct()
+        val client = component.httpClientProvider.proxied("master_$roomId")
+        val urls = component.masterUrlCandidates(roomId, pkey, token)
         var lastErr: Throwable? = null
-        for (host in hosts) {
-            val url = buildMasterUrl(host, token)
+        for (url in urls) {
+            val host = Url(url).host
             try {
                 val response = withRetry(3) { client.get(url) }
                 return M3u8Parser.parseMaster(response.bodyAsText())
@@ -333,15 +347,6 @@ class SchedulerEntry(
         }
         return match.keyName
     }
-
-    private fun buildMasterUrl(host: String, token: String?): String = buildUrl {
-        protocol = URLProtocol.HTTPS
-        this.host = host
-        encodedPath = "/hls/$roomId/master/${roomId}_auto.m3u8"
-        parameters["psch"] = "v2"
-        parameters["pkey"] = pkey
-        token?.takeIf { it.isNotEmpty() }?.let { parameters["aclAuth"] = it }
-    }.toString()
 
     private fun selectVariant(master: MasterPlaylist, requested: String): VariantStream {
         val variant = if (requested == "highest") {
@@ -385,7 +390,7 @@ class SchedulerEntry(
     private suspend fun playlistUsable(url: String): Boolean {
         return try {
             withTimeout(5.seconds) {
-                val client = ClientManager.getProxiedClient("preconfig_$roomId")
+                val client = component.httpClientProvider.proxied("preconfig_$roomId")
                 val response = withRetry(2) { client.get(url) }
                 response.status.value in 200..299
             }
@@ -579,7 +584,10 @@ class SchedulerComponent(
     internal val apiClient: ApiClient,
     internal val streamAuthKey: String,
     eventBus: EventBus,
-    parentScope: CoroutineScope
+    parentScope: CoroutineScope,
+    internal val httpClientProvider: HttpClientProvider = DefaultHttpClientProvider,
+    internal val runtimeTuning: RuntimeTuning = RuntimeTuning(),
+    internal val masterUrlCandidates: (Long, String, String?) -> List<String> = ::productionMasterUrls
 ) : Actor<SchedulerMsg>("SchedulerComponent", eventBus, parentScope) {
 
     private val entries = ConcurrentHashMap<Long, SchedulerEntry>()

--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -5,6 +5,7 @@ import github.rikacelery.v3.core.Actor
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
 import github.rikacelery.v3.data.Hosts
+import github.rikacelery.v3.data.Room
 import github.rikacelery.v3.data.RoomStatus
 import github.rikacelery.v3.data.RuntimeTuning
 import github.rikacelery.v3.data.User
@@ -701,6 +702,19 @@ class SchedulerComponent(
                     }
                     logger.info("Room {} ({}) activated (armed)", name, cmd.roomId)
                     requestBus.request<OkResponse>(RefreshRoomCmd(cmd.roomId))
+                    // Arming a room that is already recordable must not wait for the next
+                    // status event: the refresh above only publishes RoomStatusChanged when
+                    // the status actually changes, so an already-public room would sit armed
+                    // until something else moved. Feed the current status into the FSM.
+                    val currentStatus = requestBus.request<List<Room>>(GetRooms)
+                        .firstOrNull { it.id == cmd.roomId }?.status.orEmpty()
+                    if (currentStatus.isNotEmpty() && entries[cmd.roomId]?.canRecord(currentStatus) == true) {
+                        driveFsm(
+                            cmd.roomId,
+                            SchedulerEvent.RoomStatusChanged,
+                            SchedulerDriveData(roomStatus = currentStatus)
+                        )
+                    }
                 } catch (_: Exception) {
                 }
                 OkResponse

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -4,6 +4,7 @@ import github.rikacelery.v3.core.Actor
 import github.rikacelery.v3.core.DataChannel
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
+import github.rikacelery.v3.data.RuntimeTuning
 import github.rikacelery.v3.data.StreamStart
 import github.rikacelery.v3.events.*
 import github.rikacelery.v3.fsm.KEEP
@@ -12,7 +13,8 @@ import github.rikacelery.v3.fsm.StateMachine
 import github.rikacelery.v3.fsm.buildFsm
 import github.rikacelery.v3.m3u8.M3u8Parser
 import github.rikacelery.v3.m3u8.ParsedPlaylist
-import github.rikacelery.v3.utils.ClientManager
+import github.rikacelery.v3.utils.DefaultHttpClientProvider
+import github.rikacelery.v3.utils.HttpClientProvider
 import github.rikacelery.v3.utils.withRetry
 import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.request.*
@@ -24,7 +26,6 @@ import java.security.SecureRandom
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 import java.time.Duration as JavaDuration
 
 // ============================================================
@@ -195,8 +196,8 @@ class SessionEntry(
 
     internal suspend fun fetchPlaylistSignal(): SessionMsg {
         return try {
-            withTimeout(10.seconds) {
-                val client = ClientManager.getProxiedClient("m3u8_$roomId")
+            withTimeout(component.runtimeTuning.playlistFetchTimeout) {
+                val client = component.httpClientProvider.proxied("m3u8_$roomId")
                 val response = withRetry(3) { client.get(playlistUrl) }
                 val text = response.bodyAsText()
                 val key = (component.requestBus.request<ConfigResponse>(GetDecryptKey(pkey)).value as? String)
@@ -251,7 +252,7 @@ private fun buildSessionFsm(ctx: SessionEntry) =
                 retryCount = 0
                 circleCache.clear()   // a new file must re-download the init; media segments are skipped via the lastSegmentId threshold
                 launch { component.dataChannel.send(StreamStart(roomId, roomName, startTime, quality)) }
-                playlistLoop.start(3.seconds) { component.tell(fetchPlaylistSignal()) }
+                playlistLoop.start(component.runtimeTuning.playlistPollInterval) { component.tell(fetchPlaylistSignal()) }
             }
             on(RecordingEvent.StopRecording) to KEEP
             on(RecordingEvent.SegmentDownloaded) to KEEP
@@ -336,7 +337,9 @@ class SessionComponent(
     internal val m3u8Parser: M3u8Parser,
     internal val requestBus: RequestBus,
     eventBus: EventBus,
-    parentScope: CoroutineScope
+    parentScope: CoroutineScope,
+    internal val httpClientProvider: HttpClientProvider = DefaultHttpClientProvider,
+    internal val runtimeTuning: RuntimeTuning = RuntimeTuning()
 ) : Actor<SessionMsg>("SessionComponent", eventBus, parentScope) {
 
     private val entries = ConcurrentHashMap<Long, SessionEntry>()

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -252,6 +252,8 @@ private fun buildSessionFsm(ctx: SessionEntry) =
                 retryCount = 0
                 circleCache.clear()   // a new file must re-download the init; media segments are skipped via the lastSegmentId threshold
                 launch { component.dataChannel.send(StreamStart(roomId, roomName, startTime, quality)) }
+                // LiveEventSource expands the WebSocket channel set and metrics start counting on this
+                launch { component.publish(RecordingStarted(roomId, quality)) }
                 playlistLoop.start(component.runtimeTuning.playlistPollInterval) { component.tell(fetchPlaylistSignal()) }
             }
             on(RecordingEvent.StopRecording) to KEEP

--- a/src/main/kotlin/github/rikacelery/v3/components/WriterComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/WriterComponent.kt
@@ -59,6 +59,7 @@ class WriterComponent(
     private val dataChannel: DataChannel,
     private val tmpDir: File,
     private val hooks: List<WriterHook> = emptyList(),
+    private val minOutputBytes: Long = 1024,
     eventBus: EventBus,
     parentScope: CoroutineScope
 ) : Actor<WriterMsg>("WriterComponent", eventBus, parentScope) {
@@ -150,7 +151,7 @@ class WriterComponent(
     private suspend fun closeActiveFile(active: ActiveFile, reason: EndReason) {
         withContext(Dispatchers.IO + NonCancellable) {
             try {
-                if (active.bytesWritten < 1024) {
+                if (active.bytesWritten < minOutputBytes) {
                     logger.info("Closed file: ${active.file.absolutePath}, reason=$reason (empty)")
                     active.dispose()
                     return@withContext

--- a/src/main/kotlin/github/rikacelery/v3/core/OrderedEmitter.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/OrderedEmitter.kt
@@ -2,6 +2,7 @@ package github.rikacelery.v3.core
 
 import github.rikacelery.v3.data.*
 import github.rikacelery.v3.events.EndReason
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -14,6 +15,7 @@ class OrderedEmitter(
     private val mutex = Mutex()
     private var nextIndex = 0L
     private val buffer = sortedMapOf<Long, DownloadResult>()
+    private val awaiters = HashMap<Long, CompletableDeferred<Unit>>()
 
     suspend fun complete(idx: Long, result: DownloadResult) {
         mutex.withLock {
@@ -22,10 +24,28 @@ class OrderedEmitter(
         }
     }
 
+    /**
+     * Completes [idx] and suspends until it has actually been emitted downstream.
+     *
+     * Cut points use this so the caller does not publish "cut done" while an in-flight
+     * segment still holds the buffer: the next session's StreamStart must never reach the
+     * writer before the previous session's StreamEnd.
+     */
+    suspend fun completeAndAwait(idx: Long, result: DownloadResult) {
+        val emitted = CompletableDeferred<Unit>()
+        mutex.withLock {
+            awaiters[idx] = emitted
+            buffer[idx] = result
+            drain()
+        }
+        emitted.await()
+    }
+
     private suspend fun drain() {
         while (buffer.isNotEmpty() && buffer.firstKey() == nextIndex) {
             val result = buffer.remove(nextIndex)!!
             emitIfSuccess(nextIndex, result)
+            awaiters.remove(nextIndex)?.complete(Unit)
             nextIndex++
 
         }

--- a/src/main/kotlin/github/rikacelery/v3/data/Room.kt
+++ b/src/main/kotlin/github/rikacelery/v3/data/Room.kt
@@ -74,7 +74,7 @@ object SizeStrSerializer : KSerializer<Long> {
                 c.isDigit() || c == '.' -> { numberBuf += c; i++ }
                 c.isWhitespace() -> i++
                 c.isLetter() -> {
-                    val matched = keys.firstOrNull { upper.startsWith(it, i) }
+                    val matched = keys.firstOrNull { upper.startsWith(it.uppercase(), i) }
                         ?: throw IllegalArgumentException("Unknown unit at '$c' in '$input'")
                     if (numberBuf.isEmpty()) throw IllegalArgumentException("Missing number before '$matched' in '$input'")
                     total += (numberBuf.toDouble() * unitMap[matched]!!).toLong()

--- a/src/main/kotlin/github/rikacelery/v3/data/RuntimeTuning.kt
+++ b/src/main/kotlin/github/rikacelery/v3/data/RuntimeTuning.kt
@@ -1,0 +1,22 @@
+package github.rikacelery.v3.data
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+data class RuntimeTuning(
+    val roomPollInterval: Duration = 5.minutes,
+    val roomRefreshDebounce: Duration = 1500.milliseconds,
+    val webSocketReconnectInitial: Duration = 1.seconds,
+    val webSocketReconnectMax: Duration = 30.seconds,
+    val preconfigRetryInterval: Duration = 15.seconds,
+    val playlistPollInterval: Duration = 3.seconds,
+    val playlistFetchTimeout: Duration = 10.seconds,
+    val httpRestartDelay: Duration = 500.milliseconds,
+    val downloaderRaceDelay: Duration = 8.seconds,
+    val downloaderAttemptTimeout: Duration = 25.seconds,
+    val downloaderDeadline: Duration = 120.seconds,
+    val downloaderStallTimeout: Duration = 5.seconds,
+    val downloaderRetryBackoff: Duration = 500.milliseconds
+)

--- a/src/main/kotlin/github/rikacelery/v3/utils/HttpClientProvider.kt
+++ b/src/main/kotlin/github/rikacelery/v3/utils/HttpClientProvider.kt
@@ -1,0 +1,16 @@
+package github.rikacelery.v3.utils
+
+import io.ktor.client.HttpClient
+
+interface HttpClientProvider {
+    fun direct(key: String, http1: Boolean = false, expectSuccess: Boolean = true): HttpClient
+    fun proxied(key: String, http1: Boolean = false, expectSuccess: Boolean = true): HttpClient
+}
+
+object DefaultHttpClientProvider : HttpClientProvider {
+    override fun direct(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient =
+        ClientManager.getClient(key, http1, expectSuccess)
+
+    override fun proxied(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient =
+        ClientManager.getProxiedClient(key, http1, expectSuccess)
+}

--- a/src/test/kotlin/github/rikacelery/v3/api/ApiClientTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/api/ApiClientTest.kt
@@ -18,13 +18,21 @@ class ApiClientTest {
 
     @Test
     fun `api clients keep platform hosts independent`() {
-        val first = ApiClient(listOf("first.example.com"))
+        val firstHosts = mutableListOf(
+            " first.example.com/ ",
+            "first.example.com",
+            " backup.example.com// "
+        )
+        val first = ApiClient(firstHosts)
         val second = ApiClient(listOf("second.example.com"))
 
-        first.applyHosts(listOf("first-mirror.example.com"))
+        firstHosts.clear()
+        firstHosts += "caller-mutated.example.com"
+        second.applyHosts(listOf("second-mirror.example.com"))
 
-        assertEquals(listOf("first-mirror.example.com"), first.platformHosts)
-        assertEquals(listOf("second.example.com"), second.platformHosts)
+        assertEquals(listOf("first.example.com", "backup.example.com"), first.platformHosts)
+        assertEquals(listOf("second-mirror.example.com"), second.platformHosts)
+        assertEquals(listOf(ApiClient.DEFAULT_PLATFORM_HOST), ApiClient(emptyList()).platformHosts)
     }
 
     @Test
@@ -38,26 +46,29 @@ class ApiClientTest {
                 headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
             )
         })
-        var proxiedRequest: Triple<String, Boolean, Boolean>? = null
-        val provider = object : HttpClientProvider {
-            override fun direct(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient =
-                error("direct client not expected")
+        try {
+            var proxiedRequest: Triple<String, Boolean, Boolean>? = null
+            val provider = object : HttpClientProvider {
+                override fun direct(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient =
+                    error("direct client not expected")
 
-            override fun proxied(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient {
-                proxiedRequest = Triple(key, http1, expectSuccess)
-                return mockClient
+                override fun proxied(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient {
+                    proxiedRequest = Triple(key, http1, expectSuccess)
+                    return mockClient
+                }
             }
-        }
-        val client = ApiClient(
-            initialHosts = listOf("platform.test"),
-            httpClientProvider = provider,
-            baseUrlBuilder = { host -> "http://$host:18080" }
-        )
+            val client = ApiClient(
+                initialHosts = listOf("platform.test"),
+                httpClientProvider = provider,
+                baseUrlBuilder = { host -> "http://$host:18080" }
+            )
 
-        assertEquals("guest-token", client.fetchGuestWsToken())
-        assertEquals(Triple("api", true, false), proxiedRequest)
-        assertEquals("http://platform.test:18080/api/front/v3/config/initial", requestedUrl)
-        mockClient.close()
+            assertEquals("guest-token", client.fetchGuestWsToken())
+            assertEquals(Triple("api", true, false), proxiedRequest)
+            assertEquals("http://platform.test:18080/api/front/v3/config/initial", requestedUrl)
+        } finally {
+            mockClient.close()
+        }
     }
 
     @Test

--- a/src/test/kotlin/github/rikacelery/v3/api/ApiClientTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/api/ApiClientTest.kt
@@ -2,10 +2,63 @@ package github.rikacelery.v3.api
 
 import github.rikacelery.v3.exceptions.DeletedException
 import github.rikacelery.v3.exceptions.RenameException
+import github.rikacelery.v3.utils.HttpClientProvider
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.test.*
 
 class ApiClientTest {
+
+    @Test
+    fun `api clients keep platform hosts independent`() {
+        val first = ApiClient(listOf("first.example.com"))
+        val second = ApiClient(listOf("second.example.com"))
+
+        first.applyHosts(listOf("first-mirror.example.com"))
+
+        assertEquals(listOf("first-mirror.example.com"), first.platformHosts)
+        assertEquals(listOf("second.example.com"), second.platformHosts)
+    }
+
+    @Test
+    fun `guest token request uses injected network boundary`() = runTest {
+        var requestedUrl = ""
+        val mockClient = HttpClient(MockEngine { request ->
+            requestedUrl = request.url.toString()
+            respond(
+                content = """{"initial":{"client":{"websocket":{"token":"guest-token"}}}}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        })
+        var proxiedRequest: Triple<String, Boolean, Boolean>? = null
+        val provider = object : HttpClientProvider {
+            override fun direct(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient =
+                error("direct client not expected")
+
+            override fun proxied(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient {
+                proxiedRequest = Triple(key, http1, expectSuccess)
+                return mockClient
+            }
+        }
+        val client = ApiClient(
+            initialHosts = listOf("platform.test"),
+            httpClientProvider = provider,
+            baseUrlBuilder = { host -> "http://$host:18080" }
+        )
+
+        assertEquals("guest-token", client.fetchGuestWsToken())
+        assertEquals(Triple("api", true, false), proxiedRequest)
+        assertEquals("http://platform.test:18080/api/front/v3/config/initial", requestedUrl)
+        mockClient.close()
+    }
 
     @Test
     fun `404 rename description throws RenameException with new name`() {

--- a/src/test/kotlin/github/rikacelery/v3/components/ConfigComponentTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/ConfigComponentTest.kt
@@ -1,5 +1,6 @@
 package github.rikacelery.v3.components
 
+import github.rikacelery.v3.api.ApiClient
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
 import github.rikacelery.v3.data.HostsConfig
@@ -37,7 +38,7 @@ class ConfigComponentTest {
             configPath = configPath.absolutePath
         )
         val bus = EventBus()
-        val comp = ConfigComponent(config, bus, this)
+        val comp = ConfigComponent(config, ApiClient(config.hosts.platformHosts), bus, this)
         // RequestBus must use backgroundScope so its subscriber coroutine
         // gets cancelled at test end, avoiding UncompletedCoroutinesError
         val rb = RequestBus(bus, backgroundScope)
@@ -110,7 +111,7 @@ class ConfigComponentTest {
             configPath = configPath.absolutePath
         )
         val bus = EventBus()
-        val comp1 = ConfigComponent(config, bus, this)
+        val comp1 = ConfigComponent(config, ApiClient(config.hosts.platformHosts), bus, this)
         comp1.start()
         val rb1 = RequestBus(bus, backgroundScope)
         rb1.request<ConfigResponse>(ToggleMask)
@@ -118,7 +119,7 @@ class ConfigComponentTest {
         // give async IO save time to complete
         delay(300)
 
-        val comp2 = ConfigComponent(config, bus, this)
+        val comp2 = ConfigComponent(config, ApiClient(config.hosts.platformHosts), bus, this)
         comp2.start()
         val rb2 = RequestBus(bus, backgroundScope)
         val mask = rb2.request<ConfigResponse>(GetMaskStatus)
@@ -140,7 +141,7 @@ class ConfigComponentTest {
             configPath = configPath.absolutePath
         )
         val bus = EventBus()
-        val comp = ConfigComponent(config, bus, this)
+        val comp = ConfigComponent(config, ApiClient(config.hosts.platformHosts), bus, this)
         comp.start()
 
         // give async IO save time to complete
@@ -165,7 +166,7 @@ class ConfigComponentTest {
             configPath = configPath.absolutePath
         )
         val bus = EventBus()
-        val comp = ConfigComponent(config, bus, this)
+        val comp = ConfigComponent(config, ApiClient(config.hosts.platformHosts), bus, this)
         comp.start()
         val rb = RequestBus(bus, backgroundScope)
 

--- a/src/test/kotlin/github/rikacelery/v3/components/HttpRoutesTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/HttpRoutesTest.kt
@@ -1,0 +1,131 @@
+package github.rikacelery.v3.components
+
+import github.rikacelery.v3.core.EventBus
+import github.rikacelery.v3.core.RequestBus
+import github.rikacelery.v3.data.Room
+import github.rikacelery.v3.events.ActivateRecordingCmd
+import github.rikacelery.v3.events.AddRoom
+import github.rikacelery.v3.events.CommandAck
+import github.rikacelery.v3.events.CommandEnvelope
+import github.rikacelery.v3.events.DeactivateCmd
+import github.rikacelery.v3.events.GetRooms
+import github.rikacelery.v3.events.OkResponse
+import github.rikacelery.v3.events.RoomNameResponse
+import github.rikacelery.v3.hooks.EventHook
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Exercises the production control routes through Ktor's test host, so route wiring,
+ * command ordering, and injected delays are covered without opening a real socket.
+ */
+class HttpRoutesTest {
+
+    @Test
+    fun `active add issues AddRoom before ActivateRecordingCmd`() = testApplication {
+        val harness = RouteHarness()
+        try {
+            harness.eventBus.installHook(object : EventHook {
+                override suspend fun intercept(event: Any): Any? {
+                    if (event is CommandEnvelope) {
+                        harness.commands += event.command
+                        when (val cmd = event.command) {
+                            is AddRoom -> harness.eventBus.publish(
+                                CommandAck(event.id, RoomNameResponse(cmd.name))
+                            )
+
+                            is GetRooms -> harness.eventBus.publish(
+                                CommandAck(event.id, listOf(harness.room))
+                            )
+
+                            else -> harness.eventBus.publish(CommandAck(event.id, OkResponse))
+                        }
+                    }
+                    return event
+                }
+            })
+            application { harness.server.installApplication(this, stopEngine = {}) }
+
+            val response = client.get("/add?name=model&active=true")
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals("Room added: model", response.bodyAsText())
+            assertEquals(
+                listOf(AddRoom::class, GetRooms::class, ActivateRecordingCmd::class),
+                harness.commands.map { it::class }
+            )
+            assertTrue(
+                harness.commands.indexOfFirst { it is AddRoom } <
+                    harness.commands.indexOfFirst { it is ActivateRecordingCmd }
+            )
+        } finally {
+            harness.close()
+        }
+    }
+
+    @Test
+    fun `restart deactivates then reactivates using injected delay`() = testApplication {
+        val harness = RouteHarness(restartDelay = 1.milliseconds)
+        try {
+            harness.eventBus.installHook(object : EventHook {
+                override suspend fun intercept(event: Any): Any? {
+                    if (event is CommandEnvelope) {
+                        harness.commands += event.command
+                        harness.eventBus.publish(CommandAck(event.id, OkResponse))
+                    }
+                    return event
+                }
+            })
+            application { harness.server.installApplication(this, stopEngine = {}) }
+
+            val response = client.get("/restart?id=1001")
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals("Restarted", response.bodyAsText())
+            assertEquals(listOf(DeactivateCmd::class, ActivateRecordingCmd::class), harness.commands.map { it::class })
+        } finally {
+            harness.close()
+        }
+    }
+
+    private class RouteHarness(restartDelay: Duration = 500.milliseconds) {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val eventBus = EventBus()
+        val requestBus = RequestBus(eventBus, scope)
+        val commands = CopyOnWriteArrayList<Any>()
+        val room = Room(
+            id = 1001,
+            name = "model",
+            quality = "highest",
+            timeLimit = Duration.INFINITE,
+            sizeLimitBytes = 0,
+            lastSeen = null,
+            status = "off"
+        )
+        val server = HttpServerComponent(
+            port = 0,
+            eventBus = eventBus,
+            requestBus = requestBus,
+            metricComponent = MetricComponent(eventBus, scope),
+            postProcessorComponent = PostProcessorComponent(eventBus, scope),
+            scope = scope,
+            restartDelay = restartDelay
+        )
+
+        fun close() {
+            scope.cancel()
+        }
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/components/HttpRoutesTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/HttpRoutesTest.kt
@@ -3,6 +3,7 @@ package github.rikacelery.v3.components
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
 import github.rikacelery.v3.data.Room
+import github.rikacelery.v3.data.RuntimeTuning
 import github.rikacelery.v3.events.ActivateRecordingCmd
 import github.rikacelery.v3.events.AddRoom
 import github.rikacelery.v3.events.CommandAck
@@ -77,7 +78,7 @@ class HttpRoutesTest {
 
     @Test
     fun `restart deactivates then reactivates using injected delay`() = testApplication {
-        val harness = RouteHarness(restartDelay = 1.milliseconds)
+        val harness = RouteHarness(RuntimeTuning(httpRestartDelay = 1.milliseconds))
         try {
             harness.eventBus.installHook(object : EventHook {
                 override suspend fun intercept(event: Any): Any? {
@@ -100,7 +101,7 @@ class HttpRoutesTest {
         }
     }
 
-    private class RouteHarness(restartDelay: Duration = 500.milliseconds) {
+    private class RouteHarness(runtimeTuning: RuntimeTuning = RuntimeTuning()) {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val eventBus = EventBus()
         val requestBus = RequestBus(eventBus, scope)
@@ -121,7 +122,7 @@ class HttpRoutesTest {
             metricComponent = MetricComponent(eventBus, scope),
             postProcessorComponent = PostProcessorComponent(eventBus, scope),
             scope = scope,
-            restartDelay = restartDelay
+            runtimeTuning = runtimeTuning
         )
 
         fun close() {

--- a/src/test/kotlin/github/rikacelery/v3/components/RoomComponentTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/RoomComponentTest.kt
@@ -3,6 +3,7 @@ package github.rikacelery.v3.components
 import github.rikacelery.v3.api.ApiClient
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
+import github.rikacelery.v3.data.RuntimeTuning
 import github.rikacelery.v3.events.CommandAck
 import github.rikacelery.v3.events.CommandEnvelope
 import github.rikacelery.v3.events.OkResponse
@@ -57,7 +58,7 @@ class RoomComponentTest {
             requestBus = requestBus,
             eventBus = eventBus,
             parentScope = backgroundScope,
-            refreshInterval = Duration.INFINITE,
+            runtimeTuning = RuntimeTuning(roomPollInterval = Duration.INFINITE),
             roomStatusFetcher = { roomName ->
                 mockServer.get("https://mock.platform/broadcasts/$roomName").bodyAsText()
                     .substringAfter("\"status\":\"").substringBefore('"')

--- a/src/test/kotlin/github/rikacelery/v3/components/RoomComponentTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/RoomComponentTest.kt
@@ -52,7 +52,7 @@ class RoomComponentTest {
         })
 
         val component = RoomComponent(
-            apiClient = ApiClient,
+            apiClient = ApiClient(),
             listConfPath = Files.createTempFile("xhrec-room-test", ".conf").toString(),
             requestBus = requestBus,
             eventBus = eventBus,

--- a/src/test/kotlin/github/rikacelery/v3/components/RuntimeInjectionTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/RuntimeInjectionTest.kt
@@ -1,0 +1,389 @@
+package github.rikacelery.v3.components
+
+import github.rikacelery.v3.api.ApiClient
+import github.rikacelery.v3.core.DataChannel
+import github.rikacelery.v3.core.EventBus
+import github.rikacelery.v3.core.RequestBus
+import github.rikacelery.v3.data.RuntimeTuning
+import github.rikacelery.v3.data.StreamData
+import github.rikacelery.v3.data.Hosts
+import github.rikacelery.v3.events.CommandAck
+import github.rikacelery.v3.events.CommandEnvelope
+import github.rikacelery.v3.events.ConfigResponse
+import github.rikacelery.v3.events.DecryptKeyMatch
+import github.rikacelery.v3.events.Download
+import github.rikacelery.v3.events.GetDecryptKey
+import github.rikacelery.v3.events.GetRoomConfig
+import github.rikacelery.v3.events.MatchDecryptKeys
+import github.rikacelery.v3.events.RoomConfigResponse
+import github.rikacelery.v3.events.Segment
+import github.rikacelery.v3.events.WsDisconnected
+import github.rikacelery.v3.hooks.EventHook
+import github.rikacelery.v3.m3u8.M3u8Parser
+import github.rikacelery.v3.utils.CdnSelector
+import github.rikacelery.v3.utils.HttpClientProvider
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RuntimeInjectionTest {
+
+    @Test
+    fun `room polling and websocket refresh use injected timing`() = runTest(UnconfinedTestDispatcher()) {
+        val requests = CopyOnWriteArrayList<String>()
+        val requestEvents = Channel<String>(Channel.UNLIMITED)
+        val client = HttpClient(MockEngine { request ->
+            requests += request.url.toString()
+            requestEvents.trySend(request.url.toString())
+            respond(
+                content = """{"item":{"status":"off"}}""",
+                headers = jsonHeaders
+            )
+        })
+        val provider = RecordingProvider(client, client)
+        val eventBus = EventBus()
+        val component = RoomComponent(
+            apiClient = ApiClient(listOf("ignored.invalid"), provider) { "http://127.0.0.1:18080" },
+            listConfPath = Files.createTempFile("xhrec-runtime-room", ".conf").toString(),
+            requestBus = RequestBus(eventBus, backgroundScope),
+            eventBus = eventBus,
+            parentScope = backgroundScope,
+            runtimeTuning = RuntimeTuning(
+                roomPollInterval = 20.milliseconds,
+                roomRefreshDebounce = 5.milliseconds
+            )
+        )
+
+        try {
+            component.internalAdd(7, "model", "highest", Duration.INFINITE, 0, false, false)
+            component.start()
+            runCurrent()
+            assertEquals("http://127.0.0.1:18080/api/front/v1/broadcasts/model", requestEvents.receive())
+            assertEquals(1, requests.size)
+
+            advanceTimeBy(19)
+            runCurrent()
+            assertEquals(1, requests.size)
+            advanceTimeBy(1)
+            runCurrent()
+            requestEvents.receive()
+            assertEquals(2, requests.size)
+
+            eventBus.publish(WsDisconnected)
+            runCurrent()
+            advanceTimeBy(4)
+            runCurrent()
+            assertEquals(2, requests.size)
+            advanceTimeBy(1)
+            runCurrent()
+            requestEvents.receive()
+            assertEquals(3, requests.size)
+            assertTrue(requests.all { it == "http://127.0.0.1:18080/api/front/v1/broadcasts/model" })
+        } finally {
+            component.stop()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `live events use injected websocket client url and reconnect timing`() = runTest {
+        val client = HttpClient(MockEngine {
+            respond("unavailable", HttpStatusCode.ServiceUnavailable)
+        })
+        val provider = RecordingProvider(client, client)
+        val oldHosts = Hosts.current
+        Hosts.current = oldHosts.copy(webSocketHosts = listOf("ws.injected.test"))
+        val builtFor = CopyOnWriteArrayList<String>()
+        val builtUrls = CopyOnWriteArrayList<String>()
+        val component = LiveEventSource(
+            tokenProvider = { "token" },
+            eventBus = EventBus(),
+            parentScope = backgroundScope,
+            wsPoolCount = 1,
+            httpClientProvider = provider,
+            runtimeTuning = RuntimeTuning(
+                webSocketReconnectInitial = 2.milliseconds,
+                webSocketReconnectMax = 3.milliseconds
+            ),
+            wsUrlBuilder = { host ->
+                builtFor += host
+                "ws://127.0.0.1:18081/connection/websocket?source=$host".also(builtUrls::add)
+            }
+        )
+
+        try {
+            component.start()
+            runCurrent()
+            assertEquals(listOf("event_0"), provider.proxiedCalls.map { it.key })
+            assertEquals(listOf("ws.injected.test"), builtFor)
+            advanceTimeBy(1)
+            runCurrent()
+            assertEquals(1, provider.proxiedCalls.size)
+            advanceTimeBy(1)
+            runCurrent()
+            assertEquals(2, provider.proxiedCalls.size)
+            assertEquals(listOf("ws.injected.test", "ws.injected.test"), builtFor)
+            assertEquals(
+                listOf(
+                    "ws://127.0.0.1:18081/connection/websocket?source=ws.injected.test",
+                    "ws://127.0.0.1:18081/connection/websocket?source=ws.injected.test"
+                ),
+                builtUrls
+            )
+        } finally {
+            component.stop()
+            Hosts.current = oldHosts
+            client.close()
+        }
+    }
+
+    @Test
+    fun `scheduler uses injected clients and master candidates`() = runBlocking {
+        val testScope = CoroutineScope(coroutineContext + SupervisorJob())
+        val requests = CopyOnWriteArrayList<String>()
+        val client = HttpClient(MockEngine { request ->
+            val url = request.url.toString()
+            requests += url
+            when {
+                url.endsWith("/api/front/v1/broadcasts/model") -> respond(
+                    """{"item":{"status":"public"}}""",
+                    headers = jsonHeaders
+                )
+                url.startsWith("http://127.0.0.1:18082/master/") -> respond(
+                    """
+                        #EXTM3U
+                        #EXT-X-MOUFLON:PSCH:key-id
+                        #EXT-X-STREAM-INF:BANDWIDTH=1000,RESOLUTION=640x360,FRAME-RATE=30
+                        http://127.0.0.1:18082/media/model.m3u8
+                    """.trimIndent()
+                )
+                request.url.encodedPath == "/media/model.m3u8" -> respond("#EXTM3U")
+                else -> error("unexpected request $url")
+            }
+        })
+        val provider = RecordingProvider(client, client)
+        val eventBus = EventBus()
+        installRequestAnswers(eventBus)
+        val requestBus = RequestBus(eventBus, testScope)
+        val dataChannel = DataChannel()
+        val downloader = DownloaderComponent(dataChannel, eventBus = eventBus, parentScope = testScope)
+        val session = SessionComponent(dataChannel, downloader, M3u8Parser, requestBus, eventBus, testScope)
+        val candidateArgs = CopyOnWriteArrayList<Triple<Long, String, String?>>()
+        val scheduler = SchedulerComponent(
+            requestBus = requestBus,
+            sessionComponent = session,
+            apiClient = ApiClient(listOf("ignored.invalid"), provider) { "http://127.0.0.1:18082" },
+            streamAuthKey = "fallback-key",
+            eventBus = eventBus,
+            parentScope = testScope,
+            httpClientProvider = provider,
+            runtimeTuning = RuntimeTuning(preconfigRetryInterval = 4.milliseconds),
+            masterUrlCandidates = { roomId, pkey, token ->
+                candidateArgs += Triple(roomId, pkey, token)
+                listOf("http://127.0.0.1:18082/master/$roomId?pkey=$pkey&token=${token.orEmpty()}")
+            }
+        )
+        val entry = SchedulerEntry(7, "model", scheduler).apply { pkey = "room-key" }
+        val oldCdnHosts = CdnSelector.hosts
+        CdnSelector.updateHosts(emptyList())
+
+        try {
+            yield()
+            val result = entry.preconfigSignal()
+
+            assertEquals(SchedulerEvent.PreconfigDone, assertIs<SchedulerSignal>(result).event)
+            assertEquals(listOf(Triple<Long, String, String?>(7L, "room-key", "")), candidateArgs)
+            assertTrue(provider.proxiedCalls.any { it.key == "master_7" })
+            assertTrue(provider.proxiedCalls.any { it.key == "preconfig_7" })
+            assertTrue(requests.all { it.startsWith("http://127.0.0.1:18082/") })
+            assertTrue(requests.any { it == "http://127.0.0.1:18082/master/7?pkey=room-key&token=" })
+            assertTrue(requests.any { it == "http://127.0.0.1:18082/media/model.m3u8?psch=v2&pkey=key-id" })
+        } finally {
+            entry.scope.cancel()
+            testScope.cancel()
+            CdnSelector.updateHosts(oldCdnHosts)
+            client.close()
+        }
+    }
+
+    @Test
+    fun `session uses injected playlist client poll interval and fetch timeout`() = runTest(UnconfinedTestDispatcher()) {
+        val requests = CopyOnWriteArrayList<String>()
+        val requestEvents = Channel<String>(Channel.UNLIMITED)
+        val client = HttpClient(MockEngine { request ->
+            requests += request.url.toString()
+            requestEvents.trySend(request.url.toString())
+            respond("#EXTM3U\n#EXT-X-MAP:URI=\"http://127.0.0.1:18083/init.mp4\"")
+        })
+        val provider = RecordingProvider(client, client)
+        val eventBus = EventBus()
+        installRequestAnswers(eventBus)
+        val requestBus = RequestBus(eventBus, backgroundScope)
+        val dataChannel = DataChannel()
+        val downloader = DownloaderComponent(dataChannel, eventBus = eventBus, parentScope = backgroundScope)
+        val session = SessionComponent(
+            dataChannel,
+            downloader,
+            M3u8Parser,
+            requestBus,
+            eventBus,
+            backgroundScope,
+            httpClientProvider = provider,
+            runtimeTuning = RuntimeTuning(
+                playlistPollInterval = 6.milliseconds,
+                playlistFetchTimeout = 50.milliseconds
+            )
+        )
+
+        val entry = SessionEntry(9, "model", session).apply {
+            playlistUrl = "http://127.0.0.1:18083/live.m3u8"
+            pkey = "key-id"
+            quality = "360p"
+        }
+
+        try {
+            entry.fsm.drive(RecordingEvent.StartRecording)
+            runCurrent()
+            assertEquals("http://127.0.0.1:18083/live.m3u8", requestEvents.receive())
+            assertEquals(1, requests.size)
+            advanceTimeBy(5)
+            runCurrent()
+            assertEquals(1, requests.size)
+            advanceTimeBy(1)
+            runCurrent()
+            requestEvents.receive()
+            assertEquals(2, requests.size)
+            assertTrue(provider.proxiedCalls.all { it.key == "m3u8_9" })
+            assertTrue(requests.all { it == "http://127.0.0.1:18083/live.m3u8" })
+        } finally {
+            entry.scope.cancel()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `downloader uses injected direct proxy and probe clients with short race timing`() = runTest {
+        val directRequests = CopyOnWriteArrayList<Pair<HttpMethod, String>>()
+        val proxyRequests = CopyOnWriteArrayList<String>()
+        val direct = HttpClient(MockEngine { request ->
+            directRequests += request.method to request.url.toString()
+            if (request.method == HttpMethod.Get) delay(20.milliseconds)
+            respond("direct")
+        })
+        val proxied = HttpClient(MockEngine { request ->
+            proxyRequests += request.url.toString()
+            respond("proxy")
+        })
+        val provider = RecordingProvider(direct, proxied)
+        val eventBus = EventBus()
+        val dataChannel = DataChannel()
+        val oldCdnHosts = CdnSelector.hosts
+        CdnSelector.updateHosts(listOf("127.0.0.1", "127.0.0.2"))
+        val downloader = DownloaderComponent(
+            dataChannel,
+            eventBus = eventBus,
+            parentScope = backgroundScope,
+            httpClientProvider = provider,
+            runtimeTuning = RuntimeTuning(
+                downloaderRaceDelay = 2.milliseconds,
+                downloaderAttemptTimeout = 100.milliseconds,
+                downloaderDeadline = 200.milliseconds,
+                downloaderStallTimeout = 50.milliseconds,
+                downloaderRetryBackoff = 1.milliseconds
+            )
+        )
+
+        try {
+            downloader.start()
+            val received = async { dataChannel.receive() }
+            downloader.tell(DoDownload(Download(11, listOf(Segment("http://127.0.0.1/segment.mp4", 1)), 0, 99)))
+            advanceUntilIdle()
+
+            val stream = assertIs<StreamData>(received.await())
+            assertEquals("proxy", stream.data.decodeToString())
+            assertTrue(provider.directCalls.any { it.key.startsWith("dl_") })
+            assertTrue(provider.directCalls.any { it.key.startsWith("probe_") })
+            assertTrue(provider.proxiedCalls.any { it.key.startsWith("px_") })
+            assertTrue((directRequests.map { it.second } + proxyRequests).all { it.startsWith("http://127.0.0.") })
+        } finally {
+            downloader.stop()
+            CdnSelector.updateHosts(oldCdnHosts)
+            direct.close()
+            proxied.close()
+        }
+    }
+
+    private fun installRequestAnswers(eventBus: EventBus) {
+        eventBus.installHook(object : EventHook {
+            override suspend fun intercept(event: Any): Any? {
+                if (event is CommandEnvelope) {
+                    val answer = when (event.command) {
+                        is GetRoomConfig -> RoomConfigResponse("highest", Duration.INFINITE, 0, pkey = "room-key")
+                        is MatchDecryptKeys -> DecryptKeyMatch("key-id", "decrypt-key")
+                        is GetDecryptKey -> ConfigResponse("decrypt-key")
+                        else -> null
+                    }
+                    if (answer != null) eventBus.publish(CommandAck(event.id, answer))
+                }
+                return event
+            }
+        })
+    }
+
+    private data class ClientCall(
+        val key: String,
+        val http1: Boolean,
+        val expectSuccess: Boolean
+    )
+
+    private class RecordingProvider(
+        private val directClient: HttpClient,
+        private val proxiedClient: HttpClient
+    ) : HttpClientProvider {
+        val directCalls = CopyOnWriteArrayList<ClientCall>()
+        val proxiedCalls = CopyOnWriteArrayList<ClientCall>()
+
+        override fun direct(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient {
+            directCalls += ClientCall(key, http1, expectSuccess)
+            return directClient
+        }
+
+        override fun proxied(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient {
+            proxiedCalls += ClientCall(key, http1, expectSuccess)
+            return proxiedClient
+        }
+    }
+
+    private companion object {
+        val jsonHeaders = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/components/SchedulerRoomRemovalTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/SchedulerRoomRemovalTest.kt
@@ -29,7 +29,7 @@ class SchedulerRoomRemovalTest {
         val dataChannel = DataChannel()
         val downloader = DownloaderComponent(dataChannel, eventBus = eventBus, parentScope = backgroundScope)
         val session = SessionComponent(dataChannel, downloader, M3u8Parser, requestBus, eventBus, backgroundScope)
-        val scheduler = SchedulerComponent(requestBus, session, ApiClient, "streamKey", eventBus, backgroundScope)
+        val scheduler = SchedulerComponent(requestBus, session, ApiClient(), "streamKey", eventBus, backgroundScope)
         scheduler.start()
         advanceUntilIdle()
 

--- a/src/test/kotlin/github/rikacelery/v3/components/WriterSmallFileTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/WriterSmallFileTest.kt
@@ -1,0 +1,119 @@
+package github.rikacelery.v3.components
+
+import github.rikacelery.v3.core.DataChannel
+import github.rikacelery.v3.core.EventBus
+import github.rikacelery.v3.data.DownloadMeta
+import github.rikacelery.v3.data.StreamData
+import github.rikacelery.v3.data.StreamEnd
+import github.rikacelery.v3.data.StreamStart
+import github.rikacelery.v3.events.EndReason
+import github.rikacelery.v3.events.FileReady
+import github.rikacelery.v3.hooks.EventHook
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.time.Instant
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WriterSmallFileTest {
+
+    @Test
+    fun `zero threshold retains short textual recording with exact bytes`() = runTest(UnconfinedTestDispatcher()) {
+        val input = "short recording".toByteArray()
+        val tmpDir = Files.createTempDirectory("writer-small-file-").toFile()
+        val (eventBus, published) = setupEventCapture()
+        val dataChannel = DataChannel()
+        val writer = WriterComponent(
+            dataChannel = dataChannel,
+            tmpDir = tmpDir,
+            eventBus = eventBus,
+            parentScope = this,
+            minOutputBytes = 0
+        )
+        writer.start()
+
+        try {
+            sendRecording(dataChannel, input)
+            advanceUntilIdle()
+            awaitWriter()
+
+            val ready = published.filterIsInstance<FileReady>().single()
+            assertContentEquals(input, ready.file.readBytes())
+        } finally {
+            writer.stop()
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `default threshold deletes 1023 byte recording without publishing`() = runTest(UnconfinedTestDispatcher()) {
+        val tmpDir = Files.createTempDirectory("writer-small-file-").toFile()
+        val eventBus = EventBus()
+        val published = mutableListOf<Any>()
+        eventBus.installHook(object : EventHook {
+            override suspend fun intercept(event: Any): Any {
+                published += event
+                return event
+            }
+        })
+        val dataChannel = DataChannel()
+        val writer = WriterComponent(
+            dataChannel = dataChannel,
+            tmpDir = tmpDir,
+            eventBus = eventBus,
+            parentScope = this,
+            minOutputBytes = 1024
+        )
+        writer.start()
+
+        try {
+            sendRecording(dataChannel, ByteArray(1023) { it.toByte() })
+            advanceUntilIdle()
+            awaitWriter()
+
+            assertTrue(published.none { it is FileReady })
+            assertEquals(emptyList(), tmpDir.listFiles()?.toList() ?: emptyList())
+        } finally {
+            writer.stop()
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    private fun setupEventCapture(): Pair<EventBus, MutableList<Any>> {
+        val eventBus = EventBus()
+        val published = mutableListOf<Any>()
+        eventBus.installHook(object : EventHook {
+            override suspend fun intercept(event: Any): Any {
+                published += event
+                return event
+            }
+        })
+        return eventBus to published
+    }
+
+    private suspend fun sendRecording(dataChannel: DataChannel, input: ByteArray) {
+        val startTime = Instant.parse("2026-01-01T00:00:00Z")
+        dataChannel.send(StreamStart(1, "room", startTime, "highest"))
+        dataChannel.send(
+            StreamData(
+                roomId = 1,
+                data = input,
+                segmentIndex = 0,
+                meta = DownloadMeta("test", 0, false, startTime)
+            )
+        )
+        dataChannel.send(StreamEnd(1, EndReason.StreamEnd))
+    }
+
+    private suspend fun awaitWriter() {
+        withContext(Dispatchers.IO) { Thread.sleep(100) }
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/components/WriterSmallFileTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/WriterSmallFileTest.kt
@@ -9,9 +9,8 @@ import github.rikacelery.v3.data.StreamStart
 import github.rikacelery.v3.events.EndReason
 import github.rikacelery.v3.events.FileReady
 import github.rikacelery.v3.hooks.EventHook
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -29,7 +28,7 @@ class WriterSmallFileTest {
     fun `zero threshold retains short textual recording with exact bytes`() = runTest(UnconfinedTestDispatcher()) {
         val input = "short recording".toByteArray()
         val tmpDir = Files.createTempDirectory("writer-small-file-").toFile()
-        val (eventBus, published) = setupEventCapture()
+        val (eventBus, published, ready) = setupEventCapture(1)
         val dataChannel = DataChannel()
         val writer = WriterComponent(
             dataChannel = dataChannel,
@@ -43,10 +42,9 @@ class WriterSmallFileTest {
         try {
             sendRecording(dataChannel, input)
             advanceUntilIdle()
-            awaitWriter()
 
-            val ready = published.filterIsInstance<FileReady>().single()
-            assertContentEquals(input, ready.file.readBytes())
+            assertContentEquals(input, ready.await().file.readBytes())
+            assertEquals(1, published.filterIsInstance<FileReady>().single().roomId)
         } finally {
             writer.stop()
             tmpDir.deleteRecursively()
@@ -56,64 +54,62 @@ class WriterSmallFileTest {
     @Test
     fun `default threshold deletes 1023 byte recording without publishing`() = runTest(UnconfinedTestDispatcher()) {
         val tmpDir = Files.createTempDirectory("writer-small-file-").toFile()
-        val eventBus = EventBus()
-        val published = mutableListOf<Any>()
-        eventBus.installHook(object : EventHook {
-            override suspend fun intercept(event: Any): Any {
-                published += event
-                return event
-            }
-        })
+        val (eventBus, published, roomTwoReady) = setupEventCapture(2)
         val dataChannel = DataChannel()
         val writer = WriterComponent(
             dataChannel = dataChannel,
             tmpDir = tmpDir,
             eventBus = eventBus,
             parentScope = this,
-            minOutputBytes = 1024
         )
         writer.start()
 
         try {
             sendRecording(dataChannel, ByteArray(1023) { it.toByte() })
+            sendRecording(dataChannel, ByteArray(1024) { it.toByte() }, roomId = 2, roomName = "room-two")
             advanceUntilIdle()
-            awaitWriter()
+            roomTwoReady.await()
 
-            assertTrue(published.none { it is FileReady })
-            assertEquals(emptyList(), tmpDir.listFiles()?.toList() ?: emptyList())
+            assertTrue(published.filterIsInstance<FileReady>().none { it.roomId == 1L })
+            assertTrue(tmpDir.listFiles()?.none { it.name.startsWith("room-2026-01-01-080000") } ?: true)
         } finally {
             writer.stop()
             tmpDir.deleteRecursively()
         }
     }
 
-    private fun setupEventCapture(): Pair<EventBus, MutableList<Any>> {
+    private fun setupEventCapture(targetRoomId: Long): Triple<EventBus, MutableList<Any>, CompletableDeferred<FileReady>> {
         val eventBus = EventBus()
         val published = mutableListOf<Any>()
+        val targetReady = CompletableDeferred<FileReady>()
         eventBus.installHook(object : EventHook {
             override suspend fun intercept(event: Any): Any {
                 published += event
+                if (event is FileReady && event.roomId == targetRoomId) {
+                    targetReady.complete(event)
+                }
                 return event
             }
         })
-        return eventBus to published
+        return Triple(eventBus, published, targetReady)
     }
 
-    private suspend fun sendRecording(dataChannel: DataChannel, input: ByteArray) {
+    private suspend fun sendRecording(
+        dataChannel: DataChannel,
+        input: ByteArray,
+        roomId: Long = 1,
+        roomName: String = "room"
+    ) {
         val startTime = Instant.parse("2026-01-01T00:00:00Z")
-        dataChannel.send(StreamStart(1, "room", startTime, "highest"))
+        dataChannel.send(StreamStart(roomId, roomName, startTime, "highest"))
         dataChannel.send(
             StreamData(
-                roomId = 1,
+                roomId = roomId,
                 data = input,
                 segmentIndex = 0,
                 meta = DownloadMeta("test", 0, false, startTime)
             )
         )
-        dataChannel.send(StreamEnd(1, EndReason.StreamEnd))
-    }
-
-    private suspend fun awaitWriter() {
-        withContext(Dispatchers.IO) { Thread.sleep(100) }
+        dataChannel.send(StreamEnd(roomId, EndReason.StreamEnd))
     }
 }

--- a/src/test/kotlin/github/rikacelery/v3/components/WriterSmallFileTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/WriterSmallFileTest.kt
@@ -68,10 +68,10 @@ class WriterSmallFileTest {
             sendRecording(dataChannel, ByteArray(1023) { it.toByte() })
             sendRecording(dataChannel, ByteArray(1024) { it.toByte() }, roomId = 2, roomName = "room-two")
             advanceUntilIdle()
-            roomTwoReady.await()
+            val roomTwoFile = roomTwoReady.await().file
 
             assertTrue(published.filterIsInstance<FileReady>().none { it.roomId == 1L })
-            assertTrue(tmpDir.listFiles()?.none { it.name.startsWith("room-2026-01-01-080000") } ?: true)
+            assertEquals(setOf(roomTwoFile), tmpDir.listFiles()?.toSet() ?: emptySet())
         } finally {
             writer.stop()
             tmpDir.deleteRecursively()

--- a/src/test/kotlin/github/rikacelery/v3/components/WriterSmallFileTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/WriterSmallFileTest.kt
@@ -8,6 +8,7 @@ import github.rikacelery.v3.data.StreamEnd
 import github.rikacelery.v3.data.StreamStart
 import github.rikacelery.v3.events.EndReason
 import github.rikacelery.v3.events.FileReady
+import github.rikacelery.v3.events.WriterFatal
 import github.rikacelery.v3.hooks.EventHook
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.CompletableDeferred
@@ -70,6 +71,7 @@ class WriterSmallFileTest {
             advanceUntilIdle()
             val roomTwoFile = roomTwoReady.await().file
 
+            assertTrue(published.none { it is WriterFatal })
             assertTrue(published.filterIsInstance<FileReady>().none { it.roomId == 1L })
             assertEquals(setOf(roomTwoFile), tmpDir.listFiles()?.toSet() ?: emptySet())
         } finally {

--- a/src/test/kotlin/github/rikacelery/v3/core/OrderedEmitterTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/core/OrderedEmitterTest.kt
@@ -3,7 +3,9 @@ package github.rikacelery.v3.core
 import github.rikacelery.v3.data.*
 import github.rikacelery.v3.events.CutPoint
 import github.rikacelery.v3.events.EndReason
+import kotlinx.coroutines.async
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import java.time.Instant
@@ -23,6 +25,31 @@ class OrderedEmitterTest {
 
     private fun cutPoint(room: Long, reason: EndReason = EndReason.UserStop) =
         DownloadResult.CutPoint(CutPoint(room, 0, "room$room", now, reason, "highest"))
+
+    @Test
+    fun `completeAndAwait waits until a buffered cut point is emitted`() = runTest(UnconfinedTestDispatcher()) {
+        val emitted = mutableListOf<DataChannelMsg>()
+        val emitter = OrderedEmitter(42) { emitted.add(it) }
+
+        // segment 0 is still in flight, so the cut point at index 1 must stay buffered
+        var cutEmitted = false
+        val waiter = backgroundScope.async {
+            emitter.completeAndAwait(1, cutPoint(42))
+            cutEmitted = true
+        }
+        runCurrent()
+        assertEquals(0, emitted.size)
+        assertEquals(false, cutEmitted, "cut point must not be signalled while segment 0 is missing")
+
+        emitter.complete(0, success(42, 0))
+        runCurrent()
+
+        assertTrue(waiter.isCompleted, "completeAndAwait must resume once the cut point is emitted")
+        assertTrue(cutEmitted)
+        assertEquals(2, emitted.size)
+        assertTrue(emitted[1] is StreamEnd)
+        assertEquals(EndReason.UserStop, (emitted[1] as StreamEnd).reason)
+    }
 
     @Test
     fun `in-order completion emits in-order`() = runTest(UnconfinedTestDispatcher()) {

--- a/src/test/kotlin/github/rikacelery/v3/data/RuntimeTuningTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/data/RuntimeTuningTest.kt
@@ -1,0 +1,29 @@
+package github.rikacelery.v3.data
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+class RuntimeTuningTest {
+
+    @Test
+    fun `defaults preserve production timing values`() {
+        val tuning = RuntimeTuning()
+
+        assertEquals(5.minutes, tuning.roomPollInterval)
+        assertEquals(1500.milliseconds, tuning.roomRefreshDebounce)
+        assertEquals(1.seconds, tuning.webSocketReconnectInitial)
+        assertEquals(30.seconds, tuning.webSocketReconnectMax)
+        assertEquals(15.seconds, tuning.preconfigRetryInterval)
+        assertEquals(3.seconds, tuning.playlistPollInterval)
+        assertEquals(10.seconds, tuning.playlistFetchTimeout)
+        assertEquals(500.milliseconds, tuning.httpRestartDelay)
+        assertEquals(8.seconds, tuning.downloaderRaceDelay)
+        assertEquals(25.seconds, tuning.downloaderAttemptTimeout)
+        assertEquals(120.seconds, tuning.downloaderDeadline)
+        assertEquals(5.seconds, tuning.downloaderStallTimeout)
+        assertEquals(500.milliseconds, tuning.downloaderRetryBackoff)
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/data/SizeStrSerializerTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/data/SizeStrSerializerTest.kt
@@ -1,0 +1,48 @@
+package github.rikacelery.v3.data
+
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * The `/add?size=` and `/sizelimit` routes parse user input with this serializer, and
+ * [SizeStrSerializer.serialize] writes back the same two-letter binary units it must accept.
+ */
+class SizeStrSerializerTest {
+
+    @Test
+    fun `binary units parse case-insensitively`() {
+        assertEquals(1024L, SizeStrSerializer.parseSizeString("1Ki"))
+        assertEquals(1024L, SizeStrSerializer.parseSizeString("1ki"))
+        assertEquals(1024L, SizeStrSerializer.parseSizeString("1KI"))
+        assertEquals(1024L * 1024, SizeStrSerializer.parseSizeString("1Mi"))
+        assertEquals(1024L * 1024 * 1024, SizeStrSerializer.parseSizeString("1Gi"))
+        assertEquals(1024L * 1024 * 1024 * 1024, SizeStrSerializer.parseSizeString("1Ti"))
+        assertEquals(512L, SizeStrSerializer.parseSizeString("512Bi"))
+        assertEquals(2048L, SizeStrSerializer.parseSizeString("2Ki"))
+        assertEquals(0L, SizeStrSerializer.parseSizeString("0"))
+    }
+
+    @Test
+    fun `single-letter units and compounds parse`() {
+        // single letters resolve through the binary table first (K/G/M/T = Ki/Gi/Mi/Ti)
+        assertEquals(1024L, SizeStrSerializer.parseSizeString("1K"))
+        assertEquals(1024L * 1024 * 1024, SizeStrSerializer.parseSizeString("1G"))
+        assertEquals(1024L * 1024 * 1024 + 500L * 1024 * 1024, SizeStrSerializer.parseSizeString("1G500M"))
+    }
+
+    @Test
+    fun `serialized sizes round-trip through the parser`() {
+        listOf(512L, 2048L, 5L * 1024 * 1024, 3L * 1024 * 1024 * 1024).forEach { bytes ->
+            val encoded = Json.encodeToString(SizeStrSerializer, bytes).trim('"')
+            assertEquals(bytes, SizeStrSerializer.parseSizeString(encoded), "round-trip of '$encoded'")
+        }
+    }
+
+    @Test
+    fun `unknown units and missing numbers are rejected`() {
+        assertFailsWith<IllegalArgumentException> { SizeStrSerializer.parseSizeString("1Xi") }
+        assertFailsWith<IllegalArgumentException> { SizeStrSerializer.parseSizeString("Ki") }
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/integration/DownloadIntegrityIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/DownloadIntegrityIntegrationTest.kt
@@ -1,0 +1,178 @@
+package github.rikacelery.v3.integration
+
+import github.rikacelery.v3.components.SessionState
+import github.rikacelery.v3.events.FileReady
+import github.rikacelery.v3.events.SegmentDownloaded
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.delay
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Byte-exact integrity of the recording pipeline: sliding-window dedupe, init changes,
+ * permanent (404) vs transient (5xx) failures, and stall recovery all end in a file that
+ * contains exactly the expected init+segment bytes in order.
+ */
+class DownloadIntegrityIntegrationTest {
+
+    @Test
+    fun `sliding window overlaps are downloaded exactly once`() = testApplication {
+        XhrecIntegrationFixture(this).use { fx ->
+            fx.start()
+            fx.installRoutes()
+            fx.ready()
+            val room = fx.mock.addRoom(1001, "model", status = "public")
+
+            fx.get("/add?name=model&active=true").expectOk("Room added: model")
+            fx.awaitSession(1001, SessionState.Recording)
+            fx.awaitEventCount<SegmentDownloaded>(1, 15.seconds) { it.roomId == 1001L }
+
+            repeat(6) { index ->
+                room.advanceSegment()
+                fx.awaitEventCount<SegmentDownloaded>(index + 2, 20.seconds) { it.roomId == 1001L }
+            }
+
+            // several more polls see the same sliding window; dedupe must not re-fetch
+            delay(500)
+            assertEquals(
+                7,
+                fx.events.filterIsInstance<SegmentDownloaded>().count { it.roomId == 1001L },
+                "init + 6 segments, each fetched once"
+            )
+
+            fx.get("/remove?id=1001").expectOk("Removed")
+            val file = fx.awaitFile(1001)
+            assertContentEquals(fx.mock.expectedBytes(1001, room.generation, throughIndex = 6), file.readBytes())
+        }
+    }
+
+    @Test
+    fun `init change cuts the file and restarts with the new generation`() = testApplication {
+        XhrecIntegrationFixture(this).use { fx ->
+            fx.start()
+            fx.installRoutes()
+            fx.ready()
+            val room = fx.mock.addRoom(1001, "model", status = "public")
+
+            fx.get("/add?name=model&active=true").expectOk("Room added: model")
+            fx.awaitSession(1001, SessionState.Recording)
+            fx.awaitEventCount<SegmentDownloaded>(1, 15.seconds) { it.roomId == 1001L }
+            room.advanceSegment()
+            room.advanceSegment()
+            fx.awaitEventCount<SegmentDownloaded>(3, 20.seconds) { it.roomId == 1001L }
+
+            // a new init URL forces the session to close the current file
+            assertEquals(2, fx.mock.rotateInit(1001))
+            val firstFile = fx.awaitFile(1001)
+            assertContentEquals(fx.mock.expectedBytes(1001, 1, throughIndex = 2), firstFile.readBytes())
+
+            // the restarted session re-downloads the new init plus the window of generation 2
+            fx.awaitEventCount<SegmentDownloaded>(6, 20.seconds) { it.roomId == 1001L }
+            room.advanceSegment()
+            room.advanceSegment()
+            fx.awaitEventCount<SegmentDownloaded>(8, 20.seconds) { it.roomId == 1001L }
+
+            fx.get("/remove?id=1001").expectOk("Removed")
+            val files = fx.awaitEventCount<FileReady>(2, 20.seconds) { it.roomId == 1001L }
+            assertContentEquals(
+                fx.mock.expectedBytes(1001, 2, throughIndex = 4),
+                files[1].file.readBytes(),
+                "second file must use generation-2 init and segment bytes"
+            )
+        }
+    }
+
+    @Test
+    fun `404 is permanent and does not block later segments`() = testApplication {
+        XhrecIntegrationFixture(this).use { fx ->
+            fx.start()
+            fx.installRoutes()
+            fx.ready()
+            val room = fx.mock.addRoom(1001, "model", status = "public")
+
+            fx.get("/add?name=model&active=true").expectOk("Room added: model")
+            fx.awaitSession(1001, SessionState.Recording)
+            fx.awaitEventCount<SegmentDownloaded>(1, 15.seconds) { it.roomId == 1001L }
+
+            val missing = MockPayloads.segmentPath(1001, room.generation, 1)
+            fx.mock.failNext(missing, MockFault.NotFound)
+            room.advanceSegment()
+            room.advanceSegment()
+
+            // init + segment 2 only; segment 1 is gone for good
+            fx.awaitEventCount<SegmentDownloaded>(2, 20.seconds) { it.roomId == 1001L }
+            delay(500)
+            assertEquals(
+                2,
+                fx.events.filterIsInstance<SegmentDownloaded>().count { it.roomId == 1001L },
+                "the 404 segment must not be delivered"
+            )
+            val attempts = fx.mock.requests().count { it.path == missing }
+            assertTrue(attempts <= 2, "404 must not be retried on other hosts: $attempts attempts")
+
+            fx.get("/remove?id=1001").expectOk("Removed")
+            val file = fx.awaitFile(1001)
+            assertContentEquals(
+                fx.mock.expectedBytes(1001, room.generation, indices = listOf(2)),
+                file.readBytes()
+            )
+        }
+    }
+
+    @Test
+    fun `transient 500 is retried until the segment succeeds`() = testApplication {
+        XhrecIntegrationFixture(this).use { fx ->
+            fx.start()
+            fx.installRoutes()
+            fx.ready()
+            val room = fx.mock.addRoom(1001, "model", status = "public")
+
+            fx.get("/add?name=model&active=true").expectOk("Room added: model")
+            fx.awaitSession(1001, SessionState.Recording)
+            fx.awaitEventCount<SegmentDownloaded>(1, 15.seconds) { it.roomId == 1001L }
+
+            val path = MockPayloads.segmentPath(1001, room.generation, 1)
+            fx.mock.failNext(path, MockFault.ServerError)
+            room.advanceSegment()
+
+            fx.awaitEventCount<SegmentDownloaded>(2, 20.seconds) { it.roomId == 1001L }
+            assertTrue(fx.mock.requests().count { it.path == path } >= 2, "500 must trigger a retry")
+
+            fx.get("/remove?id=1001").expectOk("Removed")
+            val file = fx.awaitFile(1001)
+            assertContentEquals(fx.mock.expectedBytes(1001, room.generation, throughIndex = 1), file.readBytes())
+        }
+    }
+
+    @Test
+    fun `stalled attempt is abandoned and retried`() = testApplication {
+        val tuning = XhrecIntegrationFixture.testTuning(
+            downloaderRaceDelay = 10.seconds,
+            downloaderStallTimeout = 400.milliseconds,
+            downloaderDeadline = 10.seconds
+        )
+        withFixture(tuning) { fx ->
+            fx.ready()
+            val room = fx.mock.addRoom(1001, "model", status = "public")
+
+            fx.get("/add?name=model&active=true").expectOk("Room added: model")
+            fx.awaitSession(1001, SessionState.Recording)
+            fx.awaitEventCount<SegmentDownloaded>(1, 15.seconds) { it.roomId == 1001L }
+
+            val path = MockPayloads.segmentPath(1001, room.generation, 1)
+            fx.mock.failNext(path, MockFault.Delay(2.seconds))
+            room.advanceSegment()
+
+            fx.awaitEventCount<SegmentDownloaded>(2, 25.seconds) { it.roomId == 1001L }
+            assertTrue(fx.mock.requests().count { it.path == path } >= 2, "stalled attempt must be retried")
+
+            fx.get("/remove?id=1001").expectOk("Removed")
+            val file = fx.awaitFile(1001)
+            assertContentEquals(fx.mock.expectedBytes(1001, room.generation, throughIndex = 1), file.readBytes())
+        }
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/integration/IMPLEMENTATION_PLAN.md
+++ b/src/test/kotlin/github/rikacelery/v3/integration/IMPLEMENTATION_PLAN.md
@@ -79,11 +79,11 @@ val masterUrls: (Long, String, String?) -> List<String> = ::productionMasterUrls
 
 **Files:** modify `build.gradle.kts` and HttpServerComponent; create `HttpRoutesTest.kt`.
 
-- [ ] Add `ktor-server-websockets-jvm:3.5.2` and test dependency `ktor-server-test-host-jvm:3.5.2`.
-- [ ] Write failing testApplication test: install production routes, call active `/add`, prove AddRoom precedes ActivateRecordingCmd.
-- [ ] Run it; expect failure because routes are private inside `start()`.
-- [ ] Extract `installApplication(Application, stopEngine)`; production supplies real shutdown, tests no-op. Keep Netty/TLS/keystore in start. Inject restart delay.
-- [ ] Run focused/full tests; commit as `refactor: expose shared XhRec control routes`.
+- [x] Add `ktor-server-websockets-jvm:3.5.2` and test dependency `ktor-server-test-host-jvm:3.5.2`.
+- [x] Write failing testApplication test: install production routes, call active `/add`, prove AddRoom precedes ActivateRecordingCmd.
+- [x] Run it; expect failure because routes are private inside `start()`.
+- [x] Extract `installApplication(Application, stopEngine)`; production supplies real shutdown, tests no-op. Keep Netty/TLS/keystore in start. Inject restart delay.
+- [x] Run focused/full tests; commit as `refactor: expose shared XhRec control routes`.
 
 ```kotlin
 application { server.installApplication(this, stopEngine = {}) }

--- a/src/test/kotlin/github/rikacelery/v3/integration/IMPLEMENTATION_PLAN.md
+++ b/src/test/kotlin/github/rikacelery/v3/integration/IMPLEMENTATION_PLAN.md
@@ -162,12 +162,12 @@ assertTrue(mock.completionOrder(roomId).indexOf(2) < mock.completionOrder(roomId
 
 **Files:** create WebSocketFallbackIntegrationTest.
 
-- [ ] Write RED: with polling long, push broadcastChanged(public) and require Recording before any poll.
-- [ ] Add RED/GREEN cases for nested modelStatusChanged, streamChanged, duplicate suppression, malformed then valid frames, subscription expansion/reduction, and removal unsubscribe.
-- [ ] Write RED fallback: reject/disconnect WS, change only HTTP status, require polling to record, assert no WS push delivered it.
-- [ ] Write RED recovery: restore WS, await reconnect/resubscribe, require one debounced catch-up, then prove pushes resume without duplicates.
-- [ ] Run the class three times/full suite; verify loopback-only traffic and bounded teardown.
-- [ ] Commit as `test: verify websocket delivery and polling fallback`.
+- [x] Write RED: with polling long, push broadcastChanged(public) and require Recording before any poll.
+- [x] Add RED/GREEN cases for nested modelStatusChanged, streamChanged, duplicate suppression, malformed then valid frames, subscription expansion/reduction, and removal unsubscribe.
+- [x] Write RED fallback: reject/disconnect WS, change only HTTP status, require polling to record, assert no WS push delivered it.
+- [x] Write RED recovery: restore WS, await reconnect/resubscribe, require one debounced catch-up, then prove pushes resume without duplicates.
+- [x] Run the class three times/full suite; verify loopback-only traffic and bounded teardown.
+- [x] Commit as `test: verify websocket delivery and polling fallback`.
 
 ### Task 9: Fresh complete verification
 

--- a/src/test/kotlin/github/rikacelery/v3/integration/IMPLEMENTATION_PLAN.md
+++ b/src/test/kotlin/github/rikacelery/v3/integration/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,181 @@
+# XhRec Mock Integration Tests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `subagent-driven-development` or `executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build deterministic in-process tests for room operations, status-driven recording, WebSocket delivery, polling fallback, and exact downloaded file contents using one local Ktor mock server.
+
+**Architecture:** Production XhRec components run in the test process with instance-scoped network and timing dependencies. One loopback Ktor server provides platform HTTP, WebSocket, playlists, and deterministic segments; XhRec control routes run through Ktor `testApplication`.
+
+**Tech Stack:** Kotlin 2.3, Ktor 3.5, kotlinx.coroutines-test, JUnit Jupiter, Gradle.
+
+---
+
+## File map
+
+- `build.gradle.kts`: Ktor WebSocket/test-host dependencies.
+- `src/main/kotlin/github/rikacelery/v3/api/ApiClient.kt`: instance-scoped platform client.
+- `src/main/kotlin/github/rikacelery/v3/utils/HttpClientProvider.kt`: HTTP-client boundary.
+- `src/main/kotlin/github/rikacelery/v3/data/RuntimeTuning.kt`: production timing defaults.
+- `src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt`: routes shared with tests.
+- Room, LiveEventSource, Scheduler, Session, Downloader, and Writer components: injected endpoints, clients, timings, and output threshold.
+- `MockPayloads.kt`: deterministic playlist tokens and segment bytes.
+- `MockPlatformServer.kt`: the single HTTP/WS mock server.
+- `XhrecIntegrationFixture.kt`: real component graph, probes, waits, and cleanup.
+- RoomRoutes, StatusFlow, WebSocketFallback, and DownloadIntegrity integration test classes.
+
+## TDD tasks
+
+### Task 1: Configurable Writer threshold
+
+**Files:** modify `WriterComponent.kt`; create `WriterSmallFileTest.kt`.
+
+- [ ] Write failing tests that send StreamStart, short StreamData, and StreamEnd: threshold 0 retains exact bytes; threshold 1024 deletes 1023 bytes.
+- [ ] Run `./gradlew test --tests '*WriterSmallFileTest'`; expect compilation failure because the parameter is absent.
+- [ ] Add `private val minOutputBytes: Long = 1024` and use it instead of the literal in `closeActiveFile`.
+- [ ] Run focused and full tests; expect all to pass.
+- [ ] Commit as `test: make writer small-file policy configurable`.
+
+```kotlin
+val file = record("mock-segment".encodeToByteArray(), minOutputBytes = 0)
+assertContentEquals("mock-segment".encodeToByteArray(), file.readBytes())
+```
+
+### Task 2: Instance-scoped network and timing dependencies
+
+**Files:** create `HttpClientProvider.kt` and `RuntimeTuning.kt`; modify ApiClient, ConfigComponent, Main, and callers/tests.
+
+- [ ] Write failing tests proving two ApiClient instances keep independent hosts and RuntimeTuning preserves current production values.
+- [ ] Run focused tests; expect missing constructor/types.
+- [ ] Add this boundary; the default implementation delegates to ClientManager:
+
+```kotlin
+interface HttpClientProvider {
+    fun direct(key: String, http1: Boolean = false, expectSuccess: Boolean = true): HttpClient
+    fun proxied(key: String, http1: Boolean = false, expectSuccess: Boolean = true): HttpClient
+}
+```
+
+- [ ] Convert ApiClient to an instance accepting initial hosts, provider, and base-URL builder. Default remains HTTPS. Construct and share one production instance in Main/Config/Room/Scheduler/LiveEvent/Bootstrap.
+- [ ] Add timings: room poll 5m, debounce 1500ms, WS reconnect 1s..30s, preconfig 15s, playlist poll 3s/fetch 10s, restart 500ms, downloader race 8s/attempt 25s/deadline 120s/stall 5s/backoff 500ms.
+- [ ] Run focused tests, compilation, and full tests; expect all to pass.
+- [ ] Commit as `refactor: make network clients and timing injectable`.
+
+### Task 3: Inject live-recording boundaries
+
+**Files:** modify Room, LiveEventSource, Scheduler, Session, and Downloader; create `RuntimeInjectionTest.kt`.
+
+- [ ] Write failing construction tests using a recording provider, short timings, loopback WS URL builder, and loopback master candidates.
+- [ ] Run focused tests; expect constructor/API failures.
+- [ ] Replace only existing literals: Room poll/debounce; WS client/URL/backoff; Scheduler client/master/preconfig; Session client/playlist; Downloader client/failure timings. Keep production defaults.
+- [ ] Assert exact loopback URLs are used and ClientManager is not reached.
+- [ ] Run focused/full tests; commit as `refactor: inject recording network and timing boundaries`.
+
+```kotlin
+val wsUrl: (String) -> String = { "wss://$it/connection/websocket" }
+val masterUrls: (Long, String, String?) -> List<String> = ::productionMasterUrls
+```
+
+### Task 4: Share production HTTP routes
+
+**Files:** modify `build.gradle.kts` and HttpServerComponent; create `HttpRoutesTest.kt`.
+
+- [ ] Add `ktor-server-websockets-jvm:3.5.2` and test dependency `ktor-server-test-host-jvm:3.5.2`.
+- [ ] Write failing testApplication test: install production routes, call active `/add`, prove AddRoom precedes ActivateRecordingCmd.
+- [ ] Run it; expect failure because routes are private inside `start()`.
+- [ ] Extract `installApplication(Application, stopEngine)`; production supplies real shutdown, tests no-op. Keep Netty/TLS/keystore in start. Inject restart delay.
+- [ ] Run focused/full tests; commit as `refactor: expose shared XhRec control routes`.
+
+```kotlin
+application { server.installApplication(this, stopEngine = {}) }
+assertEquals(HttpStatusCode.OK, client.get("/add?name=model&active=true").status)
+assertEquals(listOf(AddRoom::class, ActivateRecordingCmd::class), commandTypes)
+```
+
+### Task 5: Deterministic single mock server
+
+**Files:** create MockPayloads, MockPlatformServer, and MockPlatformServerTest beside this plan.
+
+- [ ] Write failing payload tests for inverse XOR/Base64 decoding, 512-byte bodies, increasing IDs, and overlapping windows.
+- [ ] Implement fixed init/segment builders and an encoder accepted by production Decrypter/M3u8Parser.
+- [ ] Write failing server tests for platform JSON, master/media playlists, exact bytes, WS auth/subscriptions/pushes, and ephemeral loopback binding.
+- [ ] Implement per-room state, manual/automatic status and segment advancement, WS disconnect/reject/restore, request history, and next-request 404/500/delay/interruption faults.
+- [ ] Cancel/join generators before stopping Ktor. Run server tests twice.
+- [ ] Commit as `test: add deterministic platform mock server`.
+
+```kotlin
+assertEquals(token, Decrypter.decode(encryptToken(token, key).reversed(), key))
+assertEquals(512, segmentBytes(roomId = 1, generation = 2, index = 3).size)
+```
+
+Required controls:
+
+```kotlin
+fun addRoom(id: Long, name: String, status: String = "off"): MockRoom
+suspend fun setRoomStatus(id: Long, status: String, push: Boolean = true)
+suspend fun setStreamStatus(id: Long, status: String, push: Boolean = true)
+fun startSegments(id: Long, period: Duration): Job
+fun rotateStatuses(id: Long, statuses: List<String>, period: Duration): Job
+suspend fun disconnectWebSockets()
+fun rejectWebSockets(value: Boolean)
+fun failNext(path: String, fault: MockFault)
+fun requests(): List<MockRequest>
+```
+
+### Task 6: Real component fixture and room operations
+
+**Files:** create XhrecIntegrationFixture and RoomRoutesIntegrationTest.
+
+- [ ] Write RED vertical slice: add inactive, verify unarmed, activate, push public, await Recording, remove, await file close, verify dashboard absence.
+- [ ] Build real Config/Room/LiveEvent/Downloader/Writer/Session/Scheduler/Metric/HTTP components with short timings, threshold 0, temp paths, no-proxy clients, and mock URLs.
+- [ ] Add bounded awaitEvent/awaitDashboard/awaitFile. Timeout errors include recent events/requests. Teardown closes every owned resource and only its temp directory.
+- [ ] Verify the first test twice.
+- [ ] Add RED/GREEN cases individually: active add; invalid/duplicate input; remove while preconfiguring/recording; activate/deactivate; break/restart; quality; limits; both autopays; list/dashboard; list.conf persistence/reload.
+- [ ] Run route/full tests; commit as `test: cover room control routes with mock platform`.
+
+```kotlin
+fixture.get("/add?name=model&active=false").expectOk()
+fixture.awaitRoom("model") { !it.listening }
+fixture.get("/activate?id=1001").expectOk()
+fixture.mock.setRoomStatus(1001, "public")
+fixture.awaitSession(1001, "Recording")
+fixture.get("/remove?id=1001").expectOk()
+fixture.awaitRoomAbsent(1001)
+```
+
+### Task 7: Status actions and exact file bytes
+
+**Files:** create StatusFlowIntegrationTest and DownloadIntegrityIntegrationTest.
+
+- [ ] Write RED: start segments, activate offline room, set public, await four segments, set off, await FileReady, compare bytes with mock expected bytes.
+- [ ] Force segment 2 to complete before 1; assert inverted completion history and ordered output.
+- [ ] Add table-driven RED/GREEN cases for offline/public/group/private/unknown room states and distributing/finished stream states, including paid-show guards.
+- [ ] Add automatic `off -> public -> groupShow -> p2p -> public -> off` rotation and two-room state/byte isolation.
+- [ ] Add exact-boundary tests for sliding-window dedupe, init change, break, restart, time/size limits, 404 no-retry, transient 500, and stall/retry.
+- [ ] Run both classes twice/full suite; commit as `test: verify status actions and recording bytes`.
+
+```kotlin
+assertContentEquals(mock.expectedBytes(roomId, generation, throughIndex), ready.file.readBytes())
+assertTrue(mock.completionOrder(roomId).indexOf(2) < mock.completionOrder(roomId).indexOf(1))
+```
+
+### Task 8: WebSocket, fallback, and recovery
+
+**Files:** create WebSocketFallbackIntegrationTest.
+
+- [ ] Write RED: with polling long, push broadcastChanged(public) and require Recording before any poll.
+- [ ] Add RED/GREEN cases for nested modelStatusChanged, streamChanged, duplicate suppression, malformed then valid frames, subscription expansion/reduction, and removal unsubscribe.
+- [ ] Write RED fallback: reject/disconnect WS, change only HTTP status, require polling to record, assert no WS push delivered it.
+- [ ] Write RED recovery: restore WS, await reconnect/resubscribe, require one debounced catch-up, then prove pushes resume without duplicates.
+- [ ] Run the class three times/full suite; verify loopback-only traffic and bounded teardown.
+- [ ] Commit as `test: verify websocket delivery and polling fallback`.
+
+### Task 9: Fresh complete verification
+
+- [ ] Map each original requirement to an executed test name; fill gaps through RED/GREEN.
+- [ ] Run `./gradlew clean test`.
+- [ ] Run `./gradlew test --tests 'github.rikacelery.v3.integration.*'` twice.
+- [ ] Run `git diff --check`.
+- [ ] Confirm request history is loopback-only and Gradle exits without server/client/coroutine leaks.
+- [ ] Commit final corrections as `test: complete mock integration coverage`.
+
+Expected evidence: every command exits 0; exact bytes match; forced out-of-order downloads are written in order; two rooms remain isolated; both WS and polling drive recording; production defaults remain unchanged.

--- a/src/test/kotlin/github/rikacelery/v3/integration/IMPLEMENTATION_PLAN.md
+++ b/src/test/kotlin/github/rikacelery/v3/integration/IMPLEMENTATION_PLAN.md
@@ -125,12 +125,12 @@ fun requests(): List<MockRequest>
 
 **Files:** create XhrecIntegrationFixture and RoomRoutesIntegrationTest.
 
-- [ ] Write RED vertical slice: add inactive, verify unarmed, activate, push public, await Recording, remove, await file close, verify dashboard absence.
-- [ ] Build real Config/Room/LiveEvent/Downloader/Writer/Session/Scheduler/Metric/HTTP components with short timings, threshold 0, temp paths, no-proxy clients, and mock URLs.
-- [ ] Add bounded awaitEvent/awaitDashboard/awaitFile. Timeout errors include recent events/requests. Teardown closes every owned resource and only its temp directory.
-- [ ] Verify the first test twice.
-- [ ] Add RED/GREEN cases individually: active add; invalid/duplicate input; remove while preconfiguring/recording; activate/deactivate; break/restart; quality; limits; both autopays; list/dashboard; list.conf persistence/reload.
-- [ ] Run route/full tests; commit as `test: cover room control routes with mock platform`.
+- [x] Write RED vertical slice: add inactive, verify unarmed, activate, push public, await Recording, remove, await file close, verify dashboard absence.
+- [x] Build real Config/Room/LiveEvent/Downloader/Writer/Session/Scheduler/Metric/HTTP components with short timings, threshold 0, temp paths, no-proxy clients, and mock URLs.
+- [x] Add bounded awaitEvent/awaitDashboard/awaitFile. Timeout errors include recent events/requests. Teardown closes every owned resource and only its temp directory.
+- [x] Verify the first test twice.
+- [x] Add RED/GREEN cases individually: active add; invalid/duplicate input; remove while preconfiguring/recording; activate/deactivate; break/restart; quality; limits; both autopays; list/dashboard; list.conf persistence/reload.
+- [x] Run route/full tests; commit as `test: cover room control routes with mock platform`.
 
 ```kotlin
 fixture.get("/add?name=model&active=false").expectOk()

--- a/src/test/kotlin/github/rikacelery/v3/integration/IMPLEMENTATION_PLAN.md
+++ b/src/test/kotlin/github/rikacelery/v3/integration/IMPLEMENTATION_PLAN.md
@@ -29,11 +29,11 @@
 
 **Files:** modify `WriterComponent.kt`; create `WriterSmallFileTest.kt`.
 
-- [ ] Write failing tests that send StreamStart, short StreamData, and StreamEnd: threshold 0 retains exact bytes; threshold 1024 deletes 1023 bytes.
-- [ ] Run `./gradlew test --tests '*WriterSmallFileTest'`; expect compilation failure because the parameter is absent.
-- [ ] Add `private val minOutputBytes: Long = 1024` and use it instead of the literal in `closeActiveFile`.
-- [ ] Run focused and full tests; expect all to pass.
-- [ ] Commit as `test: make writer small-file policy configurable`.
+- [x] Write failing tests that send StreamStart, short StreamData, and StreamEnd: threshold 0 retains exact bytes; threshold 1024 deletes 1023 bytes.
+- [x] Run `./gradlew test --tests '*WriterSmallFileTest'`; expect compilation failure because the parameter is absent.
+- [x] Add `private val minOutputBytes: Long = 1024` and use it instead of the literal in `closeActiveFile`.
+- [x] Run focused and full tests; expect all to pass.
+- [x] Commit as `test: make writer small-file policy configurable`.
 
 ```kotlin
 val file = record("mock-segment".encodeToByteArray(), minOutputBytes = 0)
@@ -44,9 +44,9 @@ assertContentEquals("mock-segment".encodeToByteArray(), file.readBytes())
 
 **Files:** create `HttpClientProvider.kt` and `RuntimeTuning.kt`; modify ApiClient, ConfigComponent, Main, and callers/tests.
 
-- [ ] Write failing tests proving two ApiClient instances keep independent hosts and RuntimeTuning preserves current production values.
-- [ ] Run focused tests; expect missing constructor/types.
-- [ ] Add this boundary; the default implementation delegates to ClientManager:
+- [x] Write failing tests proving two ApiClient instances keep independent hosts and RuntimeTuning preserves current production values.
+- [x] Run focused tests; expect missing constructor/types.
+- [x] Add this boundary; the default implementation delegates to ClientManager:
 
 ```kotlin
 interface HttpClientProvider {
@@ -55,20 +55,20 @@ interface HttpClientProvider {
 }
 ```
 
-- [ ] Convert ApiClient to an instance accepting initial hosts, provider, and base-URL builder. Default remains HTTPS. Construct and share one production instance in Main/Config/Room/Scheduler/LiveEvent/Bootstrap.
-- [ ] Add timings: room poll 5m, debounce 1500ms, WS reconnect 1s..30s, preconfig 15s, playlist poll 3s/fetch 10s, restart 500ms, downloader race 8s/attempt 25s/deadline 120s/stall 5s/backoff 500ms.
-- [ ] Run focused tests, compilation, and full tests; expect all to pass.
-- [ ] Commit as `refactor: make network clients and timing injectable`.
+- [x] Convert ApiClient to an instance accepting initial hosts, provider, and base-URL builder. Default remains HTTPS. Construct and share one production instance in Main/Config/Room/Scheduler/LiveEvent/Bootstrap.
+- [x] Add timings: room poll 5m, debounce 1500ms, WS reconnect 1s..30s, preconfig 15s, playlist poll 3s/fetch 10s, restart 500ms, downloader race 8s/attempt 25s/deadline 120s/stall 5s/backoff 500ms.
+- [x] Run focused tests, compilation, and full tests; expect all to pass.
+- [x] Commit as `refactor: make network clients and timing injectable`.
 
 ### Task 3: Inject live-recording boundaries
 
 **Files:** modify Room, LiveEventSource, Scheduler, Session, and Downloader; create `RuntimeInjectionTest.kt`.
 
-- [ ] Write failing construction tests using a recording provider, short timings, loopback WS URL builder, and loopback master candidates.
-- [ ] Run focused tests; expect constructor/API failures.
-- [ ] Replace only existing literals: Room poll/debounce; WS client/URL/backoff; Scheduler client/master/preconfig; Session client/playlist; Downloader client/failure timings. Keep production defaults.
-- [ ] Assert exact loopback URLs are used and ClientManager is not reached.
-- [ ] Run focused/full tests; commit as `refactor: inject recording network and timing boundaries`.
+- [x] Write failing construction tests using a recording provider, short timings, loopback WS URL builder, and loopback master candidates.
+- [x] Run focused tests; expect constructor/API failures.
+- [x] Replace only existing literals: Room poll/debounce; WS client/URL/backoff; Scheduler client/master/preconfig; Session client/playlist; Downloader client/failure timings. Keep production defaults.
+- [x] Assert exact loopback URLs are used and ClientManager is not reached.
+- [x] Run focused/full tests; commit as `refactor: inject recording network and timing boundaries`.
 
 ```kotlin
 val wsUrl: (String) -> String = { "wss://$it/connection/websocket" }

--- a/src/test/kotlin/github/rikacelery/v3/integration/IMPLEMENTATION_PLAN.md
+++ b/src/test/kotlin/github/rikacelery/v3/integration/IMPLEMENTATION_PLAN.md
@@ -146,12 +146,12 @@ fixture.awaitRoomAbsent(1001)
 
 **Files:** create StatusFlowIntegrationTest and DownloadIntegrityIntegrationTest.
 
-- [ ] Write RED: start segments, activate offline room, set public, await four segments, set off, await FileReady, compare bytes with mock expected bytes.
-- [ ] Force segment 2 to complete before 1; assert inverted completion history and ordered output.
-- [ ] Add table-driven RED/GREEN cases for offline/public/group/private/unknown room states and distributing/finished stream states, including paid-show guards.
-- [ ] Add automatic `off -> public -> groupShow -> p2p -> public -> off` rotation and two-room state/byte isolation.
-- [ ] Add exact-boundary tests for sliding-window dedupe, init change, break, restart, time/size limits, 404 no-retry, transient 500, and stall/retry.
-- [ ] Run both classes twice/full suite; commit as `test: verify status actions and recording bytes`.
+- [x] Write RED: start segments, activate offline room, set public, await four segments, set off, await FileReady, compare bytes with mock expected bytes.
+- [x] Force segment 2 to complete before 1; assert inverted completion history and ordered output.
+- [x] Add table-driven RED/GREEN cases for offline/public/group/private/unknown room states and distributing/finished stream states, including paid-show guards.
+- [x] Add automatic `off -> public -> groupShow -> p2p -> public -> off` rotation and two-room state/byte isolation.
+- [x] Add exact-boundary tests for sliding-window dedupe, init change, break, restart, time/size limits, 404 no-retry, transient 500, and stall/retry.
+- [x] Run both classes twice/full suite; commit as `test: verify status actions and recording bytes`.
 
 ```kotlin
 assertContentEquals(mock.expectedBytes(roomId, generation, throughIndex), ready.file.readBytes())

--- a/src/test/kotlin/github/rikacelery/v3/integration/IMPLEMENTATION_PLAN.md
+++ b/src/test/kotlin/github/rikacelery/v3/integration/IMPLEMENTATION_PLAN.md
@@ -171,11 +171,11 @@ assertTrue(mock.completionOrder(roomId).indexOf(2) < mock.completionOrder(roomId
 
 ### Task 9: Fresh complete verification
 
-- [ ] Map each original requirement to an executed test name; fill gaps through RED/GREEN.
-- [ ] Run `./gradlew clean test`.
-- [ ] Run `./gradlew test --tests 'github.rikacelery.v3.integration.*'` twice.
-- [ ] Run `git diff --check`.
-- [ ] Confirm request history is loopback-only and Gradle exits without server/client/coroutine leaks.
-- [ ] Commit final corrections as `test: complete mock integration coverage`.
+- [x] Map each original requirement to an executed test name; fill gaps through RED/GREEN.
+- [x] Run `./gradlew clean test`.
+- [x] Run `./gradlew test --tests 'github.rikacelery.v3.integration.*'` twice.
+- [x] Run `git diff --check`.
+- [x] Confirm request history is loopback-only and Gradle exits without server/client/coroutine leaks.
+- [x] Commit final corrections as `test: complete mock integration coverage`.
 
 Expected evidence: every command exits 0; exact bytes match; forced out-of-order downloads are written in order; two rooms remain isolated; both WS and polling drive recording; production defaults remain unchanged.

--- a/src/test/kotlin/github/rikacelery/v3/integration/IMPLEMENTATION_PLAN.md
+++ b/src/test/kotlin/github/rikacelery/v3/integration/IMPLEMENTATION_PLAN.md
@@ -95,12 +95,12 @@ assertEquals(listOf(AddRoom::class, ActivateRecordingCmd::class), commandTypes)
 
 **Files:** create MockPayloads, MockPlatformServer, and MockPlatformServerTest beside this plan.
 
-- [ ] Write failing payload tests for inverse XOR/Base64 decoding, 512-byte bodies, increasing IDs, and overlapping windows.
-- [ ] Implement fixed init/segment builders and an encoder accepted by production Decrypter/M3u8Parser.
-- [ ] Write failing server tests for platform JSON, master/media playlists, exact bytes, WS auth/subscriptions/pushes, and ephemeral loopback binding.
-- [ ] Implement per-room state, manual/automatic status and segment advancement, WS disconnect/reject/restore, request history, and next-request 404/500/delay/interruption faults.
-- [ ] Cancel/join generators before stopping Ktor. Run server tests twice.
-- [ ] Commit as `test: add deterministic platform mock server`.
+- [x] Write failing payload tests for inverse XOR/Base64 decoding, 512-byte bodies, increasing IDs, and overlapping windows.
+- [x] Implement fixed init/segment builders and an encoder accepted by production Decrypter/M3u8Parser.
+- [x] Write failing server tests for platform JSON, master/media playlists, exact bytes, WS auth/subscriptions/pushes, and ephemeral loopback binding.
+- [x] Implement per-room state, manual/automatic status and segment advancement, WS disconnect/reject/restore, request history, and next-request 404/500/delay/interruption faults.
+- [x] Cancel/join generators before stopping Ktor. Run server tests twice.
+- [x] Commit as `test: add deterministic platform mock server`.
 
 ```kotlin
 assertEquals(token, Decrypter.decode(encryptToken(token, key).reversed(), key))

--- a/src/test/kotlin/github/rikacelery/v3/integration/MockPayloadTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/MockPayloadTest.kt
@@ -1,0 +1,92 @@
+package github.rikacelery.v3.integration
+
+import github.rikacelery.v3.crypto.Decrypter
+import github.rikacelery.v3.m3u8.M3u8Parser
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pure payload tests: the mock server must produce playlists the production parser
+ * accepts and bytes that tests can recompute exactly.
+ */
+class MockPayloadTest {
+
+    @Test
+    fun `encrypted token round-trips through the production decrypter`() {
+        val plain = "http://127.0.0.1:18080/media/7/7_1001_0123456789abcdef_1700000001.mp4"
+        val token = MockPayloads.encryptToken(plain)
+
+        assertEquals(plain, Decrypter.decode(token.reversed(), MockPayloads.DEFAULT_DECRYPT_KEY))
+        assertEquals(plain, MockPayloads.decodeToken(token))
+        assertTrue(token != plain)
+    }
+
+    @Test
+    fun `segment bodies are exactly 512 deterministic bytes and ids increase`() {
+        val first = MockPayloads.segmentBytes(roomId = 1, generation = 2, index = 3)
+        val again = MockPayloads.segmentBytes(roomId = 1, generation = 2, index = 3)
+        val next = MockPayloads.segmentBytes(roomId = 1, generation = 2, index = 4)
+        val otherRoom = MockPayloads.segmentBytes(roomId = 2, generation = 2, index = 3)
+
+        assertEquals(MockPayloads.SEGMENT_SIZE, first.size)
+        assertContentEquals(first, again)
+        assertTrue(!first.contentEquals(next))
+        assertTrue(!first.contentEquals(otherRoom))
+
+        assertEquals(MockPayloads.INIT_SIZE, MockPayloads.initBytes(roomId = 1, generation = 2).size)
+
+        assertTrue(MockPayloads.segmentId(2, 1) < MockPayloads.segmentId(2, 2))
+        assertTrue(MockPayloads.segmentId(2, 999) < MockPayloads.segmentId(3, 1))
+    }
+
+    @Test
+    fun `segment urls are parsed back to their ids by production parser`() {
+        for (index in 1..5) {
+            val url = MockPayloads.segmentUrl("http://127.0.0.1:18080", 7, 2, index)
+            assertEquals(
+                MockPayloads.segmentId(2, index).toInt(),
+                M3u8Parser.segmentIDFromUrl(url),
+                "url=$url"
+            )
+        }
+    }
+
+    @Test
+    fun `media playlist decrypts to ordered urls and windows overlap`() {
+        val base = "http://127.0.0.1:18080"
+        val roomId = 7L
+        val generation = 2
+
+        val firstWindow = MockPayloads.window(available = 3, windowSize = 3)
+        val secondWindow = MockPayloads.window(available = 4, windowSize = 3)
+        assertEquals(1..3, firstWindow)
+        assertEquals(2..4, secondWindow)
+        assertTrue(firstWindow.last in secondWindow)
+
+        val text = MockPayloads.mediaPlaylistText(base, roomId, generation, secondWindow.first, secondWindow.last)
+        val parsed = M3u8Parser.parse(text, MockPayloads.DEFAULT_DECRYPT_KEY)
+
+        assertEquals(MockPayloads.initUrl(base, roomId, generation), parsed.initUrl)
+        assertEquals(
+            (secondWindow.first..secondWindow.last).map { MockPayloads.segmentUrl(base, roomId, generation, it) },
+            parsed.segments.map { it.url }
+        )
+        assertEquals(
+            (secondWindow.first..secondWindow.last).map { MockPayloads.segmentId(generation, it).toInt() },
+            parsed.segments.map { it.index }
+        )
+    }
+
+    @Test
+    fun `master playlist exposes the psch key and the media variant`() {
+        val media = "http://127.0.0.1:18080/hls/7/media/7_auto.m3u8"
+        val master = M3u8Parser.parseMaster(MockPayloads.masterPlaylistText(media))
+
+        assertEquals(listOf("key-id"), master.pschKeys.map { it.substringAfter(":") })
+        assertEquals(1, master.variants.size)
+        assertEquals("360p", master.variants.single().name)
+        assertEquals(media, master.variants.single().url)
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/integration/MockPayloads.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/MockPayloads.kt
@@ -1,0 +1,144 @@
+package github.rikacelery.v3.integration
+
+import github.rikacelery.v3.crypto.Decrypter
+import java.util.Base64
+
+/**
+ * Deterministic payload builders shared by the mock platform server and its assertions.
+ *
+ * Every token produced here must round-trip through the production [Decrypter], so the
+ * playlists the mock serves exercise the real M3U8 parsing/decryption path instead of
+ * bypassing it. All bytes are a pure function of (roomId, generation, index) so tests can
+ * recompute expected output without recording it.
+ */
+object MockPayloads {
+    /** Base64 of "mock-decrypt-key" — the key the fixture hands to `GetDecryptKey`. */
+    const val DEFAULT_DECRYPT_KEY = "bW9jay1kZWNyeXB0LWtleQ=="
+    /** Name advertised in `#EXT-X-MOUFLON:PSCH:` and used as the decrypt-key id. */
+    const val DEFAULT_PSCH_KEY = "key-id"
+    const val SEGMENT_SIZE = 512
+    const val INIT_SIZE = 128
+    const val DEFAULT_WINDOW = 3
+
+    /**
+     * Encodes [plain] so production `Decrypter.decode(token.reversed(), key)` returns it.
+     * The M3U8 parser reverses the token before decoding, hence the trailing reverse.
+     */
+    fun encryptToken(plain: String, keyB64: String = DEFAULT_DECRYPT_KEY): String {
+        val key = Base64.getDecoder().decode(keyB64)
+        val bytes = plain.toByteArray(Charsets.UTF_8)
+        val xored = ByteArray(bytes.size) { i ->
+            (bytes[i].toInt() xor (key[i % key.size].toInt() and 0xFF)).toByte()
+        }
+        return Base64.getEncoder().encodeToString(xored).reversed()
+    }
+
+    /** Segment ids increase monotonically within and across generations of one room. */
+    fun segmentId(generation: Int, index: Int): Long = generation.toLong() * 1_000L + index
+
+    fun initPath(roomId: Long, generation: Int): String = "/media/$roomId/${roomId}_init_$generation.mp4"
+
+    /**
+     * Segment path matches production `M3u8Parser.segmentIDFromUrl`:
+     * `<roomId>_<segmentId>_<16 alnum>_<10 digits>.mp4`.
+     */
+    fun segmentPath(roomId: Long, generation: Int, index: Int): String =
+        "/media/$roomId/${roomId}_${segmentId(generation, index)}_" +
+            "${suffix(generation, index)}_${timestamp(index)}.mp4"
+
+    fun initUrl(baseUrl: String, roomId: Long, generation: Int): String =
+        baseUrl.trimEnd('/') + initPath(roomId, generation)
+
+    fun segmentUrl(baseUrl: String, roomId: Long, generation: Int, index: Int): String =
+        baseUrl.trimEnd('/') + segmentPath(roomId, generation, index)
+
+    fun initBytes(roomId: Long, generation: Int): ByteArray {
+        val prefix = "INIT:$roomId:$generation:".toByteArray(Charsets.UTF_8)
+        require(prefix.size < INIT_SIZE) { "init prefix too long" }
+        return prefix + fill(seed(roomId, generation, -1), INIT_SIZE - prefix.size)
+    }
+
+    /** Exactly [SEGMENT_SIZE] bytes, deterministic per (roomId, generation, index). */
+    fun segmentBytes(roomId: Long, generation: Int, index: Int): ByteArray {
+        val prefix = "SEG:$roomId:$generation:$index:".toByteArray(Charsets.UTF_8)
+        require(prefix.size < SEGMENT_SIZE) { "segment prefix too long" }
+        return prefix + fill(seed(roomId, generation, index), SEGMENT_SIZE - prefix.size)
+    }
+
+    /**
+     * Sliding-window media playlist: only segments in `fromIndex..throughIndex` are listed,
+     * so consecutive polls overlap and the session's dedupe has to hold.
+     */
+    fun mediaPlaylistText(
+        baseUrl: String,
+        roomId: Long,
+        generation: Int,
+        fromIndex: Int,
+        throughIndex: Int,
+        keyB64: String = DEFAULT_DECRYPT_KEY
+    ): String = buildString {
+        appendLine("#EXTM3U")
+        appendLine("#EXT-X-VERSION:7")
+        appendLine("#EXT-X-TARGETDURATION:2")
+        appendLine("#EXT-X-MEDIA-SEQUENCE:$fromIndex")
+        appendLine("#EXT-X-MAP:URI=\"${initUrl(baseUrl, roomId, generation)}\"")
+        for (index in fromIndex..throughIndex) {
+            val token = encryptToken(segmentUrl(baseUrl, roomId, generation, index), keyB64)
+            appendLine("#EXT-X-MOUFLON:URI:$token")
+        }
+    }
+
+    /** Master playlist advertising a single 360p variant plus the PSCH decrypt key name. */
+    fun masterPlaylistText(mediaUrl: String, pschKeyName: String = DEFAULT_PSCH_KEY): String =
+        masterPlaylistText(listOf(MasterVariant(1_000_000, "640x360", 30, mediaUrl)), pschKeyName)
+
+    /** Master playlist with an arbitrary variant ladder; `parseMaster` derives names from RESOLUTION/FRAME-RATE. */
+    fun masterPlaylistText(variants: List<MasterVariant>, pschKeyName: String = DEFAULT_PSCH_KEY): String =
+        buildString {
+            appendLine("#EXTM3U")
+            appendLine("#EXT-X-MOUFLON:PSCH:$pschKeyName")
+            variants.forEach { variant ->
+                appendLine(
+                    "#EXT-X-STREAM-INF:BANDWIDTH=${variant.bandwidth}," +
+                        "RESOLUTION=${variant.resolution},FRAME-RATE=${variant.frameRate}"
+                )
+                appendLine(variant.url)
+            }
+        }
+
+    /** One master-playlist variant entry. */
+    data class MasterVariant(
+        val bandwidth: Long,
+        val resolution: String,
+        val frameRate: Int,
+        val url: String
+    )
+
+    /** Window bounds for a room that has published [available] segments. */
+    fun window(available: Int, windowSize: Int = DEFAULT_WINDOW): IntRange {
+        if (available <= 0) return IntRange.EMPTY
+        return (available - windowSize + 1).coerceAtLeast(1)..available
+    }
+
+    private fun suffix(generation: Int, index: Int): String =
+        String.format("%016x", seed(0x5EED, generation, index) and 0xFFFFFFFFFFFFL)
+
+    private fun timestamp(index: Int): String = String.format("%010d", 1_700_000_000L + index)
+
+    private fun seed(roomId: Long, generation: Int, index: Int): Long =
+        roomId * 1_000_003L + generation * 1_009L + index * 97L
+
+    private fun fill(seed: Long, size: Int): ByteArray {
+        var s = seed
+        val out = ByteArray(size)
+        for (i in out.indices) {
+            s = s * 6364136223846793005L + 1442695040888963407L
+            out[i] = ((s ushr 33).toInt() and 0xFF).toByte()
+        }
+        return out
+    }
+
+    /** Round-trip helper used by tests and by playlist assertions. */
+    fun decodeToken(token: String, keyB64: String = DEFAULT_DECRYPT_KEY): String =
+        Decrypter.decode(token.reversed(), keyB64)
+}

--- a/src/test/kotlin/github/rikacelery/v3/integration/MockPlatformServer.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/MockPlatformServer.kt
@@ -273,16 +273,33 @@ class MockPlatformServer(
 
     // ── internals ──────────────────────────────────────────────────────────────
 
-    private suspend fun push(channel: String, data: JsonObject) {
-        val message = buildJsonObject {
-            put("push", buildJsonObject {
-                put("channel", channel)
-                put("pub", buildJsonObject { put("data", data) })
-            })
-        }.toString()
+    /** Sends a typed push frame to every session subscribed to [channel]. */
+    suspend fun push(channel: String, data: JsonObject) {
         recordedPushes += MockPush(channel, data)
+        deliver(
+            channel,
+            buildJsonObject {
+                put("push", buildJsonObject {
+                    put("channel", channel)
+                    put("pub", buildJsonObject { put("data", data) })
+                })
+            }.toString()
+        )
+    }
+
+    /** Sends raw text frames (one JSON object per line) to subscribers of [channel]. */
+    suspend fun pushRaw(channel: String, text: String) = deliver(channel, text)
+
+    private suspend fun deliver(channel: String, message: String) {
         sessions.filter { it.subscribed.contains(channel) }.forEach { it.send(message) }
     }
+
+    /** Blocks until no session is subscribed to [channel] any more. */
+    suspend fun awaitSubscriptionGone(channel: String, timeout: Duration = 5.seconds): Boolean =
+        withTimeoutOrNull(timeout) {
+            while (subscribedChannels().contains(channel)) delay(20.milliseconds)
+            true
+        } ?: false
 
     private fun ApplicationCall.record() {
         recordedRequests += MockRequest(

--- a/src/test/kotlin/github/rikacelery/v3/integration/MockPlatformServer.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/MockPlatformServer.kt
@@ -83,6 +83,8 @@ class MockRoom(
     @Volatile var availableSegments: Int = 0
     @Volatile var modelToken: String = ""
     @Volatile var freeSpyAccess: Boolean = false
+    /** Platform-side deletion: broadcasts answers 404 "model already deleted". */
+    @Volatile var deleted: Boolean = false
     @Volatile var ticketRate: Int = 100
     @Volatile var privateRate: Int = 50
     val presets: MutableList<String> = CopyOnWriteArrayList(listOf("360p", "720p"))
@@ -207,6 +209,11 @@ class MockPlatformServer(
                 delay(period)
             }
         }.also { ownedJobs += it }
+    }
+
+    /** Marks the model deleted (or restored) on the platform. */
+    fun markDeleted(name: String, deleted: Boolean = true) {
+        (roomsByName[name] ?: error("no mock room named $name")).deleted = deleted
     }
 
     /** Bumps the generation so the next playlist advertises a new init segment. */
@@ -386,6 +393,13 @@ class MockPlatformServer(
                 if (room == null) {
                     call.respondJson(
                         buildJsonObject { put("description", "model not found") },
+                        HttpStatusCode.NotFound
+                    )
+                    return@get
+                }
+                if (room.deleted) {
+                    call.respondJson(
+                        buildJsonObject { put("description", "model already deleted") },
                         HttpStatusCode.NotFound
                     )
                     return@get

--- a/src/test/kotlin/github/rikacelery/v3/integration/MockPlatformServer.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/MockPlatformServer.kt
@@ -1,0 +1,552 @@
+package github.rikacelery.v3.integration
+
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.*
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.request.httpMethod
+import io.ktor.server.request.path
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondBytes
+import io.ktor.server.response.respondBytesWriter
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.put
+import io.ktor.server.routing.routing
+import io.ktor.server.websocket.DefaultWebSocketServerSession
+import io.ktor.server.websocket.WebSockets
+import io.ktor.server.websocket.webSocket
+import io.ktor.utils.io.writeFully
+import io.ktor.websocket.CloseReason
+import io.ktor.websocket.Frame
+import io.ktor.websocket.close
+import io.ktor.websocket.readText
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/** A request the mock platform served, in arrival order. */
+data class MockRequest(
+    val method: String,
+    val path: String,
+    val query: Map<String, String>,
+    val atMs: Long
+)
+
+/** A WebSocket push the mock platform emitted. */
+data class MockPush(val channel: String, val data: JsonObject)
+
+/** Fault injected for the next matching request. */
+sealed interface MockFault {
+    data object NotFound : MockFault
+    data object ServerError : MockFault
+    data class Delay(val duration: Duration) : MockFault
+    data object Interrupt : MockFault
+}
+
+/** Mutable per-room state owned by the mock platform. */
+class MockRoom(
+    val id: Long,
+    val name: String,
+    status: String,
+    streamStatus: String
+) {
+    @Volatile var status: String = status
+    @Volatile var streamStatus: String = streamStatus
+    @Volatile var generation: Int = 1
+    @Volatile var availableSegments: Int = 0
+    @Volatile var modelToken: String = ""
+    @Volatile var freeSpyAccess: Boolean = false
+    @Volatile var ticketRate: Int = 100
+    @Volatile var privateRate: Int = 50
+    val presets: MutableList<String> = CopyOnWriteArrayList(listOf("360p", "720p"))
+    @Volatile var fps: Int = 30
+    @Volatile var height: Int = 720
+
+    /** Segment indexes in the order the mock finished writing their bodies. */
+    val completionOrder: MutableList<Int> = CopyOnWriteArrayList()
+
+    fun advanceSegment(): Int = ++availableSegments
+}
+
+/**
+ * One loopback Ktor server that impersonates the XhRec platform: platform JSON APIs,
+ * master/media playlists, byte-exact init/segment media, and the WebSocket
+ * connect/subscribe/push protocol. Nothing here touches the public internet.
+ */
+class MockPlatformServer(
+    val decryptKey: String = MockPayloads.DEFAULT_DECRYPT_KEY,
+    val pschKeyName: String = PSCH_KEY,
+    val windowSize: Int = MockPayloads.DEFAULT_WINDOW,
+    val token: String = "mock-ws-token"
+) : AutoCloseable {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val rooms = ConcurrentHashMap<Long, MockRoom>()
+    private val roomsByName = ConcurrentHashMap<String, MockRoom>()
+    private val recordedRequests = CopyOnWriteArrayList<MockRequest>()
+    private val recordedPushes = CopyOnWriteArrayList<MockPush>()
+    private val sessions = CopyOnWriteArrayList<WsHandle>()
+    private val faults = ConcurrentHashMap<String, ConcurrentLinkedQueue<MockFault>>()
+    private val segmentDelays = ConcurrentHashMap<String, Duration>()
+    private val rejectWs = AtomicBoolean(false)
+    private val ownedJobs = CopyOnWriteArrayList<Job>()
+    private val connectionIds = AtomicInteger(0)
+
+    private val server = embeddedServer(Netty, port = 0, host = "127.0.0.1") { module() }
+
+    val port: Int
+    val baseUrl: String
+    val wsUrl: String
+
+    /** Host:port form used as the configured platform/WS host inside tests. */
+    val host: String get() = "127.0.0.1:$port"
+
+    init {
+        server.start(wait = false)
+        port = runBlocking { server.engine.resolvedConnectors().first().port }
+        baseUrl = "http://127.0.0.1:$port"
+        wsUrl = "ws://127.0.0.1:$port/connection/websocket"
+    }
+
+    // ── state control ──────────────────────────────────────────────────────────
+
+    fun addRoom(id: Long, name: String, status: String = "off", streamStatus: String = "distributing"): MockRoom {
+        val room = MockRoom(id, name, status, streamStatus)
+        rooms[id] = room
+        roomsByName[name] = room
+        return room
+    }
+
+    fun room(id: Long): MockRoom = rooms[id] ?: error("no mock room $id")
+
+    fun masterUrl(roomId: Long): String = baseUrl + masterPath(roomId)
+
+    fun masterPath(roomId: Long): String = "/hls/$roomId/master/${roomId}_auto.m3u8"
+
+    fun mediaUrl(roomId: Long, quality: String = "highest"): String = baseUrl + mediaPath(roomId, quality)
+
+    /** "highest" resolves to the top variant in the ladder (720p), matching the Scheduler's default. */
+    fun mediaPath(roomId: Long, quality: String = "highest"): String {
+        val variant = if (quality == "highest") "720p" else quality
+        return "/hls/$roomId/media/${roomId}_$variant.m3u8"
+    }
+
+    private fun masterPlaylist(roomId: Long): String = MockPayloads.masterPlaylistText(
+        listOf(
+            MockPayloads.MasterVariant(800_000, "640x360", 30, mediaUrl(roomId, "360p")),
+            MockPayloads.MasterVariant(2_000_000, "1280x720", 30, mediaUrl(roomId, "720p"))
+        ),
+        pschKeyName
+    )
+
+    suspend fun setRoomStatus(id: Long, status: String, push: Boolean = true) {
+        val room = room(id)
+        room.status = status
+        if (push) {
+            push(
+                "broadcastChanged@$id",
+                buildJsonObject { put("status", status) }
+            )
+        }
+    }
+
+    suspend fun setStreamStatus(id: Long, status: String, push: Boolean = true) {
+        val room = room(id)
+        room.streamStatus = status
+        if (push) {
+            push(
+                "streamChanged@$id",
+                buildJsonObject { put("status", status) }
+            )
+        }
+    }
+
+    /** Publishes one more segment every [period] until the returned job is cancelled. */
+    fun startSegments(id: Long, period: Duration): Job = scope.launch {
+        while (true) {
+            delay(period)
+            room(id).advanceSegment()
+        }
+    }.also { ownedJobs += it }
+
+    /** Applies [statuses] in order (first immediately), then loops every [period]. */
+    fun rotateStatuses(id: Long, statuses: List<String>, period: Duration): Job {
+        require(statuses.isNotEmpty())
+        return scope.launch {
+            var index = 0
+            while (true) {
+                setRoomStatus(id, statuses[index % statuses.size])
+                index++
+                delay(period)
+            }
+        }.also { ownedJobs += it }
+    }
+
+    /** Bumps the generation so the next playlist advertises a new init segment. */
+    fun rotateInit(id: Long): Int {
+        val room = room(id)
+        room.generation += 1
+        return room.generation
+    }
+
+    suspend fun disconnectWebSockets() {
+        sessions.toList().forEach { it.close() }
+    }
+
+    fun rejectWebSockets(value: Boolean) {
+        rejectWs.set(value)
+    }
+
+    fun failNext(path: String, fault: MockFault) {
+        faults.computeIfAbsent(path) { ConcurrentLinkedQueue() }.add(fault)
+    }
+
+    fun delaySegment(roomId: Long, index: Int, delay: Duration) {
+        segmentDelays["$roomId:$index"] = delay
+    }
+
+    // ── observations ───────────────────────────────────────────────────────────
+
+    fun requests(): List<MockRequest> = recordedRequests.toList()
+
+    fun pushes(): List<MockPush> = recordedPushes.toList()
+
+    fun completionOrder(roomId: Long): List<Int> = room(roomId).completionOrder.toList()
+
+    fun connectionCount(): Int = sessions.size
+
+    fun subscribedChannels(): Set<String> = sessions.flatMap { it.subscribed.toList() }.toSet()
+
+    /** Blocks until any session subscribes to [channel]. */
+    suspend fun awaitSubscription(channel: String, timeout: Duration = 2.seconds): Boolean =
+        withTimeoutOrNull(timeout) {
+            while (subscribedChannels().none { it == channel }) delay(10.milliseconds)
+            true
+        } ?: false
+
+    /** init bytes followed by the requested segment bodies, in the given order. */
+    fun expectedBytes(roomId: Long, generation: Int, throughIndex: Int): ByteArray =
+        expectedBytes(roomId, generation, (1..throughIndex).toList())
+
+    fun expectedBytes(roomId: Long, generation: Int, indices: List<Int>): ByteArray {
+        val out = ByteArrayOutputStream()
+        out.write(MockPayloads.initBytes(roomId, generation))
+        indices.forEach { out.write(MockPayloads.segmentBytes(roomId, generation, it)) }
+        return out.toByteArray()
+    }
+
+    override fun close() {
+        ownedJobs.forEach { it.cancel() }
+        runBlocking {
+            sessions.toList().forEach { it.close() }
+            server.stop(500, 1000)
+        }
+        scope.cancel()
+    }
+
+    // ── internals ──────────────────────────────────────────────────────────────
+
+    private suspend fun push(channel: String, data: JsonObject) {
+        val message = buildJsonObject {
+            put("push", buildJsonObject {
+                put("channel", channel)
+                put("pub", buildJsonObject { put("data", data) })
+            })
+        }.toString()
+        recordedPushes += MockPush(channel, data)
+        sessions.filter { it.subscribed.contains(channel) }.forEach { it.send(message) }
+    }
+
+    private fun ApplicationCall.record() {
+        recordedRequests += MockRequest(
+            method = request.httpMethod.value,
+            path = request.path(),
+            query = request.queryParameters.entries().associate { it.key to it.value.first() },
+            atMs = System.currentTimeMillis()
+        )
+    }
+
+    /** Returns true when the request was answered by an injected fault. */
+    private suspend fun ApplicationCall.applyFault(path: String): Boolean {
+        val fault = faults[path]?.poll() ?: return false
+        return when (fault) {
+            MockFault.NotFound -> {
+                respondText("""{"description":"mock not found"}""", ContentType.Application.Json, HttpStatusCode.NotFound)
+                true
+            }
+
+            MockFault.ServerError -> {
+                respondText("mock server error", ContentType.Text.Plain, HttpStatusCode.InternalServerError)
+                true
+            }
+
+            is MockFault.Delay -> {
+                delay(fault.duration)
+                false
+            }
+
+            MockFault.Interrupt -> {
+                respondBytesWriter(contentType = ContentType.Video.MP4, contentLength = 4096L) {
+                    writeFully(ByteArray(16))
+                    flush()
+                    throw IOException("mock interrupted")
+                }
+                true
+            }
+        }
+    }
+
+    private fun Application.module() {
+        intercept(ApplicationCallPipeline.Monitoring) { call.record() }
+        install(WebSockets)
+
+        routing {
+            webSocket("/connection/websocket") {
+                if (rejectWs.get()) {
+                    close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "rejected"))
+                    return@webSocket
+                }
+                val handle = WsHandle(this)
+                sessions += handle
+                try {
+                    for (frame in incoming) {
+                        if (frame is Frame.Text) handle.onFrame(frame.readText())
+                    }
+                } finally {
+                    sessions -= handle
+                }
+            }
+
+            get("/api/front/v3/config/initial") {
+                call.respondJson(
+                    buildJsonObject {
+                        put("initial", buildJsonObject {
+                            put("client", buildJsonObject {
+                                put("websocket", buildJsonObject { put("token", token) })
+                                put("user", buildJsonObject {
+                                    put("id", 42)
+                                    put("username", "tester")
+                                    put("tokens", 100_000)
+                                })
+                                put("csrfToken", "csrf-token")
+                                put("csrfTimestamp", "1700000000")
+                            })
+                        })
+                    }
+                )
+            }
+
+            get("/api/front/v1/broadcasts/{name}") {
+                val name = call.parameters["name"].orEmpty()
+                val room = roomsByName[name]
+                if (room == null) {
+                    call.respondJson(
+                        buildJsonObject { put("description", "model not found") },
+                        HttpStatusCode.NotFound
+                    )
+                    return@get
+                }
+                call.respondJson(
+                    buildJsonObject {
+                        put("item", buildJsonObject {
+                            put("status", room.status)
+                            put("modelId", room.id)
+                            put("username", room.name)
+                            put("settings", buildJsonObject {
+                                put("presets", buildJsonArray { room.presets.forEach { add(JsonPrimitive(it)) } })
+                                put("fps", room.fps)
+                                put("height", room.height)
+                            })
+                        })
+                    }
+                )
+            }
+
+            get("/api/front/v2/models/{id}/cam") {
+                val room = call.parameters["id"]?.toLongOrNull()?.let { rooms[it] }
+                if (room == null) {
+                    call.respondJson(buildJsonObject { put("description", "model not found") }, HttpStatusCode.NotFound)
+                    return@get
+                }
+                call.respondJson(
+                    buildJsonObject {
+                        put("cam", buildJsonObject {
+                            put("modelToken", room.modelToken)
+                            put("userFanClub", buildJsonObject {
+                                put("subscription", buildJsonObject {
+                                    put("status", if (room.freeSpyAccess) "active" else "none")
+                                    put("tier", "tier1")
+                                })
+                                put("benefits", buildJsonArray {
+                                    add(buildJsonObject {
+                                        put("id", "freeSpying")
+                                        put("tiers", buildJsonObject {
+                                            put("tier1", buildJsonObject { put("isActive", room.freeSpyAccess) })
+                                        })
+                                    })
+                                })
+                            })
+                        })
+                        put("user", buildJsonObject {
+                            put("user", buildJsonObject {
+                                put("ticketRate", room.ticketRate)
+                                put("privateRate", room.privateRate)
+                            })
+                        })
+                    }
+                )
+            }
+
+            post("/api/front/show/models/{id}/groupShows/{userId}") {
+                call.parameters["id"]?.toLongOrNull()?.let { rooms[it] }?.modelToken = "show-token"
+                call.respondJson(buildJsonObject { put("ok", true) })
+            }
+
+            put("/api/front/show/models/{id}/viewers/{userId}/spy") {
+                call.parameters["id"]?.toLongOrNull()?.let { rooms[it] }?.modelToken = "spy-token"
+                call.respondJson(buildJsonObject { put("ok", true) })
+            }
+
+            get("/hls/{roomId}/master/{file}") {
+                val roomId = call.parameters["roomId"]!!.toLong()
+                if (call.applyFault(call.request.path())) return@get
+                if (rooms[roomId] == null) {
+                    call.respondText("no room", ContentType.Text.Plain, HttpStatusCode.NotFound)
+                    return@get
+                }
+                call.respondText(masterPlaylist(roomId), ContentType.parse("application/vnd.apple.mpegurl"))
+            }
+
+            get("/hls/{roomId}/media/{file}") {
+                val roomId = call.parameters["roomId"]!!.toLong()
+                if (call.applyFault(call.request.path())) return@get
+                val room = rooms[roomId]
+                if (room == null) {
+                    call.respondText("no room", ContentType.Text.Plain, HttpStatusCode.NotFound)
+                    return@get
+                }
+                val range = MockPayloads.window(room.availableSegments, windowSize)
+                call.respondText(
+                    MockPayloads.mediaPlaylistText(
+                        baseUrl, roomId, room.generation, range.first, range.last, decryptKey
+                    ),
+                    ContentType.parse("application/vnd.apple.mpegurl")
+                )
+            }
+
+            get("/media/{roomId}/{file}") {
+                val roomId = call.parameters["roomId"]!!.toLong()
+                val file = call.parameters["file"].orEmpty()
+                if (call.applyFault(call.request.path())) return@get
+                val room = rooms[roomId]
+                if (room == null) {
+                    call.respondText("no room", ContentType.Text.Plain, HttpStatusCode.NotFound)
+                    return@get
+                }
+                val init = Regex("^${roomId}_init_(\\d+)\\.mp4$").find(file)
+                if (init != null) {
+                    call.respondBytes(MockPayloads.initBytes(roomId, init.groupValues[1].toInt()), ContentType.Video.MP4)
+                    return@get
+                }
+                val segment = Regex("^${roomId}_(\\d+)_[A-Za-z0-9]{16}_\\d{10}\\.mp4$").find(file)
+                if (segment == null) {
+                    call.respondText("no media", ContentType.Text.Plain, HttpStatusCode.NotFound)
+                    return@get
+                }
+                val segmentId = segment.groupValues[1].toLong()
+                val generation = (segmentId / 1000).toInt()
+                val index = (segmentId % 1000).toInt()
+                segmentDelays["$roomId:$index"]?.let { delay(it) }
+                call.respondBytes(MockPayloads.segmentBytes(roomId, generation, index), ContentType.Video.MP4)
+                room.completionOrder += index
+            }
+        }
+    }
+
+    private suspend fun ApplicationCall.respondJson(
+        body: JsonObject,
+        status: HttpStatusCode = HttpStatusCode.OK
+    ) {
+        respondText(body.toString(), ContentType.Application.Json, status)
+    }
+
+    private inner class WsHandle(private val session: DefaultWebSocketServerSession) {
+        private val id = connectionIds.incrementAndGet()
+        val subscribed: MutableSet<String> = ConcurrentHashMap.newKeySet()
+        @Volatile private var authenticated = false
+
+        suspend fun onFrame(text: String) {
+            val json = runCatching { Json.parseToJsonElement(text).jsonObject }.getOrNull() ?: return
+            val frameId = json["id"]?.jsonPrimitive?.content ?: "0"
+
+            json["connect"]?.jsonObject?.let { connect ->
+                if (connect["token"]?.jsonPrimitive?.content == token) {
+                    authenticated = true
+                    send("""{"id":$frameId,"connect":{}}""")
+                } else {
+                    session.close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "bad token"))
+                }
+                return
+            }
+
+            json["subscribe"]?.jsonObject?.let { subscribe ->
+                val channel = subscribe["channel"]?.jsonPrimitive?.content ?: return
+                if (!authenticated) {
+                    session.close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "unauthenticated"))
+                    return
+                }
+                subscribed += channel
+                send("""{"id":$frameId,"subscribe":{"channel":"$channel"}}""")
+                return
+            }
+
+            json["unsubscribe"]?.jsonObject?.let { unsubscribe ->
+                unsubscribe["channel"]?.jsonPrimitive?.content?.let { subscribed -= it }
+            }
+        }
+
+        suspend fun send(text: String) {
+            runCatching { session.send(Frame.Text(text)) }
+        }
+
+        suspend fun close() {
+            runCatching {
+                session.close(CloseReason(CloseReason.Codes.NORMAL, "mock disconnect"))
+            }
+        }
+
+        override fun toString(): String = "WsHandle($id, subs=$subscribed)"
+    }
+
+    companion object {
+        /** Name advertised in `#EXT-X-MOUFLON:PSCH:` and used as the decrypt-key id. */
+        const val PSCH_KEY = MockPayloads.DEFAULT_PSCH_KEY
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/integration/MockPlatformServerTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/MockPlatformServerTest.kt
@@ -1,0 +1,282 @@
+package github.rikacelery.v3.integration
+
+import github.rikacelery.v3.m3u8.M3u8Parser
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.webSocket
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsBytes
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.websocket.Frame
+import io.ktor.websocket.readText
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Drives the single loopback mock server directly: platform JSON, playlists, byte-exact
+ * media, request history, faults, and the WebSocket subscribe/push contract.
+ */
+class MockPlatformServerTest {
+
+    @Test
+    fun `binds an ephemeral loopback port`() = withMock { mock ->
+        assertTrue(mock.port > 0, "port=${mock.port}")
+        assertTrue(mock.baseUrl.startsWith("http://127.0.0.1:"), mock.baseUrl)
+        assertTrue(mock.wsUrl.startsWith("ws://127.0.0.1:"), mock.wsUrl)
+    }
+
+    @Test
+    fun `serves platform config broadcast info and cam info`() = withMock { mock ->
+        val room = mock.addRoom(7, "model", status = "public")
+        withClient { client ->
+            val initial = client.get("${mock.baseUrl}/api/front/v3/config/initial").bodyAsText()
+            assertEquals(mock.token, initial.jsonPath("initial.client.websocket.token"))
+            assertEquals("tester", initial.jsonPath("initial.client.user.username"))
+
+            val broadcast = client.get("${mock.baseUrl}/api/front/v1/broadcasts/model").bodyAsText()
+            assertEquals("public", broadcast.jsonPath("item.status"))
+            assertEquals(7L, broadcast.jsonPath("item.modelId").toLong())
+
+            mock.setRoomStatus(room.id, "p2p")
+            assertEquals(
+                "p2p",
+                client.get("${mock.baseUrl}/api/front/v1/broadcasts/model").bodyAsText().jsonPath("item.status")
+            )
+
+            val missing = client.get("${mock.baseUrl}/api/front/v1/broadcasts/ghost")
+            assertEquals(HttpStatusCode.NotFound, missing.status)
+            assertTrue(missing.bodyAsText().contains("description"))
+
+            val cam = client.get("${mock.baseUrl}/api/front/v2/models/7/cam").bodyAsText()
+            assertEquals("", cam.jsonPath("cam.modelToken"))
+            assertEquals("100", cam.jsonPath("user.user.ticketRate"))
+        }
+    }
+
+    @Test
+    fun `serves master and media playlists that decrypt to exact segment bytes`() = withMock { mock ->
+        val room = mock.addRoom(7, "model", status = "public")
+        room.availableSegments = 2
+        withClient { client ->
+            val master = M3u8Parser.parseMaster(client.get(mock.masterUrl(7)).bodyAsText())
+            assertEquals(listOf("key-id"), master.pschKeys.map { it.substringAfter(":") })
+
+            assertEquals(listOf("360p", "720p"), master.variants.map { it.name })
+            val mediaUrl = master.variants.maxByOrNull { it.bandwidth }!!.url
+            assertEquals(mock.mediaUrl(7), mediaUrl)
+            val parsed = M3u8Parser.parse(client.get(mediaUrl).bodyAsText(), mock.decryptKey)
+
+            assertEquals(MockPayloads.initUrl(mock.baseUrl, 7, room.generation), parsed.initUrl)
+            assertEquals(2, parsed.segments.size)
+
+            val assembled = java.io.ByteArrayOutputStream()
+            val init = client.get(parsed.initUrl!!).bodyAsBytes()
+            assembled.write(init)
+            assertContentEquals(MockPayloads.initBytes(7, room.generation), init)
+            parsed.segments.forEachIndexed { offset, segment ->
+                val index = offset + 1
+                assertEquals(MockPayloads.segmentUrl(mock.baseUrl, 7, room.generation, index), segment.url)
+                val bytes = client.get(segment.url).bodyAsBytes()
+                assertEquals(MockPayloads.SEGMENT_SIZE, bytes.size)
+                assembled.write(bytes)
+                assertContentEquals(MockPayloads.segmentBytes(7, room.generation, index), bytes)
+            }
+            assertContentEquals(mock.expectedBytes(7, room.generation, throughIndex = 2), assembled.toByteArray())
+        }
+    }
+
+    @Test
+    fun `records loopback request history`() = withMock { mock ->
+        mock.addRoom(7, "model", status = "public")
+        withClient { client ->
+            client.get(mock.masterUrl(7))
+            client.get("${mock.baseUrl}/api/front/v1/broadcasts/model?probe=1")
+        }
+        val paths = mock.requests().map { it.path }
+        assertTrue(paths.contains("/hls/7/master/7_auto.m3u8"), "$paths")
+        assertTrue(paths.contains("/api/front/v1/broadcasts/model"), "$paths")
+        assertTrue(mock.requests().all { it.path.startsWith("/") })
+        assertEquals(
+            mapOf("probe" to "1"),
+            mock.requests().first { it.path == "/api/front/v1/broadcasts/model" }.query
+        )
+    }
+
+    @Test
+    fun `applies next-request faults`() = withMock { mock ->
+        mock.addRoom(7, "model", status = "public")
+        withClient { client ->
+            val media = mock.mediaUrl(7)
+
+            mock.failNext(mock.mediaPath(7), MockFault.NotFound)
+            assertEquals(HttpStatusCode.NotFound, client.get(media).status)
+            assertEquals(HttpStatusCode.OK, client.get(media).status)
+
+            mock.failNext(mock.mediaPath(7), MockFault.ServerError)
+            assertEquals(HttpStatusCode.InternalServerError, client.get(media).status)
+            assertEquals(HttpStatusCode.OK, client.get(media).status)
+
+            mock.failNext(mock.mediaPath(7), MockFault.Delay(150.milliseconds))
+            val startedAt = System.currentTimeMillis()
+            assertEquals(HttpStatusCode.OK, client.get(media).status)
+            assertTrue(System.currentTimeMillis() - startedAt >= 140, "delay was not applied")
+
+            mock.failNext(mock.mediaPath(7), MockFault.Interrupt)
+            val interrupted = runCatching { client.get(media).bodyAsText() }
+            assertTrue(interrupted.isFailure, "interruption must surface as a transport failure")
+        }
+    }
+
+    @Test
+    fun `advances segments and rotates statuses automatically`() = withMock { mock ->
+        val room = mock.addRoom(7, "model", status = "off")
+        val segments = mock.startSegments(7, 40.milliseconds)
+        val rotation = mock.rotateStatuses(7, listOf("off", "public", "groupShow"), 40.milliseconds)
+        try {
+            withTimeout(5.seconds) {
+                while (room.availableSegments < 3 || room.status == "off") delay(20.milliseconds)
+            }
+            assertTrue(room.availableSegments >= 3, "available=${room.availableSegments}")
+            assertTrue(room.status != "off", "status=${room.status}")
+            assertTrue(mock.pushes().any { it.channel.startsWith("broadcastChanged@7") })
+        } finally {
+            segments.cancelAndJoin()
+            rotation.cancelAndJoin()
+        }
+    }
+
+    @Test
+    fun `delivers pushes only to subscribed authenticated websockets`() = withMock { mock ->
+        val room = mock.addRoom(7, "model", status = "off")
+        withClient { client ->
+            client.webSocket(mock.wsUrl) {
+                val subscriber = this
+                send(Frame.Text("""{"connect":{"token":"${mock.token}","name":"js"},"id":1}"""))
+                send(Frame.Text("""{"subscribe":{"channel":"broadcastChanged@7"},"id":2}"""))
+                assertTrue(mock.awaitSubscription("broadcastChanged@7", 2.seconds))
+
+                client.webSocket(mock.wsUrl) {
+                    val observer = this
+                    send(Frame.Text("""{"connect":{"token":"${mock.token}","name":"js"},"id":1}"""))
+                    mock.setRoomStatus(room.id, "public", push = true)
+
+                    val text = assertNotNull(subscriber.awaitPush(3.seconds), "subscriber must receive the push")
+                    assertEquals("broadcastChanged@7", text.jsonPath("push.channel"))
+                    assertEquals("public", text.jsonPath("push.pub.data.status"))
+
+                    // the unsubscribed sibling connection must not receive the push
+                    assertTrue(observer.awaitPush(300.milliseconds) == null)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `rejects websockets then restores them`() = withMock { mock ->
+        mock.addRoom(7, "model", status = "public")
+        withClient { client ->
+            mock.rejectWebSockets(true)
+            val rejected = runCatching {
+                client.webSocket(mock.wsUrl) {
+                    send(Frame.Text("""{"connect":{"token":"${mock.token}"},"id":1}"""))
+                    withTimeoutOrNull(300.milliseconds) { incoming.receive() }
+                }
+            }
+            assertTrue(rejected.isFailure || rejected.getOrNull() == null, "connection must not stay usable")
+
+            mock.rejectWebSockets(false)
+            client.webSocket(mock.wsUrl) {
+                send(Frame.Text("""{"connect":{"token":"${mock.token}"},"id":1}"""))
+                send(Frame.Text("""{"subscribe":{"channel":"broadcastChanged@7"},"id":2}"""))
+                assertTrue(mock.awaitSubscription("broadcastChanged@7", 2.seconds))
+            }
+        }
+    }
+
+    @Test
+    fun `disconnects websockets on demand`() = withMock { mock ->
+        mock.addRoom(7, "model", status = "public")
+        withClient { client ->
+            client.webSocket(mock.wsUrl) {
+                send(Frame.Text("""{"connect":{"token":"${mock.token}"},"id":1}"""))
+                send(Frame.Text("""{"subscribe":{"channel":"broadcastChanged@7"},"id":2}"""))
+                assertTrue(mock.awaitSubscription("broadcastChanged@7", 2.seconds))
+                assertEquals(1, mock.connectionCount())
+
+                mock.disconnectWebSockets()
+                withTimeout(3.seconds) {
+                    while (mock.connectionCount() != 0) delay(20.milliseconds)
+                }
+
+                // a closed session must no longer receive pushes
+                mock.setRoomStatus(7, "public", push = true)
+                assertTrue(mock.pushes().isNotEmpty())
+                assertTrue(runCatching { awaitPush(300.milliseconds) }.getOrNull() == null)
+            }
+            assertEquals(0, mock.connectionCount())
+        }
+    }
+
+    @Test
+    fun `records segment completion order when a fetch is delayed`() = withMock { mock ->
+        val room = mock.addRoom(7, "model", status = "public")
+        room.availableSegments = 2
+        mock.delaySegment(7, 1, 300.milliseconds)
+        withClient { client ->
+            coroutineScope {
+                val first = async { client.get(MockPayloads.segmentUrl(mock.baseUrl, 7, room.generation, 1)).bodyAsBytes() }
+                delay(30.milliseconds)
+                val second = async { client.get(MockPayloads.segmentUrl(mock.baseUrl, 7, room.generation, 2)).bodyAsBytes() }
+                assertContentEquals(MockPayloads.segmentBytes(7, room.generation, 2), second.await())
+                assertContentEquals(MockPayloads.segmentBytes(7, room.generation, 1), first.await())
+            }
+        }
+        assertEquals(listOf(2, 1), mock.completionOrder(7))
+    }
+
+    private fun withMock(block: suspend (MockPlatformServer) -> Unit) = kotlinx.coroutines.runBlocking {
+        MockPlatformServer().use { mock -> block(mock) }
+    }
+
+    private suspend fun withClient(block: suspend (HttpClient) -> Unit) {
+        HttpClient(OkHttp) { install(WebSockets) }.use { client -> block(client) }
+    }
+}
+
+/** Reads frames until a push arrives, ignoring connect/subscribe acknowledgements. */
+private suspend fun DefaultClientWebSocketSession.awaitPush(timeout: kotlin.time.Duration): String? =
+    withTimeoutOrNull(timeout) {
+        var result: String? = null
+        while (result == null) {
+            val frame = incoming.receive()
+            if (frame is Frame.Text) {
+                val text = frame.readText()
+                if ("\"push\"" in text) result = text
+            }
+        }
+        result
+    }
+
+private fun String.jsonPath(path: String): String {
+    var element: kotlinx.serialization.json.JsonElement = kotlinx.serialization.json.Json.parseToJsonElement(this)
+    for (part in path.split('.')) {
+        element = element.jsonObject[part] ?: error("missing '$part' in $this")
+    }
+    return element.jsonPrimitive.content
+}

--- a/src/test/kotlin/github/rikacelery/v3/integration/RoomDeletionAndActivationIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/RoomDeletionAndActivationIntegrationTest.kt
@@ -1,0 +1,156 @@
+package github.rikacelery.v3.integration
+
+import github.rikacelery.v3.components.SessionState
+import github.rikacelery.v3.events.EndReason
+import github.rikacelery.v3.events.FileReady
+import github.rikacelery.v3.events.RecordingStarted
+import github.rikacelery.v3.events.SegmentDownloaded
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.delay
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Room lifecycle as seen from the platform side:
+ *
+ * - a model deleted on the platform while it is recording must stop the session, close the
+ *   file and disappear from the dashboard (no ghost row, no ever-growing size column);
+ * - arming a room whose status is already recordable must start recording without waiting
+ *   for a status change, and the same must hold for `/restart`.
+ */
+class RoomDeletionAndActivationIntegrationTest {
+
+    @Test
+    fun `platform deletion while recording stops the session and clears the dashboard`() = testApplication {
+        XhrecIntegrationFixture(this).use { fx ->
+            fx.start()
+            fx.installRoutes()
+            fx.ready()
+            fx.mock.addRoom(1001, "model", status = "public")
+
+            fx.get("/add?name=model&active=true").expectOk("Room added: model")
+            fx.awaitSession(1001, SessionState.Recording)
+            fx.awaitEvent<SegmentDownloaded>(15.seconds) { it.roomId == 1001L }
+
+            // the platform now reports the model as deleted; the room poll auto-removes it
+            fx.mock.markDeleted("model")
+
+            val ready = fx.awaitEvent<FileReady>(20.seconds) { it.roomId == 1001L }
+            assertTrue(ready.file.length() > 0, "the recording must be closed, not left growing")
+            assertEquals(EndReason.UserStop, ready.reason)
+
+            fx.awaitSession(1001, SessionState.Idle)
+            fx.awaitRoomAbsent(1001)
+
+            val dashboard = fx.dashboard()
+            assertTrue(dashboard["rooms"]!!.jsonArray.isEmpty(), "no ghost room row")
+            assertTrue(dashboard["listv2"]!!.jsonArray.isEmpty(), "no ghost dashboard row")
+            assertTrue(dashboard["statuses"]!!.jsonObject.isEmpty(), "no stale size metrics")
+
+            val mediaFetches = fx.mock.requests().count { it.path.startsWith("/media/1001/") }
+            delay(700)
+            assertEquals(
+                mediaFetches,
+                fx.mock.requests().count { it.path.startsWith("/media/1001/") },
+                "a deleted room must not keep fetching segments"
+            )
+        }
+    }
+
+    @Test
+    fun `re-adding a deleted room records a fresh file with no leftover bytes`() = testApplication {
+        XhrecIntegrationFixture(this).use { fx ->
+            fx.start()
+            fx.installRoutes()
+            fx.ready()
+            val room = fx.mock.addRoom(1001, "model", status = "public")
+
+            // first episode: init + two segments, advanced one at a time for a known size
+            fx.get("/add?name=model&active=true").expectOk("Room added: model")
+            fx.awaitSession(1001, SessionState.Recording)
+            fx.awaitEventCount<SegmentDownloaded>(1, 15.seconds) { it.roomId == 1001L }
+            repeat(2) { index ->
+                room.advanceSegment()
+                fx.awaitEventCount<SegmentDownloaded>(index + 2, 20.seconds) { it.roomId == 1001L }
+            }
+
+            fx.mock.markDeleted("model")
+            val firstFile = fx.awaitFile(1001)
+            assertEquals(
+                MockPayloads.INIT_SIZE.toLong() + 2L * MockPayloads.SEGMENT_SIZE,
+                firstFile.length(),
+                "first episode must be init + 2 segments"
+            )
+            fx.awaitRoomAbsent(1001)
+
+            // the model is back; re-adding must behave like a brand-new room
+            fx.mock.markDeleted("model", deleted = false)
+            fx.get("/add?name=model&active=true").expectOk("Room added: model")
+            fx.awaitEventCount<RecordingStarted>(2, 20.seconds) { it.roomId == 1001L }
+
+            // the new session re-downloads the current sliding window (init + 2 segments)
+            fx.awaitEventCount<SegmentDownloaded>(6, 20.seconds) { it.roomId == 1001L }
+            delay(300)
+
+            fx.get("/remove?id=1001").expectOk("Removed")
+            val files = fx.awaitEventCount<FileReady>(2, 20.seconds) { it.roomId == 1001L }
+            val second = files[1].file.readBytes()
+
+            assertEquals(
+                MockPayloads.INIT_SIZE + 2 * MockPayloads.SEGMENT_SIZE,
+                second.size,
+                "the new file must contain only the new episode, not the deleted room's bytes"
+            )
+            assertContentEquals(
+                MockPayloads.initBytes(1001, room.generation),
+                second.copyOfRange(0, MockPayloads.INIT_SIZE),
+                "the new file must start with the current init segment"
+            )
+        }
+    }
+
+    @Test
+    fun `activating an already public room records immediately`() = testApplication {
+        XhrecIntegrationFixture(this).use { fx ->
+            fx.start()
+            fx.installRoutes()
+            fx.ready()
+            fx.mock.addRoom(1001, "model", status = "public")
+
+            fx.get("/add?name=model&active=false").expectOk("Room added: model")
+            // the room poll learns the status first, so activation sees no status transition
+            fx.awaitRoom("model") { !it.boolField("listening") && it.path("room.status") == "public" }
+            assertTrue(fx.sessions().isEmpty(), "inactive room must not record")
+
+            // no status change and no WebSocket push: activation alone must start recording
+            fx.get("/activate?id=1001").expectOk("Activated")
+            fx.awaitSession(1001, SessionState.Recording, timeout = 15.seconds)
+            fx.awaitEvent<SegmentDownloaded>(15.seconds) { it.roomId == 1001L }
+        }
+    }
+
+    @Test
+    fun `restarting an already public room records again immediately`() = testApplication {
+        XhrecIntegrationFixture(this).use { fx ->
+            fx.start()
+            fx.installRoutes()
+            fx.ready()
+            fx.mock.addRoom(1001, "model", status = "public")
+
+            fx.get("/add?name=model&active=true").expectOk("Room added: model")
+            fx.awaitSession(1001, SessionState.Recording)
+            fx.awaitEvent<SegmentDownloaded>(15.seconds) { it.roomId == 1001L }
+            val episodes = fx.events.filterIsInstance<RecordingStarted>().count { it.roomId == 1001L }
+
+            fx.get("/restart?id=1001").expectOk("Restarted")
+
+            // the restart re-arms the room while it is still public; it must record again
+            fx.awaitEventCount<RecordingStarted>(episodes + 1, 20.seconds) { it.roomId == 1001L }
+        }
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/integration/RoomRoutesIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/RoomRoutesIntegrationTest.kt
@@ -1,14 +1,12 @@
 package github.rikacelery.v3.integration
 
 import github.rikacelery.v3.components.SessionState
-import github.rikacelery.v3.data.RuntimeTuning
 import github.rikacelery.v3.events.EndReason
 import github.rikacelery.v3.events.FileReady
 import github.rikacelery.v3.events.SegmentDownloaded
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.testing.testApplication
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
@@ -18,7 +16,6 @@ import org.junit.jupiter.api.Test
 import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -266,35 +263,6 @@ class RoomRoutesIntegrationTest {
         assertTrue(room.autoPayTicket && room.autoPaySpy, "bare 'autopay' enables both kinds")
         fx.awaitSession(1001, SessionState.Recording, quality = "720p")
     }
-}
-
-private fun withFixture(
-    tuning: RuntimeTuning = XhrecIntegrationFixture.testTuning(),
-    block: suspend (XhrecIntegrationFixture) -> Unit
-) = testApplication {
-    XhrecIntegrationFixture(this, tuning = tuning).use { fx ->
-        fx.start()
-        fx.installRoutes()
-        block(fx)
-    }
-}
-
-/** Adds an inactive room, activates it, publishes public status and waits for recording. */
-private suspend fun XhrecIntegrationFixture.startRecording(
-    roomId: Long = 1001L,
-    name: String = "model",
-    status: String = "public",
-    segmentPeriod: Duration = 30.milliseconds
-) {
-    mock.addRoom(roomId, name, status = status)
-    get("/add?name=$name&active=false").expectOk("Room added: $name")
-    awaitRoom(name) { !it.bool("listening") }
-    get("/activate?id=$roomId").expectOk("Activated")
-    mock.startSegments(roomId, segmentPeriod)
-    awaitRoomSubscribed(roomId)
-    mock.setRoomStatus(roomId, status)
-    awaitSession(roomId, SessionState.Recording)
-    awaitEvent<SegmentDownloaded>(10.seconds) { it.roomId == roomId }
 }
 
 private fun JsonObject.bool(field: String): Boolean =

--- a/src/test/kotlin/github/rikacelery/v3/integration/RoomRoutesIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/RoomRoutesIntegrationTest.kt
@@ -7,6 +7,7 @@ import github.rikacelery.v3.events.SegmentDownloaded
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.delay
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
@@ -88,6 +89,26 @@ class RoomRoutesIntegrationTest {
         assertEquals(HttpStatusCode.BadRequest, fx.get("/sizelimit").status)
         assertEquals(HttpStatusCode.BadRequest, fx.get("/autopay?id=1001").status)
         assertEquals(HttpStatusCode.BadRequest, fx.get("/autopay?id=1001&v=true&kind=bogus").status)
+    }
+
+    @Test
+    fun `remove while preconfiguring cancels the arm`() = withFixture { fx ->
+        fx.ready()
+        fx.mock.addRoom(1001, "model", status = "public")
+        // keep the room in Preconfiguring by stalling its master playlist
+        fx.mock.failNext(fx.mock.masterPath(1001), MockFault.Delay(3.seconds))
+
+        fx.get("/add?name=model").expectOk("Room added: model")
+        fx.get("/activate?id=1001").expectOk("Activated")
+        fx.await(10.seconds, "master playlist request") {
+            fx.mock.requests().firstOrNull { it.path == fx.mock.masterPath(1001) }
+        }
+
+        fx.get("/remove?id=1001").expectOk("Removed")
+        fx.awaitRoomAbsent(1001)
+        delay(1500)
+        assertTrue(fx.sessions().isEmpty(), "a removed room must not start a session")
+        assertTrue(fx.events.filterIsInstance<SegmentDownloaded>().isEmpty(), "a removed room must not download")
     }
 
     @Test

--- a/src/test/kotlin/github/rikacelery/v3/integration/RoomRoutesIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/RoomRoutesIntegrationTest.kt
@@ -3,6 +3,7 @@ package github.rikacelery.v3.integration
 import github.rikacelery.v3.components.SessionState
 import github.rikacelery.v3.events.EndReason
 import github.rikacelery.v3.events.FileReady
+import github.rikacelery.v3.events.RecordingStarted
 import github.rikacelery.v3.events.SegmentDownloaded
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
@@ -135,17 +136,17 @@ class RoomRoutesIntegrationTest {
         assertEquals(EndReason.NewInit, broken.reason)
 
         // the scheduler preconfigures again automatically after a break and keeps recording
-        fx.awaitEventCount<SegmentDownloaded>(3, 15.seconds) { it.roomId == 1001L }
+        fx.awaitEventCount<RecordingStarted>(2, 15.seconds) { it.roomId == 1001L }
+        val downloadsBeforeRestart = fx.events.filterIsInstance<SegmentDownloaded>().count { it.roomId == 1001L }
 
         // /restart stops the running session (closing its file) and arms the room again
         fx.get("/restart?id=1001").expectOk("Restarted")
         val afterRestart = fx.awaitEventCount<FileReady>(2, 15.seconds) { it.roomId == 1001L }
         assertEquals(EndReason.UserStop, afterRestart[1].reason)
 
-        // an armed room resumes when the stream status changes again
-        fx.mock.setRoomStatus(1001, "off")
-        fx.mock.setRoomStatus(1001, "public")
-        fx.awaitEventCount<SegmentDownloaded>(5, 15.seconds) { it.roomId == 1001L }
+        // the room is still public, so re-arming it records again without a status change
+        fx.awaitEventCount<RecordingStarted>(3, 20.seconds) { it.roomId == 1001L }
+        fx.awaitEventCount<SegmentDownloaded>(downloadsBeforeRestart + 1, 20.seconds) { it.roomId == 1001L }
 
         fx.get("/remove?id=1001").expectOk("Removed")
         val all = fx.awaitEventCount<FileReady>(3, 15.seconds) { it.roomId == 1001L }

--- a/src/test/kotlin/github/rikacelery/v3/integration/RoomRoutesIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/RoomRoutesIntegrationTest.kt
@@ -1,0 +1,320 @@
+package github.rikacelery.v3.integration
+
+import github.rikacelery.v3.components.SessionState
+import github.rikacelery.v3.data.RuntimeTuning
+import github.rikacelery.v3.events.EndReason
+import github.rikacelery.v3.events.FileReady
+import github.rikacelery.v3.events.SegmentDownloaded
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Room control routes driven through the production HTTP application against the mock
+ * platform: the real Room/Scheduler/Session/Downloader/Writer actors do the work.
+ */
+class RoomRoutesIntegrationTest {
+
+    @Test
+    fun `add inactive activate record remove closes the file`() = withFixture { fx ->
+        fx.ready()
+        fx.mock.addRoom(1001, "model", status = "off")
+
+        fx.get("/add?name=model&active=false").expectOk("Room added: model")
+        fx.awaitRoom("model") { !it.bool("listening") }
+        assertEquals(listOf(1001L), fx.rooms().map { it.id })
+        assertTrue(fx.sessions().isEmpty(), "inactive room must not have a session")
+
+        fx.get("/activate?id=1001").expectOk("Activated")
+        fx.mock.startSegments(1001, 30.milliseconds)
+        fx.awaitRoomSubscribed(1001)
+        fx.mock.setRoomStatus(1001, "public")
+
+        fx.awaitSession(1001, SessionState.Recording)
+        fx.awaitEvent<SegmentDownloaded>(10.seconds) { it.roomId == 1001L }
+
+        fx.get("/remove?id=1001").expectOk("Removed")
+        val file = fx.awaitFile(1001)
+        assertTrue(file.exists(), "recorded file must exist: ${file.absolutePath}")
+        assertTrue(file.length() > 0, "recorded file must not be empty")
+        fx.awaitRoomAbsent(1001)
+    }
+
+    @Test
+    fun `active add arms and records without a separate activate`() = withFixture { fx ->
+        fx.ready()
+        fx.mock.addRoom(1002, "active", status = "public")
+        fx.mock.startSegments(1002, 30.milliseconds)
+
+        fx.get("/add?name=active&active=true").expectOk("Room added: active")
+        fx.awaitSession(1002, SessionState.Recording)
+        fx.awaitEvent<SegmentDownloaded>(10.seconds) { it.roomId == 1002L }
+        assertTrue(fx.awaitRoom("active") { it.bool("listening") && it.path("session.active") == "true" }.isNotEmpty())
+    }
+
+    @Test
+    fun `invalid and duplicate input is rejected`() = withFixture { fx ->
+        fx.ready()
+        fx.mock.addRoom(1001, "model", status = "off")
+
+        val missingName = fx.get("/add")
+        assertEquals(HttpStatusCode.BadRequest, missingName.status)
+        assertEquals("Missing name", missingName.bodyAsText())
+
+        val unknown = fx.get("/add?name=ghost")
+        assertEquals(HttpStatusCode.InternalServerError, unknown.status)
+        assertTrue(unknown.bodyAsText().contains("failed to add room"), unknown.bodyAsText())
+
+        fx.get("/add?name=model").expectOk("Room added: model")
+        val duplicate = fx.get("/add?name=model")
+        assertEquals(HttpStatusCode.InternalServerError, duplicate.status)
+        assertTrue(duplicate.bodyAsText().contains("Exist model"), duplicate.bodyAsText())
+
+        assertEquals(HttpStatusCode.BadRequest, fx.get("/remove").status)
+        assertEquals(HttpStatusCode.BadRequest, fx.get("/activate").status)
+        assertEquals(HttpStatusCode.BadRequest, fx.get("/deactivate").status)
+        assertEquals(HttpStatusCode.BadRequest, fx.get("/quality").status)
+        assertEquals(HttpStatusCode.BadRequest, fx.get("/limit").status)
+        assertEquals(HttpStatusCode.BadRequest, fx.get("/sizelimit").status)
+        assertEquals(HttpStatusCode.BadRequest, fx.get("/autopay?id=1001").status)
+        assertEquals(HttpStatusCode.BadRequest, fx.get("/autopay?id=1001&v=true&kind=bogus").status)
+    }
+
+    @Test
+    fun `deactivate stops the recording and closes the file`() = withFixture { fx ->
+        fx.ready()
+        fx.startRecording()
+
+        fx.get("/deactivate?id=1001").expectOk("Deactivated")
+        val ready = fx.awaitEvent<FileReady>(15.seconds) { it.roomId == 1001L }
+        assertEquals(EndReason.UserStop, ready.reason)
+        assertTrue(ready.file.length() > 0)
+        fx.awaitSession(1001, SessionState.Idle)
+        // the room stays in list.conf (disarmed) and its session entry is retained as Idle
+        fx.awaitRoom("model") { it.path("session.status") == "Idle" && it.path("session.active") == "false" }
+    }
+
+    @Test
+    fun `break and restart produce separate files`() = withFixture { fx ->
+        fx.ready()
+        fx.startRecording()
+
+        fx.get("/break?id=1001").expectOk("Break signaled")
+        val broken = fx.awaitEvent<FileReady>(15.seconds) { it.roomId == 1001L }
+        assertEquals(EndReason.NewInit, broken.reason)
+
+        // the scheduler preconfigures again automatically after a break and keeps recording
+        fx.awaitEventCount<SegmentDownloaded>(3, 15.seconds) { it.roomId == 1001L }
+
+        // /restart stops the running session (closing its file) and arms the room again
+        fx.get("/restart?id=1001").expectOk("Restarted")
+        val afterRestart = fx.awaitEventCount<FileReady>(2, 15.seconds) { it.roomId == 1001L }
+        assertEquals(EndReason.UserStop, afterRestart[1].reason)
+
+        // an armed room resumes when the stream status changes again
+        fx.mock.setRoomStatus(1001, "off")
+        fx.mock.setRoomStatus(1001, "public")
+        fx.awaitEventCount<SegmentDownloaded>(5, 15.seconds) { it.roomId == 1001L }
+
+        fx.get("/remove?id=1001").expectOk("Removed")
+        val all = fx.awaitEventCount<FileReady>(3, 15.seconds) { it.roomId == 1001L }
+        assertEquals(
+            listOf(EndReason.NewInit, EndReason.UserStop, EndReason.UserStop),
+            all.map { it.reason },
+            "each cut must publish its own FileReady"
+        )
+        assertTrue(all.all { it.file.exists() && it.file.length() > 0 }, "every file must have bytes")
+    }
+
+    @Test
+    fun `quality change restarts the recording at the requested variant`() = withFixture { fx ->
+        fx.ready()
+        fx.startRecording()
+
+        // "highest" resolves to the top variant of the mock ladder
+        fx.awaitSession(1001, SessionState.Recording, quality = "720p")
+
+        fx.get("/quality?id=1001&q=360p").expectOk("Quality set to 360p")
+        fx.awaitRoom("model") { it.path("room.quality") == "360p" }
+
+        fx.awaitEvent<FileReady>(15.seconds) { it.roomId == 1001L }
+        fx.awaitSession(1001, SessionState.Recording, quality = "360p")
+    }
+
+    @Test
+    fun `time limit stops the recording`() = withFixture { fx ->
+        fx.ready()
+        fx.mock.addRoom(1001, "model", status = "public")
+        fx.mock.startSegments(1001, 30.milliseconds)
+
+        fx.get("/add?name=model&limit=1").expectOk("Room added: model")
+        fx.get("/activate?id=1001").expectOk("Activated")
+        fx.awaitSession(1001, SessionState.Recording)
+
+        val ready = fx.awaitEvent<FileReady>(20.seconds) { it.roomId == 1001L }
+        assertEquals(EndReason.TimeLimit, ready.reason)
+    }
+
+    @Test
+    fun `size limit stops the recording`() = withFixture { fx ->
+        fx.ready()
+        fx.mock.addRoom(1001, "model", status = "public")
+        fx.mock.startSegments(1001, 30.milliseconds)
+
+        // 1Ki = 1024 bytes: init (128) + two 512-byte segments crosses the limit
+        fx.get("/add?name=model&size=1Ki").expectOk("Room added: model")
+        fx.get("/activate?id=1001").expectOk("Activated")
+        fx.awaitSession(1001, SessionState.Recording)
+
+        val ready = fx.awaitEvent<FileReady>(20.seconds) { it.roomId == 1001L }
+        assertEquals(EndReason.SizeLimit, ready.reason)
+        assertTrue(ready.file.length() >= 1024, "file must have crossed the size limit: ${ready.file.length()}")
+    }
+
+    @Test
+    fun `group show and private autopay both record`() = withFixture { fx ->
+        fx.ready()
+        fx.mock.addRoom(1001, "model", status = "groupShow")
+        fx.mock.startSegments(1001, 30.milliseconds)
+
+        fx.get("/add?name=model&autopayTicket=true&autoPaySpy=true").expectOk("Room added: model")
+        fx.get("/activate?id=1001").expectOk("Activated")
+
+        fx.awaitSession(1001, SessionState.Recording)
+        assertTrue(
+            fx.mock.requests().any { it.method == "POST" && it.path.contains("/groupShows/") },
+            "group show must be purchased: ${fx.mock.requests().map { "${it.method} ${it.path}" }}"
+        )
+
+        // switch the room to a paid private show; the old recording is cut and a spy show is purchased
+        fx.mock.room(1001).modelToken = ""
+        fx.mock.setRoomStatus(1001, "p2p")
+
+        fx.awaitEvent<FileReady>(15.seconds) { it.roomId == 1001L }
+        fx.awaitSession(1001, SessionState.Recording)
+        assertTrue(
+            fx.mock.requests().any { it.method == "PUT" && it.path.contains("/spy") },
+            "spy show must be purchased: ${fx.mock.requests().map { "${it.method} ${it.path}" }}"
+        )
+    }
+
+    @Test
+    fun `list and dashboard expose room state`() = withFixture { fx ->
+        fx.ready()
+        fx.startRecording()
+
+        val list = Json.parseToJsonElement(fx.get("/list").bodyAsText()).jsonArray
+        val entry = list.single { it.jsonArray[3].jsonPrimitive.content == "model" }.jsonArray
+        assertEquals("public", entry[0].jsonPrimitive.content)
+        assertEquals("listening", entry[1].jsonPrimitive.content)
+        assertEquals("recording", entry[2].jsonPrimitive.content)
+        assertEquals("1001", entry[4].jsonPrimitive.content)
+        assertEquals("highest", entry[5].jsonPrimitive.content)
+
+        val dashboard = fx.dashboard()
+        assertEquals(1, dashboard["rooms"]!!.jsonArray.size)
+        val listv2 = dashboard["listv2"]!!.jsonArray.single().jsonObject
+        assertEquals("model", listv2.path("room.name"))
+        assertTrue(listv2.bool("listening"))
+        assertTrue(dashboard["metrics"]!!.jsonPrimitive.content.isNotEmpty())
+
+        val status = Json.parseToJsonElement(fx.get("/status").bodyAsText()).jsonObject
+        assertTrue(status.isNotEmpty(), "status must report the active room")
+    }
+
+    @Test
+    fun `list conf persists armed and disarmed rooms`() = withFixture { fx ->
+        fx.ready()
+        fx.mock.addRoom(1001, "model", status = "off")
+
+        fx.get("/add?name=model&active=false").expectOk("Room added: model")
+        val disarmed = fx.awaitListConf(15.seconds) { it.contains("model") }
+        assertTrue(disarmed.trimStart().startsWith("#"), "inactive room must be commented out: $disarmed")
+
+        fx.get("/activate?id=1001").expectOk("Activated")
+        val armed = fx.awaitListConf(15.seconds) { it.contains("model") && !it.trimStart().startsWith("#") }
+        assertTrue(armed.contains("q:highest"), armed)
+
+        fx.get("/deactivate?id=1001").expectOk("Deactivated")
+        fx.awaitListConf(15.seconds) { it.contains("model") && it.trimStart().startsWith("#") }
+    }
+
+    @Test
+    fun `bootstrap reloads list conf and records armed rooms`() = withFixture { fx ->
+        fx.mock.addRoom(1001, "model", status = "public")
+        fx.mock.startSegments(1001, 30.milliseconds)
+        File(fx.listConfPath).writeText("https://mock/model q:720p limit:60 autopay\n")
+
+        fx.bootstrap()
+
+        val room = fx.rooms().single { it.id == 1001L }
+        assertEquals("720p", room.quality)
+        assertEquals(60.seconds, room.timeLimit)
+        assertTrue(room.autoPayTicket && room.autoPaySpy, "bare 'autopay' enables both kinds")
+        fx.awaitSession(1001, SessionState.Recording, quality = "720p")
+    }
+}
+
+private fun withFixture(
+    tuning: RuntimeTuning = XhrecIntegrationFixture.testTuning(),
+    block: suspend (XhrecIntegrationFixture) -> Unit
+) = testApplication {
+    XhrecIntegrationFixture(this, tuning = tuning).use { fx ->
+        fx.start()
+        fx.installRoutes()
+        block(fx)
+    }
+}
+
+/** Adds an inactive room, activates it, publishes public status and waits for recording. */
+private suspend fun XhrecIntegrationFixture.startRecording(
+    roomId: Long = 1001L,
+    name: String = "model",
+    status: String = "public",
+    segmentPeriod: Duration = 30.milliseconds
+) {
+    mock.addRoom(roomId, name, status = status)
+    get("/add?name=$name&active=false").expectOk("Room added: $name")
+    awaitRoom(name) { !it.bool("listening") }
+    get("/activate?id=$roomId").expectOk("Activated")
+    mock.startSegments(roomId, segmentPeriod)
+    awaitRoomSubscribed(roomId)
+    mock.setRoomStatus(roomId, status)
+    awaitSession(roomId, SessionState.Recording)
+    awaitEvent<SegmentDownloaded>(10.seconds) { it.roomId == roomId }
+}
+
+private fun JsonObject.bool(field: String): Boolean =
+    this[field]?.jsonPrimitive?.content?.toBoolean() ?: false
+
+internal fun JsonObject.path(path: String): String? {
+    var element: kotlinx.serialization.json.JsonElement = this
+    for (part in path.split('.')) {
+        element = element.jsonObject[part] ?: return null
+    }
+    return element.jsonPrimitive.content
+}
+
+internal suspend fun HttpResponse.expectOk() {
+    val text = bodyAsText()
+    assertEquals(HttpStatusCode.OK, status, "unexpected status, body=$text")
+}
+
+internal suspend fun HttpResponse.expectOk(expectedBody: String) {
+    val text = bodyAsText()
+    assertEquals(HttpStatusCode.OK, status, "unexpected status, body=$text")
+    assertEquals(expectedBody, text)
+}

--- a/src/test/kotlin/github/rikacelery/v3/integration/StatusFlowIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/StatusFlowIntegrationTest.kt
@@ -1,0 +1,215 @@
+package github.rikacelery.v3.integration
+
+import github.rikacelery.v3.components.SessionState
+import github.rikacelery.v3.events.EndReason
+import github.rikacelery.v3.events.FileReady
+import github.rikacelery.v3.events.SegmentDownloaded
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Status-driven recording decisions plus byte-exact output: the file the Writer closes must
+ * equal the mock's init+segment bytes, in order, no matter how downloads complete.
+ */
+class StatusFlowIntegrationTest {
+
+    @ParameterizedTest(name = "status={0} ticket={1} spy={2} records={3}")
+    @CsvSource(
+        "off,false,false,false",
+        "public,false,false,true",
+        "groupShow,false,false,false",
+        "groupShow,true,false,true",
+        "p2p,false,false,false",
+        "p2p,false,true,true",
+        "virtualPrivate,false,true,true",
+        "weirdStatus,false,false,false",
+        "weirdStatus,false,true,true"
+    )
+    fun `room status gates recording`(
+        status: String,
+        autoPayTicket: Boolean,
+        autoPaySpy: Boolean,
+        expectRecording: Boolean
+    ) = testApplication {
+        XhrecIntegrationFixture(this).use { fx ->
+            fx.start()
+            fx.installRoutes()
+            fx.ready()
+            fx.mock.addRoom(1001, "model", status = "off")
+
+            fx.get("/add?name=model&autopayTicket=$autoPayTicket&autoPaySpy=$autoPaySpy")
+                .expectOk("Room added: model")
+            fx.get("/activate?id=1001").expectOk("Activated")
+            fx.mock.startSegments(1001, 40.milliseconds)
+            fx.awaitRoomSubscribed(1001)
+            fx.mock.setStreamStatus(1001, "distributing")
+            fx.mock.setRoomStatus(1001, status)
+
+            if (expectRecording) {
+                fx.awaitSession(1001, SessionState.Recording)
+                fx.awaitEvent<SegmentDownloaded>(15.seconds) { it.roomId == 1001L }
+            } else {
+                // bounded negative: the room must stay quiet while the status is not recordable
+                delay(1500)
+                assertTrue(
+                    fx.sessions().none { it.roomId == 1001L && it.state == SessionState.Recording },
+                    "room must not record while status=$status"
+                )
+                assertTrue(
+                    fx.events.filterIsInstance<SegmentDownloaded>().isEmpty(),
+                    "no segment may be fetched while status=$status"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `recorded file equals mock init and segment bytes`() = testApplication {
+        XhrecIntegrationFixture(this).use { fx ->
+            fx.start()
+            fx.installRoutes()
+            fx.ready()
+            val room = fx.mock.addRoom(1001, "model", status = "off")
+
+            fx.get("/add?name=model").expectOk("Room added: model")
+            fx.get("/activate?id=1001").expectOk("Activated")
+            fx.awaitRoomSubscribed(1001)
+            fx.mock.setRoomStatus(1001, "public")
+            fx.awaitSession(1001, SessionState.Recording)
+
+            // one segment at a time keeps the expected file deterministic
+            fx.awaitEventCount<SegmentDownloaded>(1, 15.seconds) { it.roomId == 1001L }
+            repeat(4) { index ->
+                room.advanceSegment()
+                fx.awaitEventCount<SegmentDownloaded>(index + 2, 15.seconds) { it.roomId == 1001L }
+            }
+
+            fx.mock.setRoomStatus(1001, "off")
+            val ready = fx.awaitFile(1001)
+            assertContentEquals(
+                fx.mock.expectedBytes(1001, room.generation, throughIndex = 4),
+                ready.readBytes(),
+                "file must contain init + segments 1..4 in order"
+            )
+        }
+    }
+
+    @Test
+    fun `out-of-order downloads are still written in order`() = testApplication {
+        XhrecIntegrationFixture(this).use { fx ->
+            fx.start()
+            fx.installRoutes()
+            fx.ready()
+            val room = fx.mock.addRoom(1001, "model", status = "public")
+
+            fx.get("/add?name=model&active=true").expectOk("Room added: model")
+            fx.awaitSession(1001, SessionState.Recording)
+            fx.awaitEventCount<SegmentDownloaded>(1, 15.seconds) { it.roomId == 1001L }
+
+            // segment 1 completes long after segment 2
+            fx.mock.delaySegment(1001, 1, 400.milliseconds)
+            room.advanceSegment()
+            room.advanceSegment()
+            fx.awaitEventCount<SegmentDownloaded>(3, 20.seconds) { it.roomId == 1001L }
+
+            val completion = fx.mock.completionOrder(1001).distinct()
+            assertTrue(
+                completion.indexOf(2) < completion.indexOf(1),
+                "mock must finish segment 2 first: $completion"
+            )
+
+            fx.get("/remove?id=1001").expectOk("Removed")
+            val ready = fx.awaitFile(1001)
+            assertContentEquals(
+                fx.mock.expectedBytes(1001, room.generation, throughIndex = 2),
+                ready.readBytes(),
+                "writer must reorder completions into segment order"
+            )
+        }
+    }
+
+    @Test
+    fun `finished stream status stops the recording`() = testApplication {
+        XhrecIntegrationFixture(this).use { fx ->
+            fx.start()
+            fx.installRoutes()
+            fx.ready()
+            fx.startRecording()
+
+            fx.mock.setStreamStatus(1001, "finished")
+
+            val ready = fx.awaitEvent<FileReady>(15.seconds) { it.roomId == 1001L }
+            assertEquals(EndReason.StreamEnd, ready.reason)
+            assertTrue(ready.file.length() > 0)
+        }
+    }
+
+    @Test
+    fun `automatic status rotation produces one file per episode`() = testApplication {
+        XhrecIntegrationFixture(this).use { fx ->
+            fx.start()
+            fx.installRoutes()
+            fx.ready()
+            fx.mock.addRoom(1001, "model", status = "off")
+
+            fx.get("/add?name=model").expectOk("Room added: model")
+            fx.get("/activate?id=1001").expectOk("Activated")
+            fx.mock.startSegments(1001, 40.milliseconds)
+            fx.awaitRoomSubscribed(1001)
+
+            val rotation = fx.mock.rotateStatuses(1001, listOf("public", "off"), 900.milliseconds)
+            try {
+                fx.awaitSession(1001, SessionState.Recording, timeout = 20.seconds)
+                val files = fx.awaitEventCount<FileReady>(2, 30.seconds) { it.roomId == 1001L }
+                assertEquals(2, files.size, "each off phase must close one file")
+                assertTrue(files.all { it.reason == EndReason.StreamEnd }, files.map { it.reason }.toString())
+                assertTrue(files.all { it.file.length() > 0 })
+            } finally {
+                rotation.cancelAndJoin()
+            }
+        }
+    }
+
+    @Test
+    fun `two rooms record isolated bytes`() = testApplication {
+        XhrecIntegrationFixture(this).use { fx ->
+            fx.start()
+            fx.installRoutes()
+            fx.ready()
+            val first = fx.mock.addRoom(1001, "modelA", status = "public")
+            val second = fx.mock.addRoom(1002, "modelB", status = "public")
+
+            fx.get("/add?name=modelA&active=true").expectOk("Room added: modelA")
+            fx.get("/add?name=modelB&active=true").expectOk("Room added: modelB")
+            fx.awaitSession(1001, SessionState.Recording)
+            fx.awaitSession(1002, SessionState.Recording)
+            fx.awaitEventCount<SegmentDownloaded>(1, 15.seconds) { it.roomId == 1001L }
+            fx.awaitEventCount<SegmentDownloaded>(1, 15.seconds) { it.roomId == 1002L }
+
+            repeat(2) { index ->
+                first.advanceSegment()
+                second.advanceSegment()
+                fx.awaitEventCount<SegmentDownloaded>(index + 2, 15.seconds) { it.roomId == 1001L }
+                fx.awaitEventCount<SegmentDownloaded>(index + 2, 15.seconds) { it.roomId == 1002L }
+            }
+
+            fx.get("/remove?id=1001").expectOk("Removed")
+            fx.get("/remove?id=1002").expectOk("Removed")
+            val fileA = fx.awaitFile(1001).readBytes()
+            val fileB = fx.awaitFile(1002).readBytes()
+
+            assertContentEquals(fx.mock.expectedBytes(1001, first.generation, throughIndex = 2), fileA)
+            assertContentEquals(fx.mock.expectedBytes(1002, second.generation, throughIndex = 2), fileB)
+            assertTrue(!fileA.contentEquals(fileB), "rooms must not share segment bytes")
+        }
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/integration/WebSocketFallbackIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/WebSocketFallbackIntegrationTest.kt
@@ -1,0 +1,231 @@
+package github.rikacelery.v3.integration
+
+import github.rikacelery.v3.components.SessionState
+import github.rikacelery.v3.data.Hosts
+import github.rikacelery.v3.utils.CdnSelector
+import github.rikacelery.v3.events.EndReason
+import github.rikacelery.v3.events.FileReady
+import github.rikacelery.v3.events.RecordingStarted
+import github.rikacelery.v3.events.RoomStatusChanged
+import github.rikacelery.v3.events.SegmentDownloaded
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.delay
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * WebSocket delivery is the fast path for room status; HTTP polling is the fallback and the
+ * recovery path. Both must drive the real Scheduler/Session actors without duplicates.
+ */
+class WebSocketFallbackIntegrationTest {
+
+    @Test
+    fun `websocket push starts recording while polling is idle`() = testApplication {
+        val tuning = XhrecIntegrationFixture.testTuning(roomPollInterval = 30.seconds)
+        withFixture(tuning) { fx ->
+            fx.ready()
+            fx.mock.addRoom(1001, "model", status = "off")
+
+            fx.get("/add?name=model").expectOk("Room added: model")
+            fx.get("/activate?id=1001").expectOk("Activated")
+            fx.mock.startSegments(1001, 40.milliseconds)
+            fx.awaitRoomSubscribed(1001)
+            assertTrue(fx.sessions().isEmpty(), "offline room must not record yet")
+
+            // the only signal is the WebSocket frame; the 30s poll cannot have fired
+            fx.mock.setRoomStatus(1001, "public")
+
+            fx.awaitSession(1001, SessionState.Recording, timeout = 10.seconds)
+            fx.awaitEvent<SegmentDownloaded>(10.seconds) { it.roomId == 1001L }
+        }
+    }
+
+    @Test
+    fun `nested model status and stream status frames drive the session`() = testApplication {
+        val tuning = XhrecIntegrationFixture.testTuning(roomPollInterval = 30.seconds)
+        withFixture(tuning) { fx ->
+            fx.ready()
+            fx.mock.addRoom(1001, "model", status = "off")
+
+            fx.get("/add?name=model").expectOk("Room added: model")
+            fx.get("/activate?id=1001").expectOk("Activated")
+            fx.mock.startSegments(1001, 40.milliseconds)
+            fx.awaitRoomSubscribed(1001)
+
+            // the mock's HTTP view and the frame must agree; only the frame is pushed
+            fx.mock.setRoomStatus(1001, "public", push = false)
+            // status nested under "model" instead of top-level
+            fx.mock.push(
+                "modelStatusChanged@1001",
+                buildJsonObject { put("model", buildJsonObject { put("status", "public") }) }
+            )
+            fx.awaitSession(1001, SessionState.Recording, timeout = 10.seconds)
+            fx.awaitEvent<SegmentDownloaded>(10.seconds) { it.roomId == 1001L }
+
+            // stream lifecycle is a separate domain and ends the recording
+            fx.mock.push("streamChanged@1001", buildJsonObject { put("status", "finished") })
+            val ready = fx.awaitEvent<FileReady>(10.seconds) { it.roomId == 1001L }
+            assertEquals(EndReason.StreamEnd, ready.reason)
+        }
+    }
+
+    @Test
+    fun `duplicate status frames are suppressed`() = testApplication {
+        val tuning = XhrecIntegrationFixture.testTuning(roomPollInterval = 30.seconds)
+        withFixture(tuning) { fx ->
+            fx.ready()
+            fx.mock.addRoom(1001, "model", status = "off")
+
+            fx.get("/add?name=model").expectOk("Room added: model")
+            fx.get("/activate?id=1001").expectOk("Activated")
+            fx.awaitRoomSubscribed(1001)
+
+            repeat(3) { fx.mock.setRoomStatus(1001, "public") }
+            delay(500)
+
+            assertEquals(
+                1,
+                fx.events.filterIsInstance<RoomStatusChanged>().count { it.roomId == 1001L && it.newStatus == "public" },
+                "repeated identical frames must not republish the status"
+            )
+        }
+    }
+
+    @Test
+    fun `malformed frame does not block the next valid frame`() = testApplication {
+        val tuning = XhrecIntegrationFixture.testTuning(roomPollInterval = 30.seconds)
+        withFixture(tuning) { fx ->
+            fx.ready()
+            fx.mock.addRoom(1001, "model", status = "off")
+
+            fx.get("/add?name=model").expectOk("Room added: model")
+            fx.get("/activate?id=1001").expectOk("Activated")
+            fx.mock.startSegments(1001, 40.milliseconds)
+            fx.awaitRoomSubscribed(1001)
+
+            fx.mock.setRoomStatus(1001, "public", push = false)
+            val valid = buildJsonObject {
+                put("push", buildJsonObject {
+                    put("channel", "broadcastChanged@1001")
+                    put("pub", buildJsonObject { put("data", buildJsonObject { put("status", "public") }) })
+                })
+            }
+            fx.mock.pushRaw("broadcastChanged@1001", "{\"push\":{\"channel\":\"broadcastChanged@1001\"" + "\n" + valid)
+
+            fx.awaitSession(1001, SessionState.Recording, timeout = 10.seconds)
+        }
+    }
+
+    @Test
+    fun `subscription set expands while recording and shrinks when removed`() = testApplication {
+        withFixture { fx ->
+            fx.ready()
+            fx.mock.addRoom(1001, "model", status = "off")
+
+            fx.get("/add?name=model").expectOk("Room added: model")
+            fx.awaitRoomSubscribed(1001)
+            val idle = fx.mock.subscribedChannels().filter { it.endsWith("@1001") }.toSet()
+            assertTrue("broadcastChanged@1001" in idle, "tracked rooms need status channels: $idle")
+            assertTrue("newChatMessage@1001" !in idle, "idle rooms must not hold the full set: $idle")
+
+            fx.get("/activate?id=1001").expectOk("Activated")
+            fx.mock.setRoomStatus(1001, "public")
+            fx.awaitSession(1001, SessionState.Recording)
+            assertTrue(
+                fx.mock.awaitSubscription("newChatMessage@1001", 10.seconds),
+                "recording rooms need the full channel set: ${fx.mock.subscribedChannels()}"
+            )
+
+            fx.get("/remove?id=1001").expectOk("Removed")
+            assertTrue(
+                fx.mock.awaitSubscriptionGone("broadcastChanged@1001", 10.seconds),
+                "removed rooms must be unsubscribed: ${fx.mock.subscribedChannels()}"
+            )
+            assertTrue(fx.mock.awaitSubscriptionGone("newChatMessage@1001", 10.seconds))
+        }
+    }
+
+    @Test
+    fun `all platform traffic stays on the loopback mock`() = testApplication {
+        withFixture { fx ->
+            fx.ready()
+            fx.startRecording()
+
+            assertTrue(fx.mock.requests().isNotEmpty(), "the fixture must have talked to the mock")
+            assertTrue(
+                fx.mock.requests().all { it.path.startsWith("/") && !it.path.startsWith("//") },
+                "requests must be relative paths on the mock: ${fx.mock.requests().map { it.path }}"
+            )
+            assertEquals(listOf(fx.mock.host), Hosts.current.platformHosts)
+            assertEquals(listOf(fx.mock.host), Hosts.current.webSocketHosts)
+            assertTrue(CdnSelector.hosts.isEmpty(), "CDN rewriting must be disabled: ${CdnSelector.hosts}")
+            assertTrue(fx.mock.requests().any { it.path.startsWith("/hls/1001/") })
+        }
+    }
+
+    @Test
+    fun `rejected websocket falls back to http polling`() = testApplication {
+        val tuning = XhrecIntegrationFixture.testTuning(roomPollInterval = 300.milliseconds)
+        withFixture(tuning) { fx ->
+            fx.ready()
+            fx.mock.addRoom(1001, "model", status = "off")
+            fx.mock.rejectWebSockets(true)
+
+            fx.get("/add?name=model").expectOk("Room added: model")
+            fx.get("/activate?id=1001").expectOk("Activated")
+            fx.mock.startSegments(1001, 40.milliseconds)
+            delay(300)
+
+            // HTTP status changes without any WebSocket push
+            fx.mock.setRoomStatus(1001, "public", push = false)
+
+            fx.awaitSession(1001, SessionState.Recording, timeout = 20.seconds)
+            assertTrue(
+                fx.mock.pushes().none { it.channel == "broadcastChanged@1001" },
+                "no push may have been delivered: ${fx.mock.pushes()}"
+            )
+        }
+    }
+
+    @Test
+    fun `recovery resumes pushes after a reconnect catch-up`() = testApplication {
+        val tuning = XhrecIntegrationFixture.testTuning(roomPollInterval = 30.seconds)
+        withFixture(tuning) { fx ->
+            fx.ready()
+            fx.mock.addRoom(1001, "model", status = "off")
+            fx.mock.rejectWebSockets(true)
+
+            fx.get("/add?name=model").expectOk("Room added: model")
+            fx.get("/activate?id=1001").expectOk("Activated")
+            fx.mock.startSegments(1001, 40.milliseconds)
+
+            // polling is off (30s) and the WebSocket is rejected, so nothing records yet
+            delay(1000)
+            assertTrue(fx.sessions().isEmpty(), "no transport is available yet")
+
+            // the status changes while the socket is down; only the reconnect catch-up can see it
+            fx.mock.setRoomStatus(1001, "public", push = false)
+            fx.mock.rejectWebSockets(false)
+            assertTrue(fx.mock.awaitSubscription("broadcastChanged@1001", 20.seconds))
+
+            fx.awaitSession(1001, SessionState.Recording, timeout = 20.seconds)
+            // let the recovered session actually record a segment, so the stop closes a non-empty file
+            fx.awaitEvent<SegmentDownloaded>(15.seconds) { it.roomId == 1001L }
+
+            // pushes resume and are not duplicated
+            fx.mock.setRoomStatus(1001, "off")
+            val ready = fx.awaitEvent<FileReady>(20.seconds) { it.roomId == 1001L }
+            assertEquals(EndReason.StreamEnd, ready.reason)
+            assertEquals(
+                1,
+                fx.events.filterIsInstance<RecordingStarted>().count { it.roomId == 1001L },
+                "recovery must not start a second recording episode"
+            )
+        }
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/integration/XhrecIntegrationFixture.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/XhrecIntegrationFixture.kt
@@ -1,0 +1,445 @@
+package github.rikacelery.v3.integration
+
+import github.rikacelery.v3.api.ApiClient
+import github.rikacelery.v3.components.AuthComponent
+import github.rikacelery.v3.components.ConfigComponent
+import github.rikacelery.v3.components.DownloaderComponent
+import github.rikacelery.v3.components.HttpServerComponent
+import github.rikacelery.v3.components.LiveEventSource
+import github.rikacelery.v3.components.LoadUsers
+import github.rikacelery.v3.components.MetricComponent
+import github.rikacelery.v3.components.PostProcessorComponent
+import github.rikacelery.v3.components.RoomComponent
+import github.rikacelery.v3.components.RoomSession
+import github.rikacelery.v3.components.SchedulerComponent
+import github.rikacelery.v3.components.SessionComponent
+import github.rikacelery.v3.components.SessionState
+import github.rikacelery.v3.components.WriterComponent
+import github.rikacelery.v3.core.DataChannel
+import github.rikacelery.v3.core.EventBus
+import github.rikacelery.v3.core.RequestBus
+import github.rikacelery.v3.data.Hosts
+import github.rikacelery.v3.data.HostsConfig
+import github.rikacelery.v3.data.Room
+import github.rikacelery.v3.data.RuntimeTuning
+import github.rikacelery.v3.data.SystemConfig
+import github.rikacelery.v3.data.User
+import github.rikacelery.v3.events.FileReady
+import github.rikacelery.v3.events.CommandAck
+import github.rikacelery.v3.events.CommandEnvelope
+import github.rikacelery.v3.events.GetArmedRoomIds
+import github.rikacelery.v3.events.GetRooms
+import github.rikacelery.v3.events.GetSessions
+import github.rikacelery.v3.events.RoomAdded
+import github.rikacelery.v3.hooks.EventHook
+import github.rikacelery.v3.m3u8.M3u8Parser
+import github.rikacelery.v3.utils.CdnSelector
+import github.rikacelery.v3.utils.HttpClientProvider
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.client.request.get
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.server.testing.ApplicationTestBuilder
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Runs the real XhRec component graph in-process against one loopback [MockPlatformServer].
+ *
+ * Only the network boundary and the clock are replaced: clients go straight to the mock
+ * (no proxy, no CDN rewriting), timings are compressed, and the writer keeps every byte.
+ * Everything else — Room/Scheduler/Session/Downloader/Writer actors, the FSM matrices,
+ * and the production HTTP routes — is the shipping implementation.
+ */
+class XhrecIntegrationFixture(
+    private val app: ApplicationTestBuilder,
+    val mock: MockPlatformServer = MockPlatformServer(),
+    val tuning: RuntimeTuning = testTuning()
+) : AutoCloseable {
+
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val eventBus = EventBus()
+    val dataChannel = DataChannel(capacity = 4096)
+    val requestBus = RequestBus(eventBus, scope, defaultTimeoutMs = 15_000)
+    val provider = TestHttpClientProvider()
+    val tempRoot: Path = Files.createTempDirectory("xhrec-it")
+    val outputDir: File = tempRoot.resolve("out").toFile().apply { mkdirs() }
+    val tmpDir: File = tempRoot.resolve("tmp").toFile().apply { mkdirs() }
+    val listConfPath: String = tempRoot.resolve("list.conf").toString()
+    val usersPath: String = tempRoot.resolve("users.txt").toString()
+    val configPath: String = tempRoot.resolve("xhrec.json").toString()
+
+    val events = CopyOnWriteArrayList<Any>()
+    private val previousHosts = Hosts.current
+    private val previousCdnHosts = CdnSelector.hosts
+
+    val apiClient = ApiClient(listOf(mock.host), provider) { host -> "http://$host" }
+
+    lateinit var config: SystemConfig
+        private set
+    lateinit var configComponent: ConfigComponent
+        private set
+    lateinit var authComponent: AuthComponent
+        private set
+    lateinit var roomComponent: RoomComponent
+        private set
+    lateinit var liveEventSource: LiveEventSource
+        private set
+    lateinit var downloaderComponent: DownloaderComponent
+        private set
+    lateinit var writerComponent: WriterComponent
+        private set
+    lateinit var sessionComponent: SessionComponent
+        private set
+    lateinit var schedulerComponent: SchedulerComponent
+        private set
+    lateinit var metricComponent: MetricComponent
+        private set
+    lateinit var postProcessorComponent: PostProcessorComponent
+        private set
+    lateinit var httpServer: HttpServerComponent
+        private set
+
+    /** Master playlist candidates pointing at the mock, with the production query shape. */
+    val masterUrlCandidates: (Long, String, String?) -> List<String> = { roomId, pkey, token ->
+        val url = buildString {
+            append(mock.masterUrl(roomId))
+            append("?psch=v2&pkey=").append(pkey)
+            token?.takeIf { it.isNotEmpty() }?.let { append("&aclAuth=").append(it) }
+        }
+        listOf(url)
+    }
+
+    fun start() {
+        eventBus.installHook(object : EventHook {
+            override suspend fun intercept(event: Any): Any? {
+                events += event
+                return event
+            }
+        })
+
+        Hosts.current = HostsConfig(
+            platformHosts = listOf(mock.host),
+            webSocketHosts = listOf(mock.host),
+            hlsHosts = emptyList(),
+            hlsMasterHost = mock.host,
+            webHost = mock.host,
+            previewHost = mock.host,
+            thumbHost = mock.host
+        )
+        CdnSelector.updateHosts(emptyList())
+
+        config = SystemConfig(
+            outputDir = outputDir,
+            tmpDir = tmpDir,
+            port = 0,
+            proxy = null,
+            decryptKeys = mapOf(MockPlatformServer.PSCH_KEY to mock.decryptKey),
+            streamAuthKey = MockPlatformServer.PSCH_KEY,
+            hosts = Hosts.current,
+            listConfPath = listConfPath,
+            configPath = configPath,
+            maskSensitiveLogs = false,
+            apiToken = ""
+        )
+
+        configComponent = ConfigComponent(config, apiClient, eventBus, scope)
+        authComponent = AuthComponent(usersPath, eventBus, scope)
+        roomComponent = RoomComponent(apiClient, listConfPath, requestBus, eventBus, scope, tuning)
+        liveEventSource = LiveEventSource(
+            tokenProvider = { apiClient.fetchGuestWsToken() },
+            eventBus = eventBus,
+            parentScope = scope,
+            wsPoolCount = 1,
+            httpClientProvider = provider,
+            runtimeTuning = tuning,
+            wsUrlBuilder = { host -> "ws://$host/connection/websocket" }
+        )
+        downloaderComponent = DownloaderComponent(
+            dataChannel,
+            eventBus = eventBus,
+            parentScope = scope,
+            initialConcurrency = 4,
+            httpClientProvider = provider,
+            runtimeTuning = tuning
+        )
+        writerComponent = WriterComponent(
+            dataChannel,
+            tmpDir,
+            emptyList(),
+            minOutputBytes = 0,
+            eventBus = eventBus,
+            parentScope = scope
+        )
+        sessionComponent = SessionComponent(
+            dataChannel,
+            downloaderComponent,
+            M3u8Parser,
+            requestBus,
+            eventBus,
+            scope,
+            provider,
+            tuning
+        )
+        schedulerComponent = SchedulerComponent(
+            requestBus,
+            sessionComponent,
+            apiClient,
+            config.streamAuthKey,
+            eventBus,
+            scope,
+            provider,
+            tuning,
+            masterUrlCandidates
+        )
+        metricComponent = MetricComponent(eventBus, scope)
+        postProcessorComponent = PostProcessorComponent(eventBus, scope)
+        httpServer = HttpServerComponent(
+            port = 0,
+            eventBus = eventBus,
+            requestBus = requestBus,
+            metricComponent = metricComponent,
+            postProcessorComponent = postProcessorComponent,
+            scope = scope,
+            runtimeTuning = tuning
+        )
+
+        configComponent.start()
+        authComponent.start()
+        metricComponent.start()
+        postProcessorComponent.start()
+        roomComponent.start()
+        liveEventSource.start()
+        downloaderComponent.start()
+        writerComponent.start()
+        sessionComponent.start()
+        schedulerComponent.start()
+    }
+
+    /** Marks the room list ready and loads one payable account for group/private flows. */
+    suspend fun ready(users: List<User> = listOf(User("cookie-1", 1L, "payer", 100_000L))) {
+        roomComponent.setReady()
+        authComponent.tell(LoadUsers(users))
+    }
+
+    /**
+     * Runs the production bootstrap against this fixture's list.conf/users.txt, exactly as
+     * `Main` does: rooms are added, armed lines are handed to the scheduler.
+     */
+    suspend fun bootstrap(vararg extraArgs: String) {
+        github.rikacelery.v3.bootstrap.Bootstrap(
+            apiClient,
+            roomComponent,
+            authComponent,
+            postProcessorComponent,
+            schedulerComponent
+        ).initialize(listOf("-f", listConfPath, "-u", usersPath) + extraArgs)
+    }
+
+    /**
+     * Waits until LiveEventSource has subscribed the room's status channels on the mock.
+     *
+     * `EventBus.subscribe` launches collectors asynchronously, so a room announced right
+     * after startup can miss its `RoomAdded`. Re-announcing is idempotent (subscribeRoom
+     * dedupes) and makes the WebSocket path deterministic instead of timing-dependent.
+     */
+    suspend fun awaitRoomSubscribed(roomId: Long, timeout: Duration = 10.seconds) {
+        val channel = "broadcastChanged@$roomId"
+        val deadline = System.currentTimeMillis() + timeout.inWholeMilliseconds
+        while (System.currentTimeMillis() < deadline) {
+            if (mock.subscribedChannels().contains(channel)) return
+            rooms().firstOrNull { it.id == roomId }?.let { eventBus.publish(RoomAdded(it.id, it.name)) }
+            delay(50.milliseconds)
+        }
+        throw AssertionError(
+            "timed out waiting for $channel; mock subscriptions=${mock.subscribedChannels()}; " +
+                "wsConnections=${mock.connectionCount()}"
+        )
+    }
+
+    /** Installs the production control routes into the Ktor test application. */
+    fun installRoutes() {
+        app.application { httpServer.installApplication(this, stopEngine = {}) }
+    }
+
+    suspend fun get(path: String): HttpResponse = app.client.get(path)
+
+    suspend fun dashboard(): JsonObject =
+        Json.parseToJsonElement(app.client.get("/dashboard").bodyAsText()).jsonObject
+
+    suspend fun rooms(): List<Room> = requestBus.request(GetRooms)
+
+    suspend fun sessions(): List<RoomSession> = requestBus.request(GetSessions)
+
+    suspend fun awaitRoom(
+        name: String,
+        timeout: Duration = 10.seconds,
+        predicate: (JsonObject) -> Boolean = { true }
+    ): JsonObject = await(timeout, "room $name") {
+        dashboard()["listv2"]?.jsonArray?.map { it.jsonObject }
+            ?.firstOrNull { it.path("room.name") == name }
+            ?.takeIf(predicate)
+    }
+
+    suspend fun awaitRoomAbsent(id: Long, timeout: Duration = 10.seconds) {
+        await(timeout, "room $id absent") {
+            if (rooms().none { it.id == id }) Unit else null
+        }
+    }
+
+    suspend fun awaitSession(
+        roomId: Long,
+        state: SessionState,
+        quality: String? = null,
+        timeout: Duration = 15.seconds
+    ) {
+        await(timeout, "session $roomId in $state${quality?.let { " @$it" } ?: ""}") {
+            sessions().firstOrNull {
+                it.roomId == roomId && it.state == state && (quality == null || it.quality == quality)
+            }
+        }
+    }
+
+    /** Waits until [count] matching events have been observed (useful for repeated FileReady). */
+    suspend inline fun <reified T : Any> awaitEventCount(
+        count: Int,
+        timeout: Duration = 15.seconds,
+        noinline predicate: (T) -> Boolean = { true }
+    ): List<T> = await(timeout, "$count × ${T::class.simpleName}") {
+        events.filterIsInstance<T>().filter(predicate).takeIf { it.size >= count }
+    }
+
+    /** Waits until list.conf exists and satisfies [predicate]. */
+    suspend fun awaitListConf(
+        timeout: Duration = 10.seconds,
+        predicate: (String) -> Boolean = { true }
+    ): String = await(timeout, "list.conf") {
+        val file = File(listConfPath)
+        file.takeIf { it.exists() }?.readText()?.takeIf(predicate)
+    }
+
+    suspend inline fun <reified T : Any> awaitEvent(
+        timeout: Duration = 10.seconds,
+        noinline predicate: (T) -> Boolean = { true }
+    ): T = await(timeout, "event ${T::class.simpleName}") {
+        events.filterIsInstance<T>().firstOrNull(predicate)
+    }
+
+    suspend fun awaitFile(roomId: Long, timeout: Duration = 15.seconds): File =
+        awaitEvent<FileReady>(timeout) { it.roomId == roomId }.file
+
+    suspend fun <T : Any> await(timeout: Duration, what: String, probe: suspend () -> T?): T {
+        val found = withTimeoutOrNull(timeout) {
+            var value: T? = null
+            while (value == null) {
+                value = probe()
+                if (value == null) delay(10.milliseconds)
+            }
+            value
+        }
+        return found ?: throw AssertionError(
+            "timed out after $timeout waiting for $what; " +
+                "recent events=${events.filterNot { it is CommandAck || it is CommandEnvelope }.takeLast(25)}; " +
+                "recent requests=${mock.requests().takeLast(15).map { "${it.method} ${it.path}" }}; " +
+                "sessions=${runCatching { sessions() }.getOrNull()}; " +
+                "armed=${runCatching { requestBus.request<List<Long>>(GetArmedRoomIds) }.getOrNull()}"
+        )
+    }
+
+    override fun close() {
+        runCatching { schedulerComponent.stop() }
+        runCatching { sessionComponent.stop() }
+        runCatching { downloaderComponent.stop() }
+        runCatching { writerComponent.stop() }
+        runCatching { liveEventSource.stop() }
+        runCatching { roomComponent.stop() }
+        runCatching { metricComponent.stop() }
+        runCatching { postProcessorComponent.stop() }
+        runCatching { configComponent.stop() }
+        runCatching { authComponent.stop() }
+        scope.cancel()
+        dataChannel.close()
+        provider.close()
+        Hosts.current = previousHosts
+        CdnSelector.updateHosts(previousCdnHosts)
+        runCatching { mock.close() }
+        runCatching { tempRoot.toFile().deleteRecursively() }
+    }
+
+    companion object {
+        /** Compressed production timings: same code paths, seconds instead of minutes. */
+        fun testTuning(
+            roomPollInterval: Duration = 200.milliseconds,
+            playlistPollInterval: Duration = 40.milliseconds,
+            downloaderDeadline: Duration = 5.seconds
+        ) = RuntimeTuning(
+            roomPollInterval = roomPollInterval,
+            roomRefreshDebounce = 20.milliseconds,
+            webSocketReconnectInitial = 50.milliseconds,
+            webSocketReconnectMax = 200.milliseconds,
+            preconfigRetryInterval = 100.milliseconds,
+            playlistPollInterval = playlistPollInterval,
+            playlistFetchTimeout = 3.seconds,
+            httpRestartDelay = 10.milliseconds,
+            downloaderRaceDelay = 150.milliseconds,
+            downloaderAttemptTimeout = 2.seconds,
+            downloaderDeadline = downloaderDeadline,
+            downloaderStallTimeout = 1.seconds,
+            downloaderRetryBackoff = 20.milliseconds
+        )
+    }
+}
+
+private fun JsonObject.jsonPath(path: String): String? {
+    var element: kotlinx.serialization.json.JsonElement = this
+    for (part in path.split('.')) {
+        element = element.jsonObject[part] ?: return null
+    }
+    return element.jsonPrimitive.content
+}
+
+/**
+ * Test network boundary: loopback clients with the production-relevant plugins
+ * (JSON bodies + WebSockets) but no proxy, no retry plugin and no CDN rewriting.
+ */
+class TestHttpClientProvider : HttpClientProvider, AutoCloseable {
+    private fun client(expectSuccess: Boolean): HttpClient = HttpClient(OkHttp) {
+        this.expectSuccess = expectSuccess
+        install(ContentNegotiation) { json() }
+        install(WebSockets)
+    }
+
+    private val lenient = client(expectSuccess = false)
+    private val strict = client(expectSuccess = true)
+
+    override fun direct(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient =
+        if (expectSuccess) strict else lenient
+
+    override fun proxied(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient =
+        if (expectSuccess) strict else lenient
+
+    override fun close() {
+        lenient.close()
+        strict.close()
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/integration/XhrecIntegrationFixture.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/XhrecIntegrationFixture.kt
@@ -30,6 +30,7 @@ import github.rikacelery.v3.events.CommandEnvelope
 import github.rikacelery.v3.events.GetArmedRoomIds
 import github.rikacelery.v3.events.GetRooms
 import github.rikacelery.v3.events.GetSessions
+import github.rikacelery.v3.events.SegmentDownloaded
 import github.rikacelery.v3.events.RoomAdded
 import github.rikacelery.v3.hooks.EventHook
 import github.rikacelery.v3.m3u8.M3u8Parser
@@ -44,6 +45,7 @@ import io.ktor.client.request.get
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -391,7 +393,9 @@ class XhrecIntegrationFixture(
         fun testTuning(
             roomPollInterval: Duration = 200.milliseconds,
             playlistPollInterval: Duration = 40.milliseconds,
-            downloaderDeadline: Duration = 5.seconds
+            downloaderDeadline: Duration = 5.seconds,
+            downloaderRaceDelay: Duration = 150.milliseconds,
+            downloaderStallTimeout: Duration = 1.seconds
         ) = RuntimeTuning(
             roomPollInterval = roomPollInterval,
             roomRefreshDebounce = 20.milliseconds,
@@ -401,10 +405,10 @@ class XhrecIntegrationFixture(
             playlistPollInterval = playlistPollInterval,
             playlistFetchTimeout = 3.seconds,
             httpRestartDelay = 10.milliseconds,
-            downloaderRaceDelay = 150.milliseconds,
+            downloaderRaceDelay = downloaderRaceDelay,
             downloaderAttemptTimeout = 2.seconds,
             downloaderDeadline = downloaderDeadline,
-            downloaderStallTimeout = 1.seconds,
+            downloaderStallTimeout = downloaderStallTimeout,
             downloaderRetryBackoff = 20.milliseconds
         )
     }
@@ -443,3 +447,35 @@ class TestHttpClientProvider : HttpClientProvider, AutoCloseable {
         strict.close()
     }
 }
+
+internal fun withFixture(
+    tuning: RuntimeTuning = XhrecIntegrationFixture.testTuning(),
+    block: suspend (XhrecIntegrationFixture) -> Unit
+) = testApplication {
+    XhrecIntegrationFixture(this, tuning = tuning).use { fx ->
+        fx.start()
+        fx.installRoutes()
+        block(fx)
+    }
+}
+
+/** Adds an inactive room, activates it, publishes public status and waits for recording. */
+internal suspend fun XhrecIntegrationFixture.startRecording(
+    roomId: Long = 1001L,
+    name: String = "model",
+    status: String = "public",
+    segmentPeriod: Duration = 30.milliseconds
+) {
+    mock.addRoom(roomId, name, status = status)
+    get("/add?name=$name&active=false").expectOk("Room added: $name")
+    awaitRoom(name) { !it.boolField("listening") }
+    get("/activate?id=$roomId").expectOk("Activated")
+    mock.startSegments(roomId, segmentPeriod)
+    awaitRoomSubscribed(roomId)
+    mock.setRoomStatus(roomId, status)
+    awaitSession(roomId, SessionState.Recording)
+    awaitEvent<SegmentDownloaded>(10.seconds) { it.roomId == roomId }
+}
+
+internal fun JsonObject.boolField(field: String): Boolean =
+    this[field]?.jsonPrimitive?.content?.toBoolean() ?: false


### PR DESCRIPTION
## Background

Implements the nine TDD tasks in `src/test/kotlin/github/rikacelery/v3/integration/IMPLEMENTATION_PLAN.md`: deterministic, in-process integration tests for the recording pipeline. The real Room / Scheduler / Session / Downloader / Writer / Metric / HTTP components run against a single loopback Ktor mock platform (platform JSON, master + media playlists, byte-exact init and segment media, WebSocket connect/subscribe/push). Network clients and timings are injected through constructor parameters; production defaults are unchanged.

## New test infrastructure

- `MockPayloads.kt` — deterministic payloads (XOR+Base64 tokens, 512-byte segments, increasing segment ids, sliding-window playlists), all round-tripped through the production `Decrypter` / `M3u8Parser`.
- `MockPlatformServer.kt` — one loopback Ktor server covering the platform API, a two-variant master playlist, media playlists, byte-exact media, WebSocket auth/subscribe/push, request history, per-request 404/500/delay/interrupt injection, automatic status and segment advancement, and platform-side deletion.
- `XhrecIntegrationFixture.kt` — the real component graph with injected boundaries (no-proxy clients, compressed timings, writer threshold 0, temp dirs) and bounded waits whose failures report recent events, requests, sessions and armed rooms.
- 7 test classes / 59 integration tests: `MockPayloadTest`, `MockPlatformServerTest`, `RoomRoutesIntegrationTest`, `StatusFlowIntegrationTest`, `DownloadIntegrityIntegrationTest`, `WebSocketFallbackIntegrationTest`, `RoomDeletionAndActivationIntegrationTest`.

## Seven production bugs fixed (all exposed by the new tests)

1. **Subscription downgrade unsubscribed the status channels it had just subscribed** — armed but idle rooms received no WebSocket status updates and fell back to the 5-minute poll.
2. **`parseSizeString` uppercased the input but matched mixed-case unit keys** — `/add?size=1Ki` and `/sizelimit?v=1Gi` were rejected.
3. **CutPoint was signalled done before the ordered emitter drained `StreamEnd`** — the next session's `StreamStart` overtook it, closing the wrong file and truncating the new one.
4. **A server-side WebSocket close surfaced as `CancellationException` and was rethrown** — killing the reconnect loop permanently; rejected connections also hot-looped instead of backing off.
5. **Nobody published `RecordingStarted`** — the full WebSocket channel set and metrics were dead code while recording.
6. **Activating/restarting an already `public` room did not record** — `Armed` only reacts to events, and the refresh only publishes when the status actually changes; activation now feeds the current status straight into the FSM.
7. **`ConfigComponent.saveConfig` had no serialization** — the startup save and a config-change save could overwrite each other (tests occasionally read stale values); it now uses a `Mutex`, like `RoomComponent`.

## Related issues

Closes #141
Closes #142

- #141 (removing a room does not stop recording): two integration tests cover platform-side deletion and re-adding; both pass.
- #142 (activating an already-public room does not record): two integration tests, red before the fix and green after.

## Verification

- `./gradlew clean test` → exit 0, **36 classes / 212 tests / 0 failures / 0 errors** (run twice).
- `./gradlew test --tests 'github.rikacelery.v3.integration.*'` twice and the WebSocket class three times → all exit 0.
- `git diff --check` clean; no leftover test workers after the run; a test asserts that all platform traffic stays on the loopback mock.
- CI runs `./gradlew check shadowJar --no-daemon --build-cache`.

## Compatibility

- Every new constructor parameter has a production default; `RuntimeTuning` defaults equal the previous literals (guarded by `RuntimeTuningTest`).
- Only two dependencies are added: `ktor-server-websockets-jvm` (runtime) and `ktor-server-test-host-jvm` (test).
- No breaking public API changes.
