### PR TITLE
fix: correct download metrics and summarize terminal failures

### DIFF
--- a/src/main/kotlin/github/rikacelery/v3/components/DownloaderComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/DownloaderComponent.kt
@@ -102,24 +102,32 @@ class DownloaderComponent(
 
         for (seg in cmd.urls) {
             val idx = active.idx.incrementAndGet()
-            var url = seg.url
-            hooks.forEach { url = it.beforeDownload(url) }
-
             val job = workerScope.launch {
+                val history = FailureHistory()
+                var failureLogged = false
+                fun logFailure(reason: String) {
+                    if (failureLogged) return
+                    failureLogged = true
+                    logger.warn("Segment download failed: roomId={}, idx={}, url={}, reason={}, {}",
+                        cmd.roomId, idx, seg.url, reason, history.summary())
+                }
                 try {
                     active.semaphore.withPermit {
-                        eventBus.publish(DownloadStarted(cmd.roomId, idx, url, System.currentTimeMillis()))
-                        val result = downloadSegment(url, idx)
+                        eventBus.publish(DownloadStarted(cmd.roomId, idx, seg.url, System.currentTimeMillis()))
+                        var url = seg.url
+                        hooks.forEach { url = it.beforeDownload(url) }
+                        val result = downloadSegment(url, idx, history)
                         val hooked = hooks.fold(result) { acc, hook -> hook.onDownloadResult(cmd.roomId, acc) }
                         active.emitter.complete(idx.toLong(), hooked)
 
-                        when (result) {
+                        when (hooked) {
                             is DownloadResult.Success -> {
                                 eventBus.publish(SegmentDownloaded(cmd.roomId, idx, seg.url,
-                                    result.meta.fetchDurationMs, result.meta.proxied, result.data.size, gen))
+                                    hooked.meta.fetchDurationMs, hooked.meta.proxied, hooked.data.size, gen))
                             }
                             is DownloadResult.Failed -> {
-                                eventBus.publish(DownloadError(cmd.roomId, idx, seg.url, result.reason))
+                                logFailure(hooked.reason)
+                                eventBus.publish(DownloadError(cmd.roomId, idx, seg.url, hooked.reason))
                             }
                             is DownloadResult.CutPoint -> {}
                         }
@@ -127,13 +135,24 @@ class DownloaderComponent(
                 } catch (e: kotlinx.coroutines.CancellationException) {
                     // Still account for the segment so OrderedEmitter cannot stall forever.
                     withContext(NonCancellable) {
-                        active.emitter.complete(idx.toLong(), DownloadResult.Failed(idx, seg.url, "cancelled", transportError = true))
+                        try {
+                            active.emitter.complete(idx.toLong(), DownloadResult.Failed(idx, seg.url, "cancelled", transportError = true))
+                        } finally {
+                            logFailure("cancelled")
+                            eventBus.publish(DownloadError(cmd.roomId, idx, seg.url, "cancelled"))
+                        }
                     }
                     throw e
                 } catch (e: Exception) {
-                    logger.error("Download worker failed: idx=$idx, url=${seg.url}", e)
+                    logger.trace("Download worker failed: idx=$idx, url=${seg.url}", e)
                     withContext(NonCancellable) {
-                        active.emitter.complete(idx.toLong(), DownloadResult.Failed(idx, seg.url, e.message ?: "worker error", transportError = true))
+                        val reason = e.message ?: "worker error"
+                        try {
+                            active.emitter.complete(idx.toLong(), DownloadResult.Failed(idx, seg.url, reason, transportError = true))
+                        } finally {
+                            logFailure(reason)
+                            eventBus.publish(DownloadError(cmd.roomId, idx, seg.url, reason))
+                        }
                     }
                 }
             }
@@ -153,6 +172,24 @@ class DownloaderComponent(
 
     /** Thrown when a download stalls; treated as transport error. */
     private class StreamStallException(message: String) : Exception(message)
+
+    /** Shared by a segment's direct/proxy requests; repeated failures are counted together. */
+    private class FailureHistory {
+        var attempts = 0
+        private var stalls = 0
+        private val failures = linkedMapOf<String, Int>()
+
+        @Synchronized
+        fun record(url: String, route: String, reason: String) {
+            if (reason.startsWith("stall:")) stalls++
+            val key = "${CdnSelector.hostOf(url)} $route: $reason"
+            failures[key] = (failures[key] ?: 0) + 1
+        }
+
+        @Synchronized
+        fun summary(): String = "attempts=$attempts, stalls=$stalls, history=[" +
+            failures.entries.joinToString("; ") { (reason, count) -> "$reason (x$count)" } + "]"
+    }
 
     // ── Probe scheduling ──
     /** Probe interval: fire probes for non-selected hosts this often (ms). */
@@ -174,7 +211,7 @@ class DownloaderComponent(
      *  - other 4xx are likewise permanent (auth/URL problem), so they also stop the loop;
      *  - transport errors / stalls / 5xx penalize the host and retry until [segmentDeadlineMs].
      */
-    private suspend fun downloadSegment(url: String, idx: Int): DownloadResult {
+    private suspend fun downloadSegment(url: String, idx: Int, history: FailureHistory): DownloadResult {
         val start = System.currentTimeMillis()
         val segmentDeadlineMs = runtimeTuning.downloaderDeadline.inWholeMilliseconds
         val deadline = start + segmentDeadlineMs
@@ -190,15 +227,18 @@ class DownloaderComponent(
             if (host.isEmpty()) break
             tried += host
             attempts++
+            history.attempts = attempts
 
             val resolvedUrl = if (CdnSelector.hosts.isNotEmpty()) CdnSelector.rewriteHost(url, host) else url
             val result = try {
-                attemptDownload(resolvedUrl, idx, minOf(runtimeTuning.downloaderAttemptTimeout.inWholeMilliseconds, remaining))
+                attemptDownload(resolvedUrl, idx, minOf(runtimeTuning.downloaderAttemptTimeout.inWholeMilliseconds, remaining), history)
             } catch (e: kotlinx.coroutines.CancellationException) {
                 throw e
             } catch (e: Exception) {
-                logger.error("downloadSegment attempt failed: idx=$idx, host=$host", e)
-                DownloadResult.Failed(idx, resolvedUrl, e.message ?: "download failed", transportError = true)
+                logger.trace("downloadSegment attempt failed: idx=$idx, host=$host", e)
+                val reason = e.message ?: "download failed"
+                history.record(resolvedUrl, "ATTEMPT", reason)
+                DownloadResult.Failed(idx, resolvedUrl, reason, transportError = true)
             }
 
             when {
@@ -208,17 +248,17 @@ class DownloaderComponent(
                 }
                 result is DownloadResult.Failed && result.statusCode == 404 -> {
                     // Assignment expired server-side — retrying any host is pointless.
-                    logger.info("Segment #{} gone (404 on {}), giving up after {} attempt(s)", idx, host, attempts)
+                    logger.trace("Segment #{} gone (404 on {}), giving up after {} attempt(s)", idx, host, attempts)
                     return result
                 }
                 result is DownloadResult.Failed && (result.statusCode ?: 0) in 400..499 -> {
                     // Other client errors (403 etc.): the URL itself is rejected everywhere.
-                    logger.info("Segment #{} rejected (HTTP {} on {}), giving up", idx, result.statusCode, host)
+                    logger.trace("Segment #{} rejected (HTTP {} on {}), giving up", idx, result.statusCode, host)
                     return result
                 }
                 result is DownloadResult.Failed -> {
                     if (result.transportError) CdnSelector.recordFailure(host)
-                    logger.debug("Segment #{} attempt {} failed on {}: {}", idx, attempts, host, result.reason)
+                    logger.trace("Segment #{} attempt {} failed on {}: {}", idx, attempts, host, result.reason)
                     lastFail = result
                 }
                 else -> { /* CutPoint cannot happen here */ }
@@ -259,12 +299,12 @@ class DownloaderComponent(
      * structured (coroutineScope), so a timeout or a lost race cancels the loser instead
      * of leaking it until the socket timeout.
      */
-    private suspend fun attemptDownload(resolvedUrl: String, idx: Int, budgetMs: Long): DownloadResult {
+    private suspend fun attemptDownload(resolvedUrl: String, idx: Int, budgetMs: Long, history: FailureHistory): DownloadResult {
         val start = System.currentTimeMillis()
         return withTimeoutOrNull(budgetMs.milliseconds) {
             coroutineScope {
                 val directDeferred = async {
-                    downloadWithClient(httpClientProvider.direct("dl_${Random.nextInt(32)}"), resolvedUrl, idx, false)
+                    downloadWithClient(httpClientProvider.direct("dl_${Random.nextInt(32)}"), resolvedUrl, idx, false, history)
                 }
 
                 val raceThresholdMs = runtimeTuning.downloaderRaceDelay.inWholeMilliseconds
@@ -278,9 +318,9 @@ class DownloaderComponent(
                     return@coroutineScope directResult
                 }
 
-                logger.debug("Direct download slow/failed for idx={}, falling back to proxy race", idx)
+                logger.trace("Direct download slow/failed for idx={}, falling back to proxy race", idx)
                 val proxyDeferred = async {
-                    downloadWithClient(httpClientProvider.proxied("px_${Random.nextInt(5)}"), resolvedUrl, idx, true)
+                    downloadWithClient(httpClientProvider.proxied("px_${Random.nextInt(5)}"), resolvedUrl, idx, true, history)
                 }
 
                 val result = if (directDeferred.isCompleted) {
@@ -288,6 +328,7 @@ class DownloaderComponent(
                     // chance instead of letting select() immediately return the direct failure.
                     withTimeoutOrNull(minOf(raceThresholdMs, budgetMs).milliseconds) { proxyDeferred.await() }
                         ?: DownloadResult.Failed(idx, resolvedUrl, "proxy timeout", transportError = true)
+                            .also { history.record(resolvedUrl, "PROXY", it.reason) }
                 } else {
                     select<DownloadResult> {
                         directDeferred.onAwait { r ->
@@ -306,12 +347,13 @@ class DownloaderComponent(
                 result
             }
         } ?: DownloadResult.Failed(idx, resolvedUrl, "attempt timeout after ${budgetMs}ms", transportError = true)
+            .also { history.record(resolvedUrl, "ATTEMPT", it.reason) }
     }
 
     private suspend fun downloadWithClient(
-        client: HttpClient, url: String, idx: Int, proxied: Boolean
+        client: HttpClient, url: String, idx: Int, proxied: Boolean, history: FailureHistory
     ): DownloadResult {
-        return try {
+        val result = try {
             // Stall watchdog #1: no response headers within stallTimeoutMs → dead path, bail out.
             val response = withTimeout(runtimeTuning.downloaderStallTimeout) { client.get(url) }
             val stream = response.bodyAsChannel()
@@ -334,27 +376,31 @@ class DownloaderComponent(
             // our own stall watchdog on client.get(); external cancellation is rethrown via ensureActive
             currentCoroutineContext().ensureActive()
             val stallTimeoutMs = runtimeTuning.downloaderStallTimeout.inWholeMilliseconds
-            logger.warn("downloadWithClient stalled: idx=$idx, url=$url, proxied=$proxied (no response within ${stallTimeoutMs}ms)")
+            logger.trace("downloadWithClient stalled: idx=$idx, url=$url, proxied=$proxied (no response within ${stallTimeoutMs}ms)")
             DownloadResult.Failed(idx, url, "stall: no response within ${stallTimeoutMs}ms", transportError = true)
         } catch (e: kotlinx.coroutines.CancellationException) {
             // the download race was resolved and this coroutine was cancelled — not an error
             throw e
         } catch (e: StreamStallException) {
-            logger.warn("downloadWithClient stalled: idx=$idx, url=$url, proxied=$proxied (${e.message})")
+            logger.trace("downloadWithClient stalled: idx=$idx, url=$url, proxied=$proxied (${e.message})")
             DownloadResult.Failed(idx, url, "stall: " + e.message, transportError = true)
         } catch (e: ResponseException) {
             // HTTP status errors (404 etc.) are routine — one line, no stack trace.
             // 4xx = the assignment itself is rejected (host is fine); 5xx implicates the host.
-            logger.warn("downloadWithClient failed: idx=$idx, url=$url, proxied=$proxied, status=${e.response.status}")
+            logger.trace("downloadWithClient failed: idx=$idx, url=$url, proxied=$proxied, status=${e.response.status}")
             DownloadResult.Failed(
                 idx, url, "HTTP " + e.response.status,
                 transportError = e !is ClientRequestException,
                 statusCode = e.response.status.value
             )
         } catch (e: Exception) {
-            logger.error("downloadWithClient failed: idx=$idx, url=$url, proxied=$proxied", e)
+            logger.trace("downloadWithClient failed: idx=$idx, url=$url, proxied=$proxied", e)
             DownloadResult.Failed(idx, url, e.message ?: "download failed", transportError = true)
         }
+        if (result is DownloadResult.Failed) {
+            history.record(url, if (proxied) "PROXY" else "DIRECT", result.reason)
+        }
+        return result
     }
 
     /**

--- a/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
@@ -48,17 +48,9 @@ class MetricComponent(
     private val recording = ConcurrentHashMap.newKeySet<Long>()
 
     override suspend fun onStart(scope: CoroutineScope) {
-        subscribe<SegmentDownloaded>(SegmentDownloaded::class)
-        subscribe<DownloadError>(DownloadError::class)
-        subscribe<DownloadStarted>(DownloadStarted::class)
-        subscribe<SegmentGapDetected>(SegmentGapDetected::class)
-        subscribe<FileReady>(FileReady::class)
-        subscribe<FileProcessed>(FileProcessed::class)
-        subscribe<PlaylistRefreshed>(PlaylistRefreshed::class)
-        subscribe<RecordingStarted>(RecordingStarted::class)
-        subscribe<RecordingStopped>(RecordingStopped::class)
-        subscribe<RoomStatusChanged>(RoomStatusChanged::class)
-        subscribe<CommandEnvelope>(CommandEnvelope::class)
+        // One collector preserves ordering across event types, including immediate
+        // failures and file rotations. wrapEvent filters out unrelated events.
+        subscribe(Any::class)
     }
 
     override suspend fun wrapEvent(event: Any): MetricMsg? = when (event) {

--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -322,9 +322,13 @@ class SchedulerEntry(
         var lastErr: Throwable? = null
         for (url in urls) {
             val host = Url(url).host
+            val start = System.nanoTime()
             try {
                 val response = withRetry(3) { client.get(url) }
-                return M3u8Parser.parseMaster(response.bodyAsText())
+                val master = M3u8Parser.parseMaster(response.bodyAsText())
+                val durationMs = ((System.nanoTime() - start) / 1_000_000).coerceAtLeast(1)
+                CdnSelector.record(host, durationMs)
+                return master
             } catch (e: CancellationException) {
                 throw e
             } catch (e: ClientRequestException) {

--- a/src/test/kotlin/github/rikacelery/v3/components/DownloaderLoggingTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/DownloaderLoggingTest.kt
@@ -1,0 +1,155 @@
+package github.rikacelery.v3.components
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+import github.rikacelery.v3.core.DataChannel
+import github.rikacelery.v3.core.EventBus
+import github.rikacelery.v3.data.RuntimeTuning
+import github.rikacelery.v3.events.Download
+import github.rikacelery.v3.events.DownloadError
+import github.rikacelery.v3.events.Segment
+import github.rikacelery.v3.events.SegmentDownloaded
+import github.rikacelery.v3.hooks.EventHook
+import github.rikacelery.v3.utils.CdnSelector
+import github.rikacelery.v3.utils.HttpClientProvider
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class DownloaderLoggingTest {
+    @Test
+    fun `stall recovered by proxy only logs at trace`() = checkLogging(Scenario.PROXY_RECOVERY)
+
+    @Test
+    fun `HTTP error recovered by proxy only logs at trace`() = checkLogging(Scenario.HTTP_RECOVERY)
+
+    @Test
+    fun `stall recovered by another CDN only logs at trace`() = checkLogging(Scenario.CDN_RECOVERY)
+
+    @Test
+    fun `final failure logs both routes and previous CDN stalls once`() = checkLogging(Scenario.CDN_FAILURE)
+
+    @Test
+    fun `exhausted deadline logs attempt timeout history once`() = checkLogging(Scenario.DEADLINE)
+
+    private fun checkLogging(scenario: Scenario) = runBlocking {
+        val firstHost = AtomicReference<String>()
+        fun client(proxied: Boolean) = HttpClient(MockEngine { request ->
+            if (request.method == HttpMethod.Head) return@MockEngine respond("")
+            firstHost.compareAndSet(null, request.url.host)
+            when {
+                scenario == Scenario.DEADLINE -> delay(2.seconds)
+                scenario == Scenario.HTTP_RECOVERY && !proxied ->
+                    return@MockEngine respond("unavailable", HttpStatusCode.ServiceUnavailable)
+                scenario == Scenario.PROXY_RECOVERY && !proxied -> delay(2.seconds)
+                scenario in listOf(Scenario.CDN_RECOVERY, Scenario.CDN_FAILURE) -> {
+                    if (request.url.host == firstHost.get()) delay(2.seconds)
+                    else if (scenario == Scenario.CDN_FAILURE) {
+                        return@MockEngine respond("gone", HttpStatusCode.NotFound)
+                    }
+                }
+            }
+            respond("segment")
+        }) { expectSuccess = true }
+
+        val direct = client(false)
+        val proxy = client(true)
+        val provider = object : HttpClientProvider {
+            override fun direct(key: String, http1: Boolean, expectSuccess: Boolean) = direct
+            override fun proxied(key: String, http1: Boolean, expectSuccess: Boolean) = proxy
+        }
+        val bus = EventBus()
+        val terminal = CompletableDeferred<Any>()
+        bus.installHook(object : EventHook {
+            override suspend fun intercept(event: Any): Any {
+                if (event is DownloadError || event is SegmentDownloaded) terminal.complete(event)
+                return event
+            }
+        })
+        val tuning = RuntimeTuning(
+            downloaderStallTimeout = if (scenario == Scenario.DEADLINE) 1.seconds else 50.milliseconds,
+            downloaderRaceDelay = 500.milliseconds,
+            downloaderAttemptTimeout = if (scenario == Scenario.DEADLINE) 30.milliseconds else 1.seconds,
+            downloaderDeadline = if (scenario == Scenario.DEADLINE) 150.milliseconds else 5.seconds,
+            downloaderRetryBackoff = 1.milliseconds
+        )
+        val downloader = DownloaderComponent(
+            DataChannel(), eventBus = bus, parentScope = this,
+            httpClientProvider = provider, runtimeTuning = tuning
+        )
+        val logger = LoggerFactory.getLogger("DownloaderComponent") as Logger
+        val oldLevel = logger.level
+        val oldAdditive = logger.isAdditive
+        val logs = CopyOnWriteArrayList<ILoggingEvent>()
+        val appender = object : AppenderBase<ILoggingEvent>() {
+            override fun append(event: ILoggingEvent) {
+                event.prepareForDeferredProcessing()
+                logs += event
+            }
+        }
+        val oldHosts = CdnSelector.hosts
+        CdnSelector.updateHosts(emptyList())
+        CdnSelector.updateHosts(listOf("cdn-a.test", "cdn-b.test"))
+        appender.start()
+        logger.addAppender(appender)
+        logger.level = Level.TRACE
+        logger.isAdditive = false
+        try {
+            downloader.handle(DoDownload(Download(11, listOf(Segment("http://cdn-a.test/segment.mp4", 0)), 0, 1)))
+            val result = withTimeout(10.seconds) { terminal.await() }
+            val visible = logs.filter { it.level.isGreaterOrEqual(Level.DEBUG) }
+            if (scenario == Scenario.CDN_FAILURE || scenario == Scenario.DEADLINE) {
+                assertIs<DownloadError>(result)
+                assertEquals(1, visible.size, visible.joinToString { it.formattedMessage })
+                val warning = visible.single()
+                assertEquals(Level.WARN, warning.level)
+                val message = warning.formattedMessage
+                assertTrue(message.startsWith("Segment download failed:"), message)
+                if (scenario == Scenario.CDN_FAILURE) {
+                    assertTrue("attempts=2, stalls=2" in message, message)
+                    assertTrue("${firstHost.get()} DIRECT: stall:" in message, message)
+                    assertTrue("${firstHost.get()} PROXY: stall:" in message, message)
+                    val secondHost = if (firstHost.get() == "cdn-a.test") "cdn-b.test" else "cdn-a.test"
+                    assertTrue("$secondHost DIRECT: HTTP 404" in message, message)
+                } else {
+                    assertTrue("ATTEMPT: attempt timeout" in message, message)
+                }
+            } else {
+                assertIs<SegmentDownloaded>(result)
+                assertTrue(visible.isEmpty(), visible.joinToString { it.formattedMessage })
+            }
+            if (scenario != Scenario.DEADLINE) {
+                assertTrue(logs.any { it.level == Level.TRACE && "downloadWithClient" in it.formattedMessage })
+                assertTrue(logs.any { it.level == Level.TRACE && "Direct download slow/failed for" in it.formattedMessage })
+            }
+        } finally {
+            downloader.stop()
+            direct.close()
+            proxy.close()
+            logger.detachAppender(appender)
+            appender.stop()
+            logger.level = oldLevel
+            logger.isAdditive = oldAdditive
+            CdnSelector.updateHosts(oldHosts)
+        }
+    }
+
+    private enum class Scenario { PROXY_RECOVERY, HTTP_RECOVERY, CDN_RECOVERY, CDN_FAILURE, DEADLINE }
+}

--- a/src/test/kotlin/github/rikacelery/v3/components/DownloaderMetricsTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/DownloaderMetricsTest.kt
@@ -1,0 +1,153 @@
+package github.rikacelery.v3.components
+
+import github.rikacelery.v3.core.DataChannel
+import github.rikacelery.v3.core.EventBus
+import github.rikacelery.v3.data.DownloadResult
+import github.rikacelery.v3.events.*
+import github.rikacelery.v3.hooks.DownloaderHook
+import github.rikacelery.v3.hooks.EventHook
+import github.rikacelery.v3.utils.CdnSelector
+import github.rikacelery.v3.utils.HttpClientProvider
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DownloaderMetricsTest {
+    @Test
+    fun `permanent HTTP failure is counted once`() = runTest {
+        checkDownload(status = HttpStatusCode.NotFound, expectedFailure = "HTTP 404")
+    }
+
+    @Test
+    fun `worker exception records failure and clears running URL`() = runTest {
+        checkDownload(hook = object : PassThroughHook() {
+            override suspend fun onDownloadResult(roomId: Long, result: DownloadResult): DownloadResult =
+                error("result hook failed")
+        }, expectedFailure = "result hook failed")
+    }
+
+    @Test
+    fun `cancelled worker records failure and clears running URL`() = runTest {
+        checkDownload(hook = object : PassThroughHook() {
+            override suspend fun onDownloadResult(roomId: Long, result: DownloadResult): DownloadResult =
+                throw CancellationException("cancelled by hook")
+        }, expectedFailure = "cancelled")
+    }
+
+    @Test
+    fun `before download exception records failure`() = runTest {
+        checkDownload(hook = object : PassThroughHook() {
+            override suspend fun beforeDownload(url: String): String = error("before hook failed")
+        }, expectedFailure = "before hook failed")
+    }
+
+    @Test
+    fun `hook rejection is counted using final result`() = runTest {
+        checkDownload(hook = object : PassThroughHook() {
+            override suspend fun onDownloadResult(roomId: Long, result: DownloadResult): DownloadResult =
+                DownloadResult.Failed(0, URL, "rejected by hook")
+        }, expectedFailure = "rejected by hook")
+    }
+
+    @Test
+    fun `rewritten URL is cleared on failure`() = runTest {
+        checkDownload(status = HttpStatusCode.NotFound, hook = object : PassThroughHook() {
+            override suspend fun beforeDownload(url: String): String = "$url?rewritten=true"
+        }, expectedFailure = "HTTP 404")
+    }
+
+    @Test
+    fun `successful download does not increment failures`() = runTest {
+        checkDownload()
+    }
+
+    private suspend fun TestScope.checkDownload(
+        status: HttpStatusCode = HttpStatusCode.OK,
+        hook: DownloaderHook = PassThroughHook(),
+        expectedFailure: String? = null
+    ) {
+        val client = HttpClient(MockEngine { respond("segment", status) }) { expectSuccess = true }
+        val provider = object : HttpClientProvider {
+            override fun direct(key: String, http1: Boolean, expectSuccess: Boolean) = client
+            override fun proxied(key: String, http1: Boolean, expectSuccess: Boolean) = client
+        }
+        val eventBus = EventBus()
+        val metric = MetricComponent(eventBus, backgroundScope)
+        val downloader = DownloaderComponent(
+            DataChannel(), listOf(hook), eventBus, backgroundScope, httpClientProvider = provider
+        )
+        val terminal = CompletableDeferred<Any>()
+        val errors = mutableListOf<DownloadError>()
+        val successes = mutableListOf<SegmentDownloaded>()
+        eventBus.installHook(object : EventHook {
+            override suspend fun intercept(event: Any): Any {
+                when (event) {
+                    is DownloadError -> { errors += event; terminal.complete(event) }
+                    is SegmentDownloaded -> { successes += event; terminal.complete(event) }
+                }
+                return event
+            }
+        })
+        val oldHosts = CdnSelector.hosts
+        CdnSelector.updateHosts(emptyList())
+        try {
+            metric.start()
+            downloader.start()
+            runCurrent()
+            eventBus.publish(RecordingStarted(ROOM_ID))
+            runCurrent()
+            downloader.tell(DoDownload(Download(ROOM_ID, listOf(Segment(URL, 0)), 0, 1)))
+            terminal.await()
+            runCurrent()
+
+            val failed = if (expectedFailure == null) 0 else 1
+            assertEquals(failed, errors.size)
+            assertEquals(1 - failed, successes.size)
+            if (expectedFailure != null) {
+                assertTrue(errors.single().reason.startsWith(expectedFailure), errors.single().reason)
+                assertEquals(URL, errors.single().url)
+            }
+            assertMetric(metric, "xhrec_attempted_total", 1)
+            assertMetric(metric, "xhrec_failed_total", failed)
+            assertMetric(metric, "xhrec_downloaded_total", 1 - failed)
+            assertMetric(metric, "xhrec_downloading_current", 0)
+
+            // Rotating the output file must preserve the cumulative failure count.
+            eventBus.publish(FileReady(ROOM_ID, File("unused.mp4"), EndReason.SizeLimit, "model", 0, 1, 1, ""))
+            runCurrent()
+            assertMetric(metric, "xhrec_failed_total", failed)
+        } finally {
+            downloader.stop()
+            metric.stop()
+            CdnSelector.updateHosts(oldHosts)
+            client.close()
+        }
+    }
+
+    private fun assertMetric(metric: MetricComponent, name: String, expected: Int) {
+        val text = metric.prometheusText()
+        assertTrue("$name{roomId=\"$ROOM_ID\"} $expected" in text.lines(), text)
+    }
+
+    private open class PassThroughHook : DownloaderHook {
+        override suspend fun beforeDownload(url: String) = url
+        override suspend fun onDownloadResult(roomId: Long, result: DownloadResult) = result
+    }
+
+    private companion object {
+        const val ROOM_ID = 11L
+        const val URL = "http://localhost/segment.mp4"
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/components/RuntimeInjectionTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/RuntimeInjectionTest.kt
@@ -167,7 +167,12 @@ class RuntimeInjectionTest {
     }
 
     @Test
-    fun `scheduler uses injected clients and master candidates`() = runBlocking {
+    fun `scheduler uses injected clients and records successful master fetch`() = checkSchedulerMaster(false)
+
+    @Test
+    fun `scheduler records master failure and fallback success on their respective hosts`() = checkSchedulerMaster(true)
+
+    private fun checkSchedulerMaster(failPrimary: Boolean) = runBlocking {
         val testScope = CoroutineScope(coroutineContext + SupervisorJob())
         val requests = CopyOnWriteArrayList<String>()
         val client = HttpClient(MockEngine { request ->
@@ -178,7 +183,9 @@ class RuntimeInjectionTest {
                     """{"item":{"status":"public"}}""",
                     headers = jsonHeaders
                 )
-                url.startsWith("http://127.0.0.1:18082/master/") -> respond(
+                request.url.encodedPath.startsWith("/master/") && failPrimary && request.url.host == "127.0.0.1" ->
+                    respond("not found", HttpStatusCode.NotFound)
+                request.url.encodedPath.startsWith("/master/") -> respond(
                     """
                         #EXTM3U
                         #EXT-X-MOUFLON:PSCH:key-id
@@ -189,7 +196,7 @@ class RuntimeInjectionTest {
                 request.url.encodedPath == "/media/model.m3u8" -> respond("#EXTM3U")
                 else -> error("unexpected request $url")
             }
-        })
+        }) { expectSuccess = true }
         val provider = RecordingProvider(client, client)
         val eventBus = EventBus()
         installRequestAnswers(eventBus)
@@ -209,7 +216,10 @@ class RuntimeInjectionTest {
             runtimeTuning = RuntimeTuning(preconfigRetryInterval = 4.milliseconds),
             masterUrlCandidates = { roomId, pkey, token ->
                 candidateArgs += Triple(roomId, pkey, token)
-                listOf("http://127.0.0.1:18082/master/$roomId?pkey=$pkey&token=${token.orEmpty()}")
+                buildList {
+                    add("http://127.0.0.1:18082/master/$roomId?pkey=$pkey&token=${token.orEmpty()}")
+                    if (failPrimary) add("http://127.0.0.2:18082/master/$roomId?pkey=$pkey&token=${token.orEmpty()}")
+                }
             }
         )
         val entry = SchedulerEntry(7, "model", scheduler).apply { pkey = "room-key" }
@@ -224,9 +234,24 @@ class RuntimeInjectionTest {
             assertEquals(listOf(Triple<Long, String, String?>(7L, "room-key", "")), candidateArgs)
             assertTrue(provider.proxiedCalls.any { it.key == "master_7" })
             assertTrue(provider.proxiedCalls.any { it.key == "preconfig_7" })
-            assertTrue(requests.all { it.startsWith("http://127.0.0.1:18082/") })
+            assertTrue(requests.all {
+                it.startsWith("http://127.0.0.1:18082/") || (failPrimary && it.startsWith("http://127.0.0.2:18082/master/"))
+            })
             assertTrue(requests.any { it == "http://127.0.0.1:18082/master/7?pkey=room-key&token=" })
             assertTrue(requests.any { it == "http://127.0.0.1:18082/media/model.m3u8?psch=v2&pkey=key-id" })
+            val stats = CdnSelector.snapshot()
+            val successHost = if (failPrimary) "127.0.0.2" else "127.0.0.1"
+            val success = stats.getValue(successHost)
+            assertEquals(1, success.totalSuccesses)
+            assertEquals(0, success.totalErrors)
+            assertTrue(success.estimatedDurationMs > 0)
+            assertTrue(success.estimateSource != "none")
+            assertTrue(success.confidence > 0)
+            if (failPrimary) {
+                val failure = stats.getValue("127.0.0.1")
+                assertEquals(0, failure.totalSuccesses)
+                assertEquals(1, failure.totalErrors)
+            }
         } finally {
             entry.scope.cancel()
             testScope.cancel()

--- a/src/test/kotlin/github/rikacelery/v3/integration/RoomRoutesIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/RoomRoutesIntegrationTest.kt
@@ -130,6 +130,7 @@ class RoomRoutesIntegrationTest {
     fun `break and restart produce separate files`() = withFixture { fx ->
         fx.ready()
         fx.startRecording()
+        val initialDownload = fx.awaitEvent<SegmentDownloaded> { it.roomId == 1001L }
 
         fx.get("/break?id=1001").expectOk("Break signaled")
         val broken = fx.awaitEvent<FileReady>(15.seconds) { it.roomId == 1001L }
@@ -137,7 +138,11 @@ class RoomRoutesIntegrationTest {
 
         // the scheduler preconfigures again automatically after a break and keeps recording
         fx.awaitEventCount<RecordingStarted>(2, 15.seconds) { it.roomId == 1001L }
-        val downloadsBeforeRestart = fx.events.filterIsInstance<SegmentDownloaded>().count { it.roomId == 1001L }
+        // RecordingStarted precedes playlist polling. Wait for bytes in this generation
+        // before closing it, otherwise the writer correctly discards an empty file.
+        val afterBreakDownload = fx.awaitEvent<SegmentDownloaded>(20.seconds) {
+            it.roomId == 1001L && it.generation != initialDownload.generation
+        }
 
         // /restart stops the running session (closing its file) and arms the room again
         fx.get("/restart?id=1001").expectOk("Restarted")
@@ -146,7 +151,10 @@ class RoomRoutesIntegrationTest {
 
         // the room is still public, so re-arming it records again without a status change
         fx.awaitEventCount<RecordingStarted>(3, 20.seconds) { it.roomId == 1001L }
-        fx.awaitEventCount<SegmentDownloaded>(downloadsBeforeRestart + 1, 20.seconds) { it.roomId == 1001L }
+        fx.awaitEvent<SegmentDownloaded>(20.seconds) {
+            it.roomId == 1001L && it.generation != initialDownload.generation &&
+                it.generation != afterBreakDownload.generation
+        }
 
         fx.get("/remove?id=1001").expectOk("Removed")
         val all = fx.awaitEventCount<FileReady>(3, 15.seconds) { it.roomId == 1001L }


### PR DESCRIPTION
Failed segments could go uncounted when a worker threw, was cancelled, or a download hook rejected the result. Master playlist hosts recorded errors without recording successful fetches. Individual stalls also produced warnings even when the segment later recovered through another CDN or the proxy.

- Publish missing segment failure events, use the final hook result for metrics, and consistently clear running downloads by their original URL. Use one metric subscription to preserve ordering across event types.
- Record the successful host and elapsed time after fetching and parsing a master playlist, including fallback hosts.
- Move individual attempt failures and `Direct download slow/failed for` messages to TRACE. Emit one WARN only when a segment ultimately fails, summarizing attempts, stalls, and failure reasons by CDN and direct/proxy route, with repeated reasons counted together.
- Make the break/restart integration test wait for a successful download from each recording generation before closing its file. A recording-start event alone can arrive before any data, leaving an empty file that produces no FileReady event.

Validation: `./gradlew check shadowJar --console=plain` passed locally, including the full test suite and ShadowJar packaging. Regression coverage includes 404s, exceptions, cancellation, hook rejection, URL rewriting, proxy/CDN recovery, exhausted deadlines, master fetch success/fallback accounting, and break/restart file production.

Previously missed success counts cannot be reconstructed; successful master fetches start contributing samples after this update.
