### PR TITLE
test: make the integration suite deterministic under load

### DIFF
--- a/src/test/kotlin/github/rikacelery/v3/components/ConfigComponentTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/ConfigComponentTest.kt
@@ -7,17 +7,21 @@ import github.rikacelery.v3.data.HostsConfig
 import github.rikacelery.v3.data.SystemConfig
 import github.rikacelery.v3.events.*
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import java.io.File
 import java.nio.file.Path
 import kotlin.test.*
 
@@ -116,16 +120,31 @@ class ConfigComponentTest {
         val rb1 = RequestBus(bus, backgroundScope)
         rb1.request<ConfigResponse>(ToggleMask)
 
-        // give async IO save time to complete
-        delay(300)
+        // the toggle is persisted by the caller (like the /mask/toggle route does); the save runs
+        // on Dispatchers.IO, so a fixed delay (virtual here) would only race it
+        bus.publish(PersistConfig)
+        awaitSavedConfig(configPath) { it["maskSensitiveLogs"]?.jsonPrimitive?.content == "false" }
+        // only one component may answer the request below, otherwise the assertion races comp1
+        comp1.stop()
 
         val comp2 = ConfigComponent(config, ApiClient(config.hosts.platformHosts), bus, this)
         comp2.start()
         val rb2 = RequestBus(bus, backgroundScope)
-        val mask = rb2.request<ConfigResponse>(GetMaskStatus)
-        assertEquals(false, mask.value)
+        // loadConfig hops through Dispatchers.IO, so the virtual request timeout can fire while
+        // that hop is in flight: poll on a real dispatcher until the loaded value shows up
+        val mask = withContext(Dispatchers.IO) {
+            val deadline = System.currentTimeMillis() + 10_000
+            var value: Any? = null
+            while (value != false && System.currentTimeMillis() < deadline) {
+                value = runCatching {
+                    rb2.request<ConfigResponse>(GetMaskStatus, timeoutMs = 2_000).value
+                }.getOrNull()
+                if (value != false) delay(25)
+            }
+            value
+        }
+        assertEquals(false, mask, "the saved mask must be loaded back by the new component")
 
-        comp1.stop()
         comp2.stop()
     }
 
@@ -144,10 +163,8 @@ class ConfigComponentTest {
         val comp = ConfigComponent(config, ApiClient(config.hosts.platformHosts), bus, this)
         comp.start()
 
-        // give async IO save time to complete
-        delay(300)
-
-        val saved = Json.parseToJsonElement(configPath.readText()).jsonObject
+        // the file the test wrote has no maskSensitiveLogs key: seeing it proves saveConfig ran
+        val saved = awaitSavedConfig(configPath) { it.containsKey("maskSensitiveLogs") }
         assertEquals("mirror.example.com", saved["platformHosts"]?.jsonArray?.first()?.jsonPrimitive?.content)
         assertEquals("ws.mirror.example.com", saved["webSocketHosts"]?.jsonArray?.first()?.jsonPrimitive?.content)
         assertEquals("cdn.mirror.example.com", saved["hlsHosts"]?.jsonArray?.first()?.jsonPrimitive?.content)
@@ -184,10 +201,32 @@ class ConfigComponentTest {
         assertEquals(listOf("new1.example.com", "new2.example.com"), cfg.platformHosts)
         assertEquals(listOf("cdn.new.example.com", "cdn2.new.example.com"), cfg.hlsHosts)
 
-        delay(300)
-        val saved = Json.parseToJsonElement(configPath.readText()).jsonObject
+        val saved = awaitSavedConfig(configPath) {
+            it["platformHosts"]?.jsonArray?.first()?.jsonPrimitive?.content == "new1.example.com"
+        }
         assertEquals("new1.example.com", saved["platformHosts"]?.jsonArray?.first()?.jsonPrimitive?.content)
         comp.stop()
+    }
+
+    /**
+     * Waits for a config save to land. `saveConfig` writes through `Dispatchers.IO`, while a
+     * `delay` inside `runTest` only advances virtual time — so reading the file right after a
+     * fixed sleep races the writer and fails on a loaded machine.
+     */
+    private suspend fun awaitSavedConfig(
+        file: File,
+        timeoutMs: Long = 10_000,
+        predicate: (JsonObject) -> Boolean = { true }
+    ): JsonObject = withContext(Dispatchers.IO) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        var parsed: JsonObject? = null
+        while (parsed == null && System.currentTimeMillis() < deadline) {
+            parsed = runCatching { Json.parseToJsonElement(file.readText()).jsonObject }
+                .getOrNull()
+                ?.takeIf(predicate)
+            if (parsed == null) delay(25)
+        }
+        parsed ?: throw AssertionError("config was not saved as expected: ${file.absolutePath}")
     }
 
     @Test

--- a/src/test/kotlin/github/rikacelery/v3/integration/RoomRoutesIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/RoomRoutesIntegrationTest.kt
@@ -263,11 +263,12 @@ class RoomRoutesIntegrationTest {
         fx.mock.setRoomStatus(1001, "p2p")
 
         fx.awaitEvent<FileReady>(15.seconds) { it.roomId == 1001L }
-        fx.awaitSession(1001, SessionState.Recording)
-        assertTrue(
-            fx.mock.requests().any { it.method == "PUT" && it.path.contains("/spy") },
-            "spy show must be purchased: ${fx.mock.requests().map { "${it.method} ${it.path}" }}"
-        )
+        // the stopped session still reports Recording while it closes, so waiting for the state
+        // alone can return before anything was purchased: wait for the purchase and the next session
+        fx.await(15.seconds, "spy show purchase") {
+            fx.mock.requests().any { it.method == "PUT" && it.path.contains("/spy") }.takeIf { it }
+        }
+        fx.awaitEventCount<RecordingStarted>(2, 15.seconds) { it.roomId == 1001L }
     }
 
     @Test

--- a/src/test/kotlin/github/rikacelery/v3/integration/XhrecIntegrationFixture.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/XhrecIntegrationFixture.kt
@@ -67,6 +67,7 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -437,13 +438,24 @@ private fun JsonObject.jsonPath(path: String): String? {
 
 /**
  * Test network boundary: loopback clients with the production-relevant plugins
- * (JSON bodies + WebSockets) but no proxy, no retry plugin and no CDN rewriting.
+ * (JSON bodies + WebSockets + timeouts) but no proxy, no retry plugin and no CDN rewriting.
+ *
+ * The timeouts mirror `ClientManager`: without them a stalled connection blocks the caller
+ * forever, so the ApiClient retry/failover logic never runs and a route such as `/add` can only
+ * time out. OkHttp keeps WebSocket sessions on a separate connection with no read timeout.
  */
 class TestHttpClientProvider : HttpClientProvider, AutoCloseable {
     private fun client(expectSuccess: Boolean): HttpClient = HttpClient(OkHttp) {
         this.expectSuccess = expectSuccess
         install(ContentNegotiation) { json() }
         install(WebSockets)
+        engine {
+            config {
+                connectTimeout(5, TimeUnit.SECONDS)
+                readTimeout(15, TimeUnit.SECONDS)
+                writeTimeout(15, TimeUnit.SECONDS)
+            }
+        }
     }
 
     private val lenient = client(expectSuccess = false)


### PR DESCRIPTION
## Background

Follow-up to #150 (merged), which the reviewer asked to close out by making the whole suite
reliable rather than occasionally red. Each fix below was reproduced on a loaded machine first
(3-4 busy cores, which is what a 2-core CI runner looks like), then fixed at the root and
re-verified with repeated runs.

## 1. `RoomRoutesIntegrationTest.break and restart produce separate files` — `/add` that never gets answered

Seen twice outside #150's runs: locally (1 of 6 loaded full-suite runs) and on
`fix/download-metrics-and-failure-logs` CI run
[34422173316](https://github.com/RikaCelery/XhRec/actions/runs/34422173316) (that run's report
artifact shows `RoomRoutesIntegrationTest.break and restart produce separate files` failing).
The console for the local reproduction is unambiguous: the fixture starts, nothing at all is
logged for 30 seconds, then `Request AddRoom(name=model, quality=highest) timed out after 30000ms`.
No ApiClient retry or failover line appears either — i.e. the platform call never returned.

Root cause: the fixture's HTTP clients installed no timeouts at all, unlike production
(`ClientManager` sets connect/read/write timeouts). A stalled loopback connection therefore hung
forever, so `withRetry` / `withHostFallback` never got the exception they retry on, and the only
possible outcome was the route's own 30 s timeout.

Fix: the test boundary now mirrors production (`connect 5s`, `read/write 15s`). OkHttp keeps
WebSocket sessions on a connection without read timeout, so the WS tests are unaffected (the WS,
status, room-route and download integration classes were run explicitly to confirm).

## 2. `ConfigComponentTest.SetHostsConfig updates runtime and persists` — reading a file a sleep did not wait for

2 of 6 loaded runs failed with `FileNotFoundException: .../xhrec-set.json`. The tests waited for the
asynchronous save with `delay(300)`, but `saveConfig` writes through `Dispatchers.IO` while a
`delay` inside `runTest` only advances *virtual* time — the read raced the writer.

Fix: the saved file is awaited on a real dispatcher until the expected value is on disk; the
assertions themselves are unchanged.

The same test class had a second, worse problem: `saveConfig then loadConfig round-trips` started a
second `ConfigComponent` while the first was still subscribed, and both answered the same
`GetMaskStatus` request — so the assertion passed or failed on whichever ack arrived first, and the
file round trip its name promises was never actually verified. It now stops the first component,
persists the way the `/mask/toggle` route does, and asserts the value loaded back from disk.

## 3. `RoomRoutesIntegrationTest.group show and private autopay both record`

After the group-show cut the stopped session still reports `Recording` while it closes, so
`awaitSession(Recording)` could return before anything was purchased and the following
`PUT /spy` assertion raced the purchase. It now waits for the purchase itself and for the next
session start. (#150 already made it stop cutting a recording with no bytes, which was the other
half of this test's flakiness.)

## Verification

- Full suite under 3 pinned busy cores: **16 consecutive green runs** (6 + 10) after the change,
  against 3 red runs (two `ConfigComponentTest`, one `AddRoom` timeout) in 12 loaded runs before it.
- `ConfigComponentTest` under load: previously 2 of 6 red, now **10 of 10 green**.
- `RoomRoutesIntegrationTest.break and restart produce separate files` in isolation under load:
  **15 of 15 green** (the hang never reproduced in isolation, which is why the loaded full-suite
  runs above are the evidence that matters).
- Full suite idle: 8 of 8 green before these changes, 1 more green after.
- No production code is touched by this PR: test intent, assertions and coverage are unchanged.
