### PR TITLE
feat: per-room recording filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ java -jar build/libs/XhRec-all.jar -p 12340 -f list.conf -post postprocessor.jso
 One room per line. Lines starting with `#` or `;` are inactive (not automatically recorded).
 
 ```ini
-# https://stripchat.com/modelA q:720p limit:120
+#https://stripchat.com/modelA q:720p limit:120
 ; https://stripchat.com/modelB q:240p
 https://stripchat.com/modelC q:highest
+https://stripchat.com/modelD q:highest nopublic nofreespy autopay:private
 ```
 
 | Field          | Description                                                                                                                                 |
@@ -45,8 +46,17 @@ https://stripchat.com/modelC q:highest
 | `q:<quality>`  | Preferred quality: `240p`, `480p`, `720p`, `720p60`, `1080p`, `1080p60`, or `highest` (default). `raw` is deprecated, use `highest` instead |
 | `limit:<sec>`  | Recording time limit in seconds                                                                                                             |
 | `size:<bytes>` | Recording size limit (supports suffixes: `K`, `M`, `G`, e.g. `500M`)                                                                        |
-| `autopay`      | Enable auto-payment for private shows                                                                                                       |
 | `pkey:<key>`   | Custom psch key                                                                                                                             |
+| `nopublic`     | Do not record public (free) shows                                                                                                          |
+| `nofreespy`    | Do not record private shows that a free-spy privilege would cover                                                                          |
+| `autopay`      | Buy tickets and spy shows automatically (same as `autopay:ticket autopay:private`)                                                         |
+| `autopay:ticket`  | Buy a ticket to record group shows                                                                                                       |
+| `autopay:private` | Spend tokens to record private shows                                                                                                     |
+
+Recording filters default to: public shows on, free-spy shows on, ticket purchase off,
+spy purchase off. `nopublic` and `nofreespy` are therefore opt-out tokens — leaving
+them out keeps the defaults — while the `autopay` tokens are opt-in. All four switches
+are editable per room in the dashboard (the sliders button on the room row).
 
 If the requested quality is unavailable, the closest match is selected automatically.
 
@@ -135,7 +145,7 @@ All endpoints return JSON unless noted. Parameters are passed as query strings.
 
 | Endpoint   | Params                                                          | Description                           |
 |------------|-----------------------------------------------------------------|---------------------------------------|
-| `/add`     | `name`, `quality`, `active`, `limit`, `autopay`, `pkey`, `size` | Add a room                            |
+| `/add`     | `name`, `quality`, `active`, `limit`, `autopayTicket`, `autoPaySpy`, `pkey`, `size` | Add a room        |
 | `/remove`  | `id`                                                            | Remove a room                         |
 | `/restart` | `id`                                                            | Stop then restart recording           |
 | `/break`   | `id`                                                            | Temporary stop (resumes on next poll) |
@@ -147,7 +157,8 @@ All endpoints return JSON unless noted. Parameters are passed as query strings.
 | `/activate`   | `id`                   | Enable auto-recording          |
 | `/deactivate` | `id`                   | Disable auto-recording         |
 | `/quality`    | `id`, `q`              | Set quality                    |
-| `/autopay`    | `id`, `v` (true/false) | Toggle auto-payment            |
+| `/filter`     | `id`, `kind` (`public`\|`freespy`\|`ticket`\|`paidspy`), `v` | Toggle one recording filter |
+| `/autopay`    | `id`, `v` (true/false), `kind` (`ticket`\|`private`) | Alias of `/filter` |
 | `/limit`      | `id`, `v` (seconds)    | Set time limit (0 = unlimited) |
 | `/sizelimit`  | `id`, `v`              | Set size limit (0 = unlimited) |
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ All endpoints return JSON unless noted. Parameters are passed as query strings.
 |--------------|---------------------------------------------------------|
 | `/status`    | Active room status (segments, bytes, running downloads) |
 | `/list`      | All rooms with status, session state, quality           |
-| `/dashboard` | Consolidated payload: rooms, statuses, listv2, metrics  |
+| `/dashboard` | Consolidated payload: rooms, statuses, listv2, metrics, and a per-room `hint` explaining why an armed room is not recording (`public_filter_off`, `ticket_purchase_off`, `private_filter_off`, `no_free_spy`, `preconfig_failed` plus an optional raw `detail`) |
 | `/metrics`   | Prometheus metrics endpoint                             |
 
 | `/mask/toggle` | Toggle log masking on/off |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ java -jar build/libs/XhRec-all.jar -p 12340 -f list.conf -post postprocessor.jso
 
 ### list.conf
 
-One room per line. Lines starting with `#` or `;` are inactive (not automatically recorded).
+One room per line. A line starting with `#` is a known room that is **inactive** (not
+automatically recorded); the marker may be followed by a space (`# https://...`) or not
+(`#https://...`), and the rest of the line is read normally. A line starting with `;` is
+ignored entirely, room and all.
 
 ```ini
 #https://stripchat.com/modelA q:720p limit:120
@@ -158,7 +161,6 @@ All endpoints return JSON unless noted. Parameters are passed as query strings.
 | `/deactivate` | `id`                   | Disable auto-recording         |
 | `/quality`    | `id`, `q`              | Set quality                    |
 | `/filter`     | `id`, `kind` (`public`\|`freespy`\|`ticket`\|`paidspy`), `v` | Toggle one recording filter |
-| `/autopay`    | `id`, `v` (true/false), `kind` (`ticket`\|`private`) | Alias of `/filter` |
 | `/limit`      | `id`, `v` (seconds)    | Set time limit (0 = unlimited) |
 | `/sizelimit`  | `id`, `v`              | Set size limit (0 = unlimited) |
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -35,9 +35,10 @@ java -jar build/libs/XhRec-all.jar -p 12340 -f list.conf -post postprocessor.jso
 每行一个房间。以 `#` 或 `;` 开头的行视为未激活（不会自动录制）。
 
 ```ini
-# https://stripchat.com/modelA q:720p limit:120
+#https://stripchat.com/modelA q:720p limit:120
 ; https://stripchat.com/modelB q:240p
 https://stripchat.com/modelC q:highest
+https://stripchat.com/modelD q:highest nopublic nofreespy autopay:private
 ```
 
 | 字段            | 描述                                                                                                          |
@@ -45,8 +46,16 @@ https://stripchat.com/modelC q:highest
 | `q:<quality>`   | 画质偏好: `240p`, `480p`, `720p`, `720p60`, `1080p`, `1080p60`, 或 `highest` (默认)。`raw` 已弃用，请用 `highest` |
 | `limit:<sec>`   | 录制时长限制（秒）                                                                                               |
 | `size:<bytes>`  | 录制大小限制（支持后缀: `K`, `M`, `G`, 如 `500M`）                                                                |
-| `autopay`       | 对私密秀开启自动支付                                                                                             |
 | `pkey:<key>`    | 自定义 psch 密钥                                                                                               |
+| `nopublic`      | 不录制公开（免费）秀                                                                                             |
+| `nofreespy`     | 不录制可用免费偷窥额度观看的私密秀                                                                                 |
+| `autopay`       | 自动购买门票与偷窥（等价于 `autopay:ticket autopay:private`）                                                      |
+| `autopay:ticket`  | 自动购买门票以录制群秀                                                                                        |
+| `autopay:private` | 自动花费代币录制私密秀                                                                                        |
+
+录制开关的默认值：公开秀开启、免费偷窥开启、门票自动购买关闭、偷窥自动付费关闭。
+因此 `nopublic` 与 `nofreespy` 是"取消默认"的开关（不写即保持默认），而 `autopay`
+两项则需要显式开启。四个开关都可以在面板里按房间修改（房间行右侧的滑杆按钮）。
 
 如果请求的画质不可用，系统会自动选择最接近的匹配项。
 
@@ -131,7 +140,7 @@ cookie_string_here
 
 | 接口       | 参数                                                              | 描述                 |
 |------------|------------------------------------------------------------------|---------------------|
-| `/add`     | `name`, `quality`, `active`, `limit`, `autopay`, `pkey`, `size`   | 添加房间              |
+| `/add`     | `name`, `quality`, `active`, `limit`, `autopayTicket`, `autoPaySpy`, `pkey`, `size` | 添加房间 |
 | `/remove`  | `id`                                                             | 删除房间              |
 | `/restart` | `id`                                                             | 停止后重新开始录制      |
 | `/break`   | `id`                                                             | 暂时中断（下次轮询时恢复）|
@@ -143,7 +152,8 @@ cookie_string_here
 | `/activate`   | `id`                     | 启用自动录制               |
 | `/deactivate` | `id`                     | 禁用自动录制               |
 | `/quality`    | `id`, `q`                | 设置画质                  |
-| `/autopay`    | `id`, `v` (true/false)   | 切换自动支付               |
+| `/filter`     | `id`, `kind` (`public`\|`freespy`\|`ticket`\|`paidspy`), `v` | 切换某个录制开关 |
+| `/autopay`    | `id`, `v` (true/false), `kind` (`ticket`\|`private`) | `/filter` 的兼容别名 |
 | `/limit`      | `id`, `v` （秒）          | 设置时长限制（0 = 不限）     |
 | `/sizelimit`  | `id`, `v`                | 设置大小限制（0 = 不限）     |
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -32,7 +32,9 @@ java -jar build/libs/XhRec-all.jar -p 12340 -f list.conf -post postprocessor.jso
 
 ### list.conf
 
-每行一个房间。以 `#` 或 `;` 开头的行视为未激活（不会自动录制）。
+每行一个房间。以 `#` 开头的行是**未激活**的房间（不会自动录制），`#` 后面可以带空格
+（`# https://...`）也可以不带（`#https://...`），其余字段照常解析。以 `;` 开头的行则被
+整行忽略，房间不会被加载。
 
 ```ini
 #https://stripchat.com/modelA q:720p limit:120
@@ -153,7 +155,6 @@ cookie_string_here
 | `/deactivate` | `id`                     | 禁用自动录制               |
 | `/quality`    | `id`, `q`                | 设置画质                  |
 | `/filter`     | `id`, `kind` (`public`\|`freespy`\|`ticket`\|`paidspy`), `v` | 切换某个录制开关 |
-| `/autopay`    | `id`, `v` (true/false), `kind` (`ticket`\|`private`) | `/filter` 的兼容别名 |
 | `/limit`      | `id`, `v` （秒）          | 设置时长限制（0 = 不限）     |
 | `/sizelimit`  | `id`, `v`                | 设置大小限制（0 = 不限）     |
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -164,7 +164,7 @@ cookie_string_here
 |-------------|--------------------------------------------------|
 | `/status`   | 活跃房间状态（分段数、字节数、正在运行的下载任务）           |
 | `/list`     | 所有房间的状态、会话状态、画质                          |
-| `/dashboard`| 聚合数据: rooms, statuses, listv2, metrics          |
+| `/dashboard`| 聚合数据: rooms, statuses, listv2, metrics，以及每个房间的 `hint`（解释已启用却未录制的原因: `public_filter_off`、`ticket_purchase_off`、`private_filter_off`、`no_free_spy`、`preconfig_failed`，可附带原始 `detail`） |
 | `/metrics`  | Prometheus 指标接口                                 |
 
 | `/mask/toggle` | 切换日志脱敏开关      |

--- a/src/main/kotlin/github/rikacelery/v3/bootstrap/Bootstrap.kt
+++ b/src/main/kotlin/github/rikacelery/v3/bootstrap/Bootstrap.kt
@@ -2,6 +2,7 @@ package github.rikacelery.v3.bootstrap
 
 import github.rikacelery.v3.api.ApiClient
 import github.rikacelery.v3.components.*
+import github.rikacelery.v3.data.RoomSettings
 import github.rikacelery.v3.utils.SensitiveStringRegistry
 import github.rikacelery.v3.exceptions.RenameException
 import github.rikacelery.v3.postprocessors.*
@@ -154,7 +155,17 @@ class Bootstrap(
         val autoPayTicket: Boolean = false, val autoPaySpy: Boolean = false,
         val pkey: String = "",
         val armed: Boolean
-    )
+    ) {
+        /** The parsed line as the settings the room components work with. */
+        fun toSettings(): RoomSettings = RoomSettings(
+            quality = quality,
+            timeLimit = if (timeLimit > 0) timeLimit.seconds else Duration.INFINITE,
+            sizeLimitBytes = sizeLimit,
+            autoPayTicket = autoPayTicket,
+            autoPaySpy = autoPaySpy,
+            pkey = pkey
+        )
+    }
 
     private suspend fun loadRooms(cli: CliConfig) {
         val file = File(cli.listConfPath)
@@ -193,10 +204,10 @@ class Bootstrap(
 
     private suspend fun addRoomFromParsed(id: Long, name: String, parsed: ListConfLine) {
         SensitiveStringRegistry.mask(name)
-        val timeLimit = if (parsed.timeLimit > 0) parsed.timeLimit.seconds else Duration.INFINITE
-        roomComponent.internalAdd(id, name, parsed.quality, timeLimit, parsed.sizeLimit, parsed.autoPayTicket, parsed.autoPaySpy, parsed.pkey)
+        val settings = parsed.toSettings()
+        roomComponent.internalAdd(id, name, settings)
         if (parsed.armed) {
-            schedulerComponent.internalAdd(id, name, parsed.quality, parsed.pkey, parsed.armed, parsed.autoPayTicket, parsed.autoPaySpy)
+            schedulerComponent.internalAdd(id, name, settings, parsed.armed)
         }
     }
 

--- a/src/main/kotlin/github/rikacelery/v3/bootstrap/Bootstrap.kt
+++ b/src/main/kotlin/github/rikacelery/v3/bootstrap/Bootstrap.kt
@@ -152,6 +152,7 @@ class Bootstrap(
     data class ListConfLine(
         val url: String, val quality: String = "highest",
         val timeLimit: Long = 0, val sizeLimit: Long = 0,
+        val recordPublic: Boolean = true, val recordFreeSpy: Boolean = true,
         val autoPayTicket: Boolean = false, val autoPaySpy: Boolean = false,
         val pkey: String = "",
         val armed: Boolean
@@ -161,6 +162,8 @@ class Bootstrap(
             quality = quality,
             timeLimit = if (timeLimit > 0) timeLimit.seconds else Duration.INFINITE,
             sizeLimitBytes = sizeLimit,
+            recordPublic = recordPublic,
+            recordFreeSpy = recordFreeSpy,
             autoPayTicket = autoPayTicket,
             autoPaySpy = autoPaySpy,
             pkey = pkey
@@ -220,6 +223,8 @@ class Bootstrap(
         var sizeLimit = 0L
         var autoPayTicket = false
         var autoPaySpy = false
+        var recordPublic = true
+        var recordFreeSpy = true
         var pkey = ""
         for (i in 1 until parts.size) {
             when {
@@ -234,10 +239,17 @@ class Bootstrap(
                 }
                 parts[i] == "autopay:ticket" -> autoPayTicket = true
                 parts[i] == "autopay:private" -> autoPaySpy = true
+                // recording filters are opt-out tokens: their absence keeps the defaults
+                parts[i] == "nopublic" -> recordPublic = false
+                parts[i] == "nofreespy" -> recordFreeSpy = false
             }
         }
         val trimmed = line.trim()
-        return ListConfLine(url, quality, timeLimit, sizeLimit, autoPayTicket, autoPaySpy, pkey, armed = !trimmed.startsWith("#") && !trimmed.startsWith(";"))
+        return ListConfLine(
+            url, quality, timeLimit, sizeLimit, recordPublic, recordFreeSpy,
+            autoPayTicket, autoPaySpy, pkey,
+            armed = !trimmed.startsWith("#") && !trimmed.startsWith(";")
+        )
     }
 
     private fun parseSize(s: String): Long {

--- a/src/main/kotlin/github/rikacelery/v3/bootstrap/Bootstrap.kt
+++ b/src/main/kotlin/github/rikacelery/v3/bootstrap/Bootstrap.kt
@@ -215,7 +215,11 @@ class Bootstrap(
     }
 
     private fun parseListConfLine(line: String): ListConfLine? {
-        val parts = line.trim().split(" ")
+        val trimmed = line.trim()
+        // A commented line keeps the room in the file but disarmed. Both spellings are in use —
+        // the writer emits "#https://..." and the docs show "# https://..." — so the marker and
+        // any spaces after it are stripped before the line is read as a room.
+        val parts = trimmed.trimStart('#', ';').trim().split(" ").filter { it.isNotEmpty() }
         if (parts.isEmpty()) return null
         val url = parts[0]
         var quality = "highest"
@@ -244,7 +248,6 @@ class Bootstrap(
                 parts[i] == "nofreespy" -> recordFreeSpy = false
             }
         }
-        val trimmed = line.trim()
         return ListConfLine(
             url, quality, timeLimit, sizeLimit, recordPublic, recordFreeSpy,
             autoPayTicket, autoPaySpy, pkey,

--- a/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
@@ -335,6 +335,7 @@ class HttpServerComponent(
                 }
                 get("/dashboard") {
                     val rooms = requestBus.request<List<Room>>(GetRooms)
+                    val hints = requestBus.request<RecordingHintsResponse>(GetRecordingHints).hints
                     val statuses = requestBus.request<Map<Long, Map<String, Any>>>(GetRoomDetailedStatus)
                     val sessions = requestBus.request<List<RoomSession>>(GetSessions)
                     val armedIds = requestBus.request<List<Long>>(GetArmedRoomIds).toSet()
@@ -374,6 +375,12 @@ class HttpServerComponent(
                                         put("sizeLimitBytes", r.sizeLimitBytes)
                                         put("recordPublic", r.recordPublic); put("recordFreeSpy", r.recordFreeSpy)
                                         put("autoPayTicket", r.autoPayTicket); put("autoPaySpy", r.autoPaySpy)
+                                        hints[r.id]?.let { hint ->
+                                            put("hint", buildJsonObject {
+                                                put("code", hint.code.wireName)
+                                                hint.detail?.let { put("detail", it) }
+                                            })
+                                        }
                                     })
                                 })
                             }

--- a/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
@@ -260,7 +260,7 @@ class HttpServerComponent(
                         "Missing id",
                         status = HttpStatusCode.BadRequest
                     )
-                    val kind = filterKind(call.request.queryParameters["kind"])
+                    val kind = RecordingFilterKind.fromWire(call.request.queryParameters["kind"])
                         ?: return@get call.respondText(
                             "Invalid kind (expected 'public', 'freespy', 'ticket' or 'paidspy')",
                             status = HttpStatusCode.BadRequest
@@ -269,7 +269,7 @@ class HttpServerComponent(
                         ?: return@get call.respondText("Missing v (true/false)", status = HttpStatusCode.BadRequest)
                     requestBus.request<OkResponse>(SetRoomFilter(id, kind, v))
                     persistConfig()
-                    call.respondText("Filter ${kind.name.lowercase()} set to $v")
+                    call.respondText("Filter ${kind.wireName} set to $v")
                 }
                 // legacy alias kept for existing scripts: autopay ticket/private are two of the filters
                 get("/autopay") {
@@ -388,7 +388,9 @@ class HttpServerComponent(
                                         put("name", r.name); put("id", r.id); put("quality", r.quality)
                                         put("status", r.status)
                                         put("timeLimit", if (r.timeLimit == Duration.INFINITE) 0L else r.timeLimit.inWholeMilliseconds)
-                                        put("sizeLimitBytes", r.sizeLimitBytes); put("autoPayTicket", r.autoPayTicket); put("autoPaySpy", r.autoPaySpy)
+                                        put("sizeLimitBytes", r.sizeLimitBytes)
+                                        put("recordPublic", r.recordPublic); put("recordFreeSpy", r.recordFreeSpy)
+                                        put("autoPayTicket", r.autoPayTicket); put("autoPaySpy", r.autoPaySpy)
                                     })
                                 })
                             }
@@ -745,15 +747,6 @@ class HttpServerComponent(
     companion object {
         /** Platform timeout for a favorites command: one request per account plus name lookups. */
         private const val FAVORITES_TIMEOUT_MS = 120_000L
-
-        /** Query-string spelling of a recording filter, shared by `/filter` and `/autopay`. */
-        private fun filterKind(value: String?): RecordingFilterKind? = when (value) {
-            "public" -> RecordingFilterKind.PUBLIC
-            "freespy" -> RecordingFilterKind.FREE_SPY
-            "ticket" -> RecordingFilterKind.TICKET
-            "paidspy" -> RecordingFilterKind.PAID_SPY
-            else -> null
-        }
 
         private fun hasRecentActivity(data: Map<String, Any>): Boolean {
             val running = data["running"] as? Map<*, *>

--- a/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
@@ -4,6 +4,7 @@ import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
 import github.rikacelery.v3.data.HostsConfig
 import github.rikacelery.v3.data.Room
+import github.rikacelery.v3.data.RoomSettings
 import github.rikacelery.v3.data.RuntimeTuning
 import github.rikacelery.v3.events.*
 import github.rikacelery.v3.ml.PredictionEngine
@@ -141,12 +142,14 @@ class HttpServerComponent(
                         val resp = requestBus.request<RoomNameResponse>(
                             AddRoom(
                                 name,
-                                quality,
-                                pkey,
-                                if (limit > 0) limit.seconds else Duration.INFINITE,
-                                sizeBytes,
-                                autopayTicket,
-                                autoPaySpy
+                                RoomSettings(
+                                    quality = quality,
+                                    timeLimit = if (limit > 0) limit.seconds else Duration.INFINITE,
+                                    sizeLimitBytes = sizeBytes,
+                                    autoPayTicket = autopayTicket,
+                                    autoPaySpy = autoPaySpy,
+                                    pkey = pkey
+                                )
                             ), timeoutMs = 30_000
                         )
                         if (active) {
@@ -252,6 +255,23 @@ class HttpServerComponent(
                     persistConfig()
                     call.respondText("Quality set to $q")
                 }
+                get("/filter") {
+                    val id = call.request.queryParameters["id"]?.toLongOrNull() ?: return@get call.respondText(
+                        "Missing id",
+                        status = HttpStatusCode.BadRequest
+                    )
+                    val kind = filterKind(call.request.queryParameters["kind"])
+                        ?: return@get call.respondText(
+                            "Invalid kind (expected 'public', 'freespy', 'ticket' or 'paidspy')",
+                            status = HttpStatusCode.BadRequest
+                        )
+                    val v = call.request.queryParameters["v"]?.toBooleanStrictOrNull()
+                        ?: return@get call.respondText("Missing v (true/false)", status = HttpStatusCode.BadRequest)
+                    requestBus.request<OkResponse>(SetRoomFilter(id, kind, v))
+                    persistConfig()
+                    call.respondText("Filter ${kind.name.lowercase()} set to $v")
+                }
+                // legacy alias kept for existing scripts: autopay ticket/private are two of the filters
                 get("/autopay") {
                     val id = call.request.queryParameters["id"]?.toLongOrNull() ?: return@get call.respondText(
                         "Missing id",
@@ -260,11 +280,11 @@ class HttpServerComponent(
                     val v = call.request.queryParameters["v"]?.toBooleanStrictOrNull()
                         ?: return@get call.respondText("Missing v (true/false)", status = HttpStatusCode.BadRequest)
                     val kind = when (call.request.queryParameters["kind"]) {
-                        "private" -> AutoPayKind.PRIVATE
-                        "ticket", null -> AutoPayKind.GROUP_SHOW
+                        "private" -> RecordingFilterKind.PAID_SPY
+                        "ticket", null -> RecordingFilterKind.TICKET
                         else -> return@get call.respondText("Invalid kind (expected 'ticket' or 'private')", status = HttpStatusCode.BadRequest)
                     }
-                    requestBus.request<OkResponse>(SetRoomAutoPay(id, kind, v))
+                    requestBus.request<OkResponse>(SetRoomFilter(id, kind, v))
                     persistConfig()
                     call.respondText("Autopay ($kind) set to $v")
                 }
@@ -725,6 +745,15 @@ class HttpServerComponent(
     companion object {
         /** Platform timeout for a favorites command: one request per account plus name lookups. */
         private const val FAVORITES_TIMEOUT_MS = 120_000L
+
+        /** Query-string spelling of a recording filter, shared by `/filter` and `/autopay`. */
+        private fun filterKind(value: String?): RecordingFilterKind? = when (value) {
+            "public" -> RecordingFilterKind.PUBLIC
+            "freespy" -> RecordingFilterKind.FREE_SPY
+            "ticket" -> RecordingFilterKind.TICKET
+            "paidspy" -> RecordingFilterKind.PAID_SPY
+            else -> null
+        }
 
         private fun hasRecentActivity(data: Map<String, Any>): Boolean {
             val running = data["running"] as? Map<*, *>

--- a/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
@@ -271,23 +271,6 @@ class HttpServerComponent(
                     persistConfig()
                     call.respondText("Filter ${kind.wireName} set to $v")
                 }
-                // legacy alias kept for existing scripts: autopay ticket/private are two of the filters
-                get("/autopay") {
-                    val id = call.request.queryParameters["id"]?.toLongOrNull() ?: return@get call.respondText(
-                        "Missing id",
-                        status = HttpStatusCode.BadRequest
-                    )
-                    val v = call.request.queryParameters["v"]?.toBooleanStrictOrNull()
-                        ?: return@get call.respondText("Missing v (true/false)", status = HttpStatusCode.BadRequest)
-                    val kind = when (call.request.queryParameters["kind"]) {
-                        "private" -> RecordingFilterKind.PAID_SPY
-                        "ticket", null -> RecordingFilterKind.TICKET
-                        else -> return@get call.respondText("Invalid kind (expected 'ticket' or 'private')", status = HttpStatusCode.BadRequest)
-                    }
-                    requestBus.request<OkResponse>(SetRoomFilter(id, kind, v))
-                    persistConfig()
-                    call.respondText("Autopay ($kind) set to $v")
-                }
                 get("/limit") {
                     val id = call.request.queryParameters["id"]?.toLongOrNull() ?: return@get call.respondText(
                         "Missing id",

--- a/src/main/kotlin/github/rikacelery/v3/components/RoomComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/RoomComponent.kt
@@ -7,6 +7,7 @@ import github.rikacelery.v3.core.RequestBus
 import github.rikacelery.v3.data.FavoriteCandidate
 import github.rikacelery.v3.data.Hosts
 import github.rikacelery.v3.data.Room
+import github.rikacelery.v3.data.RoomSettings
 import github.rikacelery.v3.data.RuntimeTuning
 import github.rikacelery.v3.data.User
 import github.rikacelery.v3.events.*
@@ -151,14 +152,7 @@ class RoomComponent(
             is GetRoomConfig -> {
                 val r = rooms[cmd.roomId]
                     ?: throw NoSuchElementException("room ${cmd.roomId} not found")
-                RoomConfigResponse(
-                    r.quality,
-                    r.timeLimit,
-                    r.sizeLimitBytes,
-                    r.autoPayTicket,
-                    r.autoPaySpy,
-                    r.pkey
-                )
+                RoomConfigResponse(r.settings())
             }
 
             is SetRoomQuality -> {
@@ -180,12 +174,18 @@ class RoomComponent(
                 OkResponse
             }
 
-            is SetRoomAutoPay -> {
-                rooms[cmd.roomId]?.let {
-                    rooms[it.id] = when (cmd.kind) {
-                        AutoPayKind.GROUP_SHOW -> it.copy(autoPayTicket = cmd.autoPay)
-                        AutoPayKind.PRIVATE -> it.copy(autoPaySpy = cmd.autoPay)
+            is SetRoomFilter -> {
+                rooms[cmd.roomId]?.let { room ->
+                    val updated = when (cmd.kind) {
+                        RecordingFilterKind.PUBLIC -> room.copy(recordPublic = cmd.value)
+                        RecordingFilterKind.FREE_SPY -> room.copy(recordFreeSpy = cmd.value)
+                        RecordingFilterKind.TICKET -> room.copy(autoPayTicket = cmd.value)
+                        RecordingFilterKind.PAID_SPY -> room.copy(autoPaySpy = cmd.value)
                     }
+                    rooms[room.id] = updated
+                    // an armed room refreshes its own copy only through a preconfig attempt, and a
+                    // room that is no longer recordable never makes one: push the change instead
+                    eventBus.publish(RoomSettingsChanged(updated.id, updated.settings(), updated.status))
                 }
                 OkResponse
             }
@@ -199,19 +199,9 @@ class RoomComponent(
                         logger.warn("Duplicate room: id={}, name={}", id, name)
                         ErrorResponse("Exist $name")
                     } else {
-                        rooms[id] = Room(
-                            id,
-                            name,
-                            cmd.quality,
-                            cmd.timeLimit,
-                            cmd.sizeLimitBytes,
-                            cmd.autoPayTicket,
-                            cmd.autoPaySpy,
-                            null,
-                            pkey = cmd.pkey
-                        )
+                        rooms[id] = newRoom(id, name, cmd.settings)
                         SensitiveStringRegistry.mask(name)
-                        logger.info("Room added: id={}, name={}, quality={}", id, name, cmd.quality)
+                        logger.info("Room added: id={}, name={}, quality={}", id, name, cmd.settings.quality)
                         eventBus.publish(RoomAdded(id, name))
                         RoomNameResponse(name)
                     }
@@ -303,17 +293,27 @@ class RoomComponent(
         }
     }
 
+    /** A room carrying every field of [settings], with no status seen yet. */
+    private fun newRoom(id: Long, name: String, settings: RoomSettings): Room = Room(
+        id = id,
+        name = name,
+        quality = settings.quality,
+        timeLimit = settings.timeLimit,
+        sizeLimitBytes = settings.sizeLimitBytes,
+        recordPublic = settings.recordPublic,
+        recordFreeSpy = settings.recordFreeSpy,
+        autoPayTicket = settings.autoPayTicket,
+        autoPaySpy = settings.autoPaySpy,
+        lastSeen = null,
+        pkey = settings.pkey
+    )
+
     suspend fun internalAdd(
         id: Long,
         name: String,
-        quality: String,
-        timeLimit: Duration,
-        sizeLimitBytes: Long,
-        autoPayTicket: Boolean,
-        autoPaySpy: Boolean,
-        pkey: String = ""
+        settings: RoomSettings,
     ) {
-        rooms[id] = Room(id, name, quality, timeLimit, sizeLimitBytes, autoPayTicket, autoPaySpy, null, pkey = pkey)
+        rooms[id] = newRoom(id, name, settings)
         // let LiveEventSource subscribe the room's status channels
         eventBus.publish(RoomAdded(id, name))
     }
@@ -346,7 +346,7 @@ class RoomComponent(
         val known = rooms.keys
         val added = resolveRoomNames(modelIds.distinct().filterNot { it in known }).map { (id, name) ->
             SensitiveStringRegistry.mask(name)
-            internalAdd(id, name, FAVORITES_DEFAULT_QUALITY, Duration.INFINITE, 0, false, false)
+            internalAdd(id, name, RoomSettings(quality = FAVORITES_DEFAULT_QUALITY))
             logger.info("Favorite imported as room: id={}, name={}", id, name)
             name
         }

--- a/src/main/kotlin/github/rikacelery/v3/components/RoomComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/RoomComponent.kt
@@ -410,6 +410,9 @@ class RoomComponent(
                     if (room.timeLimit != Duration.INFINITE) sb.append(" limit:${room.timeLimit.inWholeSeconds}")
                     if (room.sizeLimitBytes > 0) sb.append(" size:${formatSize(room.sizeLimitBytes)}")
                     if (room.pkey.isNotBlank()) sb.append(" pkey:${room.pkey}")
+                    // filters are opt-out tokens: a line without them keeps the defaults
+                    if (!room.recordPublic) sb.append(" nopublic")
+                    if (!room.recordFreeSpy) sb.append(" nofreespy")
                     when {
                         room.autoPayTicket && room.autoPaySpy -> sb.append(" autopay")
                         room.autoPayTicket -> sb.append(" autopay:ticket")

--- a/src/main/kotlin/github/rikacelery/v3/components/RoomComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/RoomComponent.kt
@@ -163,29 +163,23 @@ class RoomComponent(
             }
 
             is SetRoomTimeLimit -> {
-                rooms[cmd.roomId]?.let { rooms[it.id] = it.copy(timeLimit = cmd.limit) }
-                eventBus.publish(RoomTimeLimitChanged(cmd.roomId, cmd.limit))
+                publishSettingsChange(cmd.roomId) { it.copy(timeLimit = cmd.limit) }
                 OkResponse
             }
 
             is SetRoomSizeLimit -> {
-                rooms[cmd.roomId]?.let { rooms[it.id] = it.copy(sizeLimitBytes = cmd.limitBytes) }
-                eventBus.publish(RoomSizeLimitChanged(cmd.roomId, cmd.limitBytes))
+                publishSettingsChange(cmd.roomId) { it.copy(sizeLimitBytes = cmd.limitBytes) }
                 OkResponse
             }
 
             is SetRoomFilter -> {
-                rooms[cmd.roomId]?.let { room ->
-                    val updated = when (cmd.kind) {
+                publishSettingsChange(cmd.roomId) { room ->
+                    when (cmd.kind) {
                         RecordingFilterKind.PUBLIC -> room.copy(recordPublic = cmd.value)
                         RecordingFilterKind.FREE_SPY -> room.copy(recordFreeSpy = cmd.value)
                         RecordingFilterKind.TICKET -> room.copy(autoPayTicket = cmd.value)
                         RecordingFilterKind.PAID_SPY -> room.copy(autoPaySpy = cmd.value)
                     }
-                    rooms[room.id] = updated
-                    // an armed room refreshes its own copy only through a preconfig attempt, and a
-                    // room that is no longer recordable never makes one: push the change instead
-                    eventBus.publish(RoomSettingsChanged(updated.id, updated.settings(), updated.status))
                 }
                 OkResponse
             }
@@ -247,6 +241,22 @@ class RoomComponent(
             else -> return
         }
         eventBus.publish(CommandAck(env.id, ack))
+    }
+
+    /**
+     * Applies [change] to a room and pushes the resulting settings to the scheduler.
+     *
+     * An armed room refreshes its own copy only through a preconfig attempt, and a room that is
+     * no longer recordable never makes one, so a change made in the dashboard would otherwise
+     * sit unused until something else moved the room. Quality is deliberately not published
+     * here: it travels as [QualityChangeRequested], which restarts a running session.
+     */
+    private suspend fun publishSettingsChange(roomId: Long, change: (Room) -> Room) {
+        rooms[roomId]?.let { room ->
+            val updated = change(room)
+            rooms[roomId] = updated
+            eventBus.publish(RoomSettingsChanged(updated.id, updated.settings(), updated.status))
+        }
     }
 
     private suspend fun refreshRoomStatus(room: Room) {

--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -6,6 +6,7 @@ import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
 import github.rikacelery.v3.data.Hosts
 import github.rikacelery.v3.data.Room
+import github.rikacelery.v3.data.RoomSettings
 import github.rikacelery.v3.data.RoomStatus
 import github.rikacelery.v3.data.RuntimeTuning
 import github.rikacelery.v3.data.User
@@ -41,7 +42,6 @@ import kotlinx.serialization.json.JsonObject
 import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.abs
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 // ============================================================
@@ -51,7 +51,7 @@ import kotlin.time.Duration.Companion.seconds
 enum class SchedulerState { Armed, Preconfiguring, Recording, Stopping }
 
 enum class SchedulerEvent {
-    RoomStatusChanged, StreamStatusChanged, ChangeQuality, SessionExit,
+    RoomStatusChanged, StreamStatusChanged, ChangeQuality, SettingsChanged, SessionExit,
     PreconfigDone, PreconfigFailed,
     BeginPreconfig, RestartRecording, BackToArmed, StopAndWait,
 }
@@ -106,12 +106,7 @@ class SchedulerEntry(
     internal val component: SchedulerComponent
 ) {
     // —— Armed configuration ——
-    var targetQuality: String = "highest"
-    var pkey: String = ""
-    var autoPayTicket: Boolean = false
-    var autoPaySpy: Boolean = false
-    var timeLimit: Duration = Duration.INFINITE
-    var sizeLimitBytes: Long = 0L
+    var settings: RoomSettings = RoomSettings()
 
     // —— Status ——
     var roomStatus: String = ""
@@ -149,9 +144,9 @@ class SchedulerEntry(
     }
 
     internal fun canRecord(status: String): Boolean = when {
-        RoomStatus.isPublic(status) -> true
-        RoomStatus.isGroupShow(status) -> autoPayTicket
-        RoomStatus.isPrivate(status) -> autoPaySpy
+        RoomStatus.isPublic(status) -> settings.recordPublic
+        RoomStatus.isGroupShow(status) -> settings.autoPayTicket
+        RoomStatus.isPrivate(status) -> settings.autoPaySpy
         else -> false
     }
 
@@ -185,8 +180,8 @@ class SchedulerEntry(
                     pkey = configuredPkey,
                     quality = configuredQuality,
                     startIndex = lastIndex?.plus(1),
-                    timeLimit = timeLimit,
-                    sizeLimitBytes = sizeLimitBytes,
+                    timeLimit = settings.timeLimit,
+                    sizeLimitBytes = settings.sizeLimitBytes,
                 )
             )
         }
@@ -201,18 +196,13 @@ class SchedulerEntry(
     internal suspend fun preconfigSignal(): SchedulerMsg {
         return try {
             val config = component.requestBus.request<RoomConfigResponse>(GetRoomConfig(roomId))
-            timeLimit = config.timeLimit
-            sizeLimitBytes = config.sizeLimitBytes
-            targetQuality = config.quality
-            autoPayTicket = config.autoPayTicket
-            autoPaySpy = config.autoPaySpy
-            pkey = config.pkey.ifBlank { component.streamAuthKey }
+            settings = config.settings.copy(pkey = config.settings.pkey.ifBlank { component.streamAuthKey })
 
             val token = fetchToken(config)
                 ?: return SchedulerSignal(roomId, SchedulerEvent.PreconfigFailed, SchedulerDriveData(failReason = lastFailReason ?: "no token"))
             val master = fetchMaster(token)
             val keyName = matchPkey(master)
-            val variant = selectVariant(master, targetQuality)
+            val variant = selectVariant(master, settings.quality)
             val url = resolveVariantUrl(variant, keyName, token)
             if (!playlistUsable(url)) {
                 return SchedulerSignal(roomId, SchedulerEvent.PreconfigFailed, SchedulerDriveData(failReason = "playlist unusable"))
@@ -244,7 +234,7 @@ class SchedulerEntry(
     }
 
     private suspend fun fetchGroupToken(config: RoomConfigResponse): String? {
-        if (!config.autoPayTicket) {
+        if (!config.settings.autoPayTicket) {
             lastFailReason = "autopay disabled"
             return null
         }
@@ -280,7 +270,7 @@ class SchedulerEntry(
             return token
         }
         lastFailReason = "no free spy access"
-        if (!config.autoPaySpy) {
+        if (!config.settings.autoPaySpy) {
             lastFailReason = "autopay disabled"
             return null
         }
@@ -318,7 +308,7 @@ class SchedulerEntry(
 
     private suspend fun fetchMaster(token: String?): MasterPlaylist {
         val client = component.httpClientProvider.proxied("master_$roomId")
-        val urls = component.masterUrlCandidates(roomId, pkey, token)
+        val urls = component.masterUrlCandidates(roomId, settings.pkey, token)
         var lastErr: Throwable? = null
         for (url in urls) {
             val host = Url(url).host
@@ -427,13 +417,18 @@ private fun buildSchedulerFsm(ctx: SchedulerEntry) =
                 if (canRecord(roomStatus) && streamStatus == "distributing") self(SchedulerEvent.BeginPreconfig)
             }
             on(SchedulerEvent.ChangeQuality) to KEEP action { d ->
-                if (d?.newQuality != null) targetQuality = d.newQuality
+                if (d?.newQuality != null) settings = settings.copy(quality = d.newQuality)
             }
             on(SchedulerEvent.SessionExit) to KEEP
             on(SchedulerEvent.BeginPreconfig) to SchedulerState.Preconfiguring action { startPreconfigLoop() }
             on(SchedulerEvent.RestartRecording) to KEEP
             on(SchedulerEvent.BackToArmed) to KEEP
             on(SchedulerEvent.StopAndWait) to KEEP
+            on(SchedulerEvent.SettingsChanged) to KEEP action { d ->
+                val st = d?.roomStatus ?: return@action
+                roomStatus = st
+                if (canRecord(st)) self(SchedulerEvent.BeginPreconfig)
+            }
         }
 
         state(SchedulerState.Preconfiguring) {
@@ -442,7 +437,7 @@ private fun buildSchedulerFsm(ctx: SchedulerEntry) =
                 playlistUrl = d?.playlistUrl ?: return@action
                 configuredQuality = d.quality ?: ""
                 configuredToken = d.token
-                configuredPkey = d.pkey ?: pkey
+                configuredPkey = d.pkey ?: settings.pkey
                 currentKind = kindOf(roomStatus)
                 lastFailReason = null
                 launch {
@@ -454,8 +449,8 @@ private fun buildSchedulerFsm(ctx: SchedulerEntry) =
                             pkey = configuredPkey,
                             quality = configuredQuality,
                             startIndex = lastIndex?.plus(1),
-                            timeLimit = timeLimit,
-                            sizeLimitBytes = sizeLimitBytes,
+                            timeLimit = settings.timeLimit,
+                            sizeLimitBytes = settings.sizeLimitBytes,
                         )
                     )
                 }
@@ -477,12 +472,16 @@ private fun buildSchedulerFsm(ctx: SchedulerEntry) =
                 if (d?.streamStatus != null) streamStatus = d.streamStatus
             }
             on(SchedulerEvent.ChangeQuality) to KEEP action { d ->
-                if (d?.newQuality != null) targetQuality = d.newQuality
+                if (d?.newQuality != null) settings = settings.copy(quality = d.newQuality)
             }
             on(SchedulerEvent.BeginPreconfig) to KEEP
             on(SchedulerEvent.BackToArmed) to SchedulerState.Armed action { stopPreconfigLoop() }
             on(SchedulerEvent.RestartRecording) to KEEP
             on(SchedulerEvent.StopAndWait) to KEEP
+            on(SchedulerEvent.SettingsChanged) to KEEP action { d ->
+                if (d?.roomStatus != null) roomStatus = d.roomStatus
+                if (!canRecord(roomStatus)) self(SchedulerEvent.BackToArmed)
+            }
         }
 
         state(SchedulerState.Recording) {
@@ -507,8 +506,8 @@ private fun buildSchedulerFsm(ctx: SchedulerEntry) =
             }
             on(SchedulerEvent.ChangeQuality) to KEEP action { d ->
                 val q = d?.newQuality ?: return@action
-                if (q != targetQuality) {
-                    targetQuality = q
+                if (q != settings.quality) {
+                    settings = settings.copy(quality = q)
                     self(SchedulerEvent.StopAndWait, SchedulerDriveData(stopReason = EndReason.NewInit))
                 }
             }
@@ -520,7 +519,13 @@ private fun buildSchedulerFsm(ctx: SchedulerEntry) =
                 lastIndex = d?.lastIndex
                 val reason = d?.exitReason ?: EndReason.UserStop
                 when (reason) {
-                    EndReason.TimeLimit, EndReason.SizeLimit -> self(SchedulerEvent.RestartRecording)
+                    // a limit cut only resumes the room while it is still recordable: the filter
+                    // may have been switched off while this session was running
+                    // a limit cut only resumes the room while it is still recordable: the filter
+                    // may have been switched off while this session was running
+                    EndReason.TimeLimit, EndReason.SizeLimit ->
+                        if (canRecord(roomStatus)) self(SchedulerEvent.RestartRecording)
+                        else self(SchedulerEvent.BackToArmed)
                     else -> {
                         if (canRecord(roomStatus)) self(SchedulerEvent.BeginPreconfig)
                         else self(SchedulerEvent.BackToArmed)
@@ -538,6 +543,12 @@ private fun buildSchedulerFsm(ctx: SchedulerEntry) =
             }
             on(SchedulerEvent.PreconfigDone) to KEEP
             on(SchedulerEvent.PreconfigFailed) to KEEP
+            on(SchedulerEvent.SettingsChanged) to KEEP action { d ->
+                if (d?.roomStatus != null) roomStatus = d.roomStatus
+                if (!canRecord(roomStatus)) {
+                    self(SchedulerEvent.StopAndWait, SchedulerDriveData(stopReason = EndReason.StatusChanged))
+                }
+            }
         }
 
         state(SchedulerState.Stopping) {
@@ -549,7 +560,9 @@ private fun buildSchedulerFsm(ctx: SchedulerEntry) =
                 lastIndex = d?.lastIndex
                 val reason = d?.exitReason ?: EndReason.UserStop
                 when (reason) {
-                    EndReason.TimeLimit, EndReason.SizeLimit -> self(SchedulerEvent.RestartRecording)
+                    EndReason.TimeLimit, EndReason.SizeLimit ->
+                        if (canRecord(roomStatus)) self(SchedulerEvent.RestartRecording)
+                        else self(SchedulerEvent.BackToArmed)
                     EndReason.NewInit -> self(SchedulerEvent.BeginPreconfig)
                     EndReason.StatusChanged -> {
                         if (canRecord(roomStatus)) self(SchedulerEvent.BeginPreconfig)
@@ -571,11 +584,14 @@ private fun buildSchedulerFsm(ctx: SchedulerEntry) =
                 if (d?.streamStatus != null) streamStatus = d.streamStatus
             }
             on(SchedulerEvent.ChangeQuality) to KEEP action { d ->
-                if (d?.newQuality != null) targetQuality = d.newQuality
+                if (d?.newQuality != null) settings = settings.copy(quality = d.newQuality)
             }
             on(SchedulerEvent.StopAndWait) to KEEP
             on(SchedulerEvent.PreconfigDone) to KEEP
             on(SchedulerEvent.PreconfigFailed) to KEEP
+            on(SchedulerEvent.SettingsChanged) to KEEP action { d ->
+                if (d?.roomStatus != null) roomStatus = d.roomStatus
+            }
         }
     }
 
@@ -604,6 +620,7 @@ class SchedulerComponent(
         subscribe<RoomRemoved>(RoomRemoved::class)
         subscribe<SessionExit>(SessionExit::class)
         subscribe<QualityChangeRequested>(QualityChangeRequested::class)
+        subscribe<RoomSettingsChanged>(RoomSettingsChanged::class)
         subscribe<CommandEnvelope>(CommandEnvelope::class)
         subscribe<WriterFatal>(WriterFatal::class)
         subscribe<AuthExpired>(AuthExpired::class)
@@ -616,6 +633,7 @@ class SchedulerComponent(
         is RoomRemoved -> SchedulerBus(event)
         is SessionExit -> SchedulerBus(event)
         is QualityChangeRequested -> SchedulerBus(event)
+        is RoomSettingsChanged -> SchedulerBus(event)
         is CommandEnvelope -> SchedulerHandleCommand(event)
         is WriterFatal -> SchedulerBus(event)
         is AuthExpired -> SchedulerBus(event)
@@ -637,6 +655,20 @@ class SchedulerComponent(
             is StreamStatusChanged -> driveFsm(event.roomId, SchedulerEvent.StreamStatusChanged, SchedulerDriveData(streamStatus = event.newStatus))
             is SessionExit -> driveFsm(event.roomId, SchedulerEvent.SessionExit, SchedulerDriveData(lastIndex = event.lastIndex, exitReason = event.reason))
             is QualityChangeRequested -> driveFsm(event.roomId, SchedulerEvent.ChangeQuality, SchedulerDriveData(newQuality = event.newQuality))
+            is RoomSettingsChanged -> {
+                // mirror what the entry would have read on its next preconfig attempt, then let
+                // the FSM decide whether the new settings mean start, stop or carry on
+                entries[event.roomId]?.let { entry ->
+                    entry.settings = event.settings.copy(
+                        pkey = event.settings.pkey.ifBlank { streamAuthKey }
+                    )
+                    driveFsm(
+                        event.roomId,
+                        SchedulerEvent.SettingsChanged,
+                        SchedulerDriveData(roomStatus = event.status)
+                    )
+                }
+            }
             is WriterFatal -> {
                 logger.error("Writer fatal room {}: {}", event.roomId, event.error)
                 entries.remove(event.roomId)?.scope?.cancel()
@@ -674,18 +706,16 @@ class SchedulerComponent(
         e.fsm.driveCatch(event, data)?.let { logger.error("Scheduler FSM drive failed", it) }
     }
 
-    /** Used by Bootstrap to arm rooms loaded from list.conf */
-    fun internalAdd(room: Long, name: String, quality: String, pkey: String, isArmed: Boolean, autoPayTicket: Boolean, autoPaySpy: Boolean) {
-        if (!isArmed) return
-        entries.getOrPut(room) {
+    /** Arms a room loaded from list.conf and returns its entry, or null when it is not armed. */
+    fun internalAdd(room: Long, name: String, settings: RoomSettings, isArmed: Boolean): SchedulerEntry? {
+        if (!isArmed) return null
+        val entry = entries.getOrPut(room) {
             SchedulerEntry(room, name, this).apply {
-                targetQuality = quality
-                this.pkey = pkey.ifBlank { streamAuthKey }
-                this.autoPayTicket = autoPayTicket
-                this.autoPaySpy = autoPaySpy
+                this.settings = settings.copy(pkey = settings.pkey.ifBlank { streamAuthKey })
             }
         }
         logger.info("Room {} ({}) armed and waiting", name, room)
+        return entry
     }
 
     private suspend fun handleCommand(env: CommandEnvelope) {
@@ -696,12 +726,9 @@ class SchedulerComponent(
                     val config = requestBus.request<RoomConfigResponse>(GetRoomConfig(cmd.roomId))
                     entries.getOrPut(cmd.roomId) {
                         SchedulerEntry(cmd.roomId, name, this).apply {
-                            targetQuality = config.quality
-                            pkey = config.pkey.ifBlank { streamAuthKey }
-                            autoPayTicket = config.autoPayTicket
-                            autoPaySpy = config.autoPaySpy
-                            timeLimit = config.timeLimit
-                            sizeLimitBytes = config.sizeLimitBytes
+                            settings = config.settings.copy(
+                                pkey = config.settings.pkey.ifBlank { streamAuthKey }
+                            )
                         }
                     }
                     logger.info("Room {} ({}) activated (armed)", name, cmd.roomId)

--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -6,6 +6,8 @@ import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
 import github.rikacelery.v3.data.Hosts
 import github.rikacelery.v3.data.Room
+import github.rikacelery.v3.data.RoomHint
+import github.rikacelery.v3.data.RoomHintCode
 import github.rikacelery.v3.data.RoomSettings
 import github.rikacelery.v3.data.RoomStatus
 import github.rikacelery.v3.data.RuntimeTuning
@@ -168,6 +170,34 @@ class SchedulerEntry(
         RoomStatus.isPrivate(status) -> settings.autoPaySpy ||
             (settings.recordFreeSpy && !freeSpyExhausted)
         else -> false
+    }
+
+    /**
+     * Why an armed room is not recording, or null when there is nothing to explain: the session
+     * is running, the show is simply not on, or recording is about to start. The dashboard shows
+     * it next to the room status, so a room that is waiting for the room status to change can be
+     * told apart from one that was switched off or cannot get a token.
+     */
+    fun hint(): RoomHint? {
+        if (fsm.currentState == SchedulerState.Recording) return null
+        return when {
+            RoomStatus.isPublic(roomStatus) && !settings.recordPublic ->
+                RoomHint(RoomHintCode.PUBLIC_FILTER_OFF)
+
+            RoomStatus.isGroupShow(roomStatus) && !settings.autoPayTicket ->
+                RoomHint(RoomHintCode.TICKET_PURCHASE_OFF)
+
+            RoomStatus.isPrivate(roomStatus) && !settings.autoPaySpy && freeSpyExhausted ->
+                RoomHint(RoomHintCode.NO_FREE_SPY)
+
+            RoomStatus.isPrivate(roomStatus) && !settings.autoPaySpy && !settings.recordFreeSpy ->
+                RoomHint(RoomHintCode.PRIVATE_FILTER_OFF)
+
+            fsm.currentState == SchedulerState.Preconfiguring && lastFailReason != null ->
+                RoomHint(RoomHintCode.PRECONFIG_FAILED, lastFailReason)
+
+            else -> null
+        }
     }
 
     internal fun kindOf(status: String): String = when {
@@ -820,6 +850,10 @@ class SchedulerComponent(
             }
 
             is GetArmedRoomIds -> entries.keys().toList()
+
+            is GetRecordingHints -> RecordingHintsResponse(
+                entries.mapNotNull { (roomId, entry) -> entry.hint()?.let { roomId to it } }.toMap()
+            )
 
             is ShutdownCmd -> {
                 gracefulStop = true

--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -712,6 +712,9 @@ class SchedulerComponent(
                 // the FSM decide whether the new settings mean start, stop or carry on
                 entries[event.roomId]?.let { entry ->
                     entry.settings = event.settings.copy(
+                        // quality travels as QualityChangeRequested: it restarts a running session
+                        // by comparing the requested value with the one held here
+                        quality = entry.settings.quality,
                         pkey = event.settings.pkey.ifBlank { streamAuthKey }
                     )
                     entry.freeSpyExhausted = false

--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -56,6 +56,14 @@ enum class SchedulerEvent {
     BeginPreconfig, RestartRecording, BackToArmed, StopAndWait,
 }
 
+/**
+ * Why a token could not be obtained. Decisions read this instead of parsing
+ * [SchedulerDriveData.failReason], which stays a human-readable log message.
+ */
+enum class TokenFailure {
+    AutopayDisabled, NoAccount, PriceUnavailable, InsufficientBalance, NoToken, NoFreeSpy, BadStatus
+}
+
 data class SchedulerDriveData(
     val roomStatus: String? = null,
     val streamStatus: String? = null,
@@ -67,6 +75,7 @@ data class SchedulerDriveData(
     val token: String? = null,
     val pkey: String? = null,
     val failReason: String? = null,
+    val tokenFailure: TokenFailure? = null,
     val stopReason: EndReason? = null,
 )
 
@@ -108,6 +117,14 @@ class SchedulerEntry(
     // —— Armed configuration ——
     var settings: RoomSettings = RoomSettings()
 
+    /**
+     * Set when a private show could not use a free spy privilege and paid spy is off. The
+     * privilege is a property of the account, not of the show, so one probe per private
+     * episode is enough — without this the preconfig loop would ask the platform every
+     * [RuntimeTuning.preconfigRetryInterval] while the show lasts.
+     */
+    var freeSpyExhausted: Boolean = false
+
     // —— Status ——
     var roomStatus: String = ""
     var streamStatus: String = ""
@@ -122,6 +139,7 @@ class SchedulerEntry(
     // —— Resume state ——
     var lastIndex: Long? = null
     var lastFailReason: String? = null
+    private var tokenFailure: TokenFailure? = null
 
     val scope = CoroutineScope(
         component.ioScope.coroutineContext + SupervisorJob(component.ioScope.coroutineContext[Job])
@@ -146,7 +164,9 @@ class SchedulerEntry(
     internal fun canRecord(status: String): Boolean = when {
         RoomStatus.isPublic(status) -> settings.recordPublic
         RoomStatus.isGroupShow(status) -> settings.autoPayTicket
-        RoomStatus.isPrivate(status) -> settings.autoPaySpy
+        // a free spy privilege is worth recording on its own; paying still needs autoPaySpy
+        RoomStatus.isPrivate(status) -> settings.autoPaySpy ||
+            (settings.recordFreeSpy && !freeSpyExhausted)
         else -> false
     }
 
@@ -197,9 +217,14 @@ class SchedulerEntry(
         return try {
             val config = component.requestBus.request<RoomConfigResponse>(GetRoomConfig(roomId))
             settings = config.settings.copy(pkey = config.settings.pkey.ifBlank { component.streamAuthKey })
+            tokenFailure = null
 
             val token = fetchToken(config)
-                ?: return SchedulerSignal(roomId, SchedulerEvent.PreconfigFailed, SchedulerDriveData(failReason = lastFailReason ?: "no token"))
+                ?: return SchedulerSignal(
+                    roomId,
+                    SchedulerEvent.PreconfigFailed,
+                    SchedulerDriveData(failReason = lastFailReason ?: "no token", tokenFailure = tokenFailure)
+                )
             val master = fetchMaster(token)
             val keyName = matchPkey(master)
             val variant = selectVariant(master, settings.quality)
@@ -228,6 +253,7 @@ class SchedulerEntry(
             RoomStatus.isPrivate(status) -> fetchPrivateToken(config)
             else -> {
                 lastFailReason = "status $status"
+                tokenFailure = TokenFailure.BadStatus
                 null
             }
         }
@@ -236,6 +262,7 @@ class SchedulerEntry(
     private suspend fun fetchGroupToken(config: RoomConfigResponse): String? {
         if (!config.settings.autoPayTicket) {
             lastFailReason = "autopay disabled"
+            tokenFailure = TokenFailure.AutopayDisabled
             return null
         }
         val camInfo = component.apiClient.roomFetchCamInfo(roomId, "")
@@ -244,6 +271,7 @@ class SchedulerEntry(
         val u = users.firstOrNull()
         if (u == null) {
             lastFailReason = "no account"
+            tokenFailure = TokenFailure.NoAccount
             return null
         }
         var token = component.apiClient.roomFetchModelToken(roomId, u)
@@ -255,6 +283,7 @@ class SchedulerEntry(
         }
         if (token == null) {
             lastFailReason = "no token"
+            tokenFailure = TokenFailure.NoToken
             return null
         }
         return token
@@ -266,10 +295,14 @@ class SchedulerEntry(
         if (freeUser != null) {
             val cam = component.apiClient.roomFetchCamInfo(roomId, freeUser.cookie)
             val token = cam.PathSingle("cam.modelToken").asString().ifBlank { null }
-            if (token == null) lastFailReason = "no token"
+            if (token == null) {
+                lastFailReason = "no token"
+                tokenFailure = TokenFailure.NoToken
+            }
             return token
         }
         lastFailReason = "no free spy access"
+        tokenFailure = TokenFailure.NoFreeSpy
         if (!config.settings.autoPaySpy) {
             lastFailReason = "autopay disabled"
             return null
@@ -277,16 +310,19 @@ class SchedulerEntry(
         val paidUser = users.firstOrNull()
         if (paidUser == null) {
             lastFailReason = "no account"
+            tokenFailure = TokenFailure.NoAccount
             return null
         }
         val paidCam = component.apiClient.roomFetchCamInfo(roomId, paidUser.cookie)
         val price = paidCam.PathSingleOrNull("user.user.privateRate")?.asInt()
         if (price == null) {
             lastFailReason = "price unavailable"
+            tokenFailure = TokenFailure.PriceUnavailable
             return null
         }
         if (paidUser.coins < price) {
             lastFailReason = "insufficient balance"
+            tokenFailure = TokenFailure.InsufficientBalance
             return null
         }
         var token = paidCam.PathSingle("cam.modelToken").asString().ifBlank { null }
@@ -301,6 +337,7 @@ class SchedulerEntry(
         }
         if (token == null) {
             lastFailReason = "no token"
+            tokenFailure = TokenFailure.NoToken
             return null
         }
         return token
@@ -456,7 +493,17 @@ private fun buildSchedulerFsm(ctx: SchedulerEntry) =
                 }
             }
             on(SchedulerEvent.PreconfigFailed) to KEEP action { d ->
-                // stay in Preconfiguring; the 15s ticker retries automatically
+                // no free spy privilege and paid spy is off: this room is not recordable while the
+                // private show lasts, so stop asking the platform every retry interval
+                if (d?.tokenFailure == TokenFailure.NoFreeSpy && !settings.autoPaySpy) {
+                    freeSpyExhausted = true
+                    schedulerLogger.info(
+                        "Room {}: no free spy access, waiting for the next private show", roomId
+                    )
+                    self(SchedulerEvent.BackToArmed)
+                    return@action
+                }
+                // stay in Preconfiguring; the ticker retries automatically
                 if (lastFailReason != d?.failReason) {
                     schedulerLogger.warn("Preconfig failed room={}: {}", roomId, d?.failReason)
                     lastFailReason = d?.failReason
@@ -651,7 +698,12 @@ class SchedulerComponent(
 
     private suspend fun onBus(event: Any) {
         when (event) {
-            is RoomStatusChanged -> driveFsm(event.roomId, SchedulerEvent.RoomStatusChanged, SchedulerDriveData(roomStatus = event.newStatus))
+            is RoomStatusChanged -> {
+                // the free spy privilege is probed once per private show, so anything that ends
+                // the show (offline, public, group show) re-arms the probe for the next one
+                if (!RoomStatus.isPrivate(event.newStatus)) entries[event.roomId]?.freeSpyExhausted = false
+                driveFsm(event.roomId, SchedulerEvent.RoomStatusChanged, SchedulerDriveData(roomStatus = event.newStatus))
+            }
             is StreamStatusChanged -> driveFsm(event.roomId, SchedulerEvent.StreamStatusChanged, SchedulerDriveData(streamStatus = event.newStatus))
             is SessionExit -> driveFsm(event.roomId, SchedulerEvent.SessionExit, SchedulerDriveData(lastIndex = event.lastIndex, exitReason = event.reason))
             is QualityChangeRequested -> driveFsm(event.roomId, SchedulerEvent.ChangeQuality, SchedulerDriveData(newQuality = event.newQuality))
@@ -662,6 +714,7 @@ class SchedulerComponent(
                     entry.settings = event.settings.copy(
                         pkey = event.settings.pkey.ifBlank { streamAuthKey }
                     )
+                    entry.freeSpyExhausted = false
                     driveFsm(
                         event.roomId,
                         SchedulerEvent.SettingsChanged,

--- a/src/main/kotlin/github/rikacelery/v3/data/Room.kt
+++ b/src/main/kotlin/github/rikacelery/v3/data/Room.kt
@@ -17,12 +17,30 @@ data class Room(
     @Serializable(with = DurationMillisSerializer::class)
     val timeLimit: Duration = Duration.INFINITE,
     val sizeLimitBytes: Long,
+    val recordPublic: Boolean = true,
+    val recordFreeSpy: Boolean = true,
     val autoPayTicket: Boolean = false,
     val autoPaySpy: Boolean = false,
     val lastSeen: String?,
     val status: String = "",
     val pkey: String = ""
-)
+) {
+    /** This room's recording settings as one value. */
+    fun settings(): RoomSettings =
+        RoomSettings(quality, timeLimit, sizeLimitBytes, recordPublic, recordFreeSpy, autoPayTicket, autoPaySpy, pkey)
+
+    /** This room with the recording parts of [settings] replaced, identity and status untouched. */
+    fun withSettings(settings: RoomSettings): Room = copy(
+        quality = settings.quality,
+        timeLimit = settings.timeLimit,
+        sizeLimitBytes = settings.sizeLimitBytes,
+        recordPublic = settings.recordPublic,
+        recordFreeSpy = settings.recordFreeSpy,
+        autoPayTicket = settings.autoPayTicket,
+        autoPaySpy = settings.autoPaySpy,
+        pkey = settings.pkey
+    )
+}
 
 object DurationMillisSerializer : KSerializer<Duration> {
     override val descriptor = PrimitiveSerialDescriptor("DurationMillis", PrimitiveKind.LONG)

--- a/src/main/kotlin/github/rikacelery/v3/data/RoomHint.kt
+++ b/src/main/kotlin/github/rikacelery/v3/data/RoomHint.kt
@@ -1,0 +1,29 @@
+package github.rikacelery.v3.data
+
+/**
+ * Why an armed room is not recording, as a stable [code] the dashboard translates plus an
+ * optional [detail] (a platform-level reason such as "no account") shown verbatim.
+ */
+data class RoomHint(val code: RoomHintCode, val detail: String? = null)
+
+/** The reasons the dashboard can explain, and their spelling on the wire. */
+enum class RoomHintCode(val wireName: String) {
+    /** The room is public, but public recording is switched off. */
+    PUBLIC_FILTER_OFF("public_filter_off"),
+
+    /** The room is in a group show, but ticket purchase is switched off. */
+    TICKET_PURCHASE_OFF("ticket_purchase_off"),
+
+    /** The room is private and neither free spy nor paid spy recording is allowed. */
+    PRIVATE_FILTER_OFF("private_filter_off"),
+
+    /** The room is private, paid spy is off, and this account has no free spy privilege. */
+    NO_FREE_SPY("no_free_spy"),
+
+    /** The room should be recordable but preconfig keeps failing; [RoomHint.detail] says why. */
+    PRECONFIG_FAILED("preconfig_failed");
+
+    companion object {
+        fun fromWire(value: String?): RoomHintCode? = entries.firstOrNull { it.wireName == value }
+    }
+}

--- a/src/main/kotlin/github/rikacelery/v3/data/RoomSettings.kt
+++ b/src/main/kotlin/github/rikacelery/v3/data/RoomSettings.kt
@@ -1,0 +1,24 @@
+package github.rikacelery.v3.data
+
+import kotlin.time.Duration
+import kotlinx.serialization.Serializable
+
+/**
+ * Per-room recording settings: how to record (quality, limits) and what may be recorded
+ * (the paid-show switches). Bundled into one value so list.conf, the room commands, the
+ * scheduler entry and the WebUI carry a single object instead of a growing parameter list.
+ */
+@Serializable
+data class RoomSettings(
+    val quality: String = "highest",
+    @Serializable(with = DurationMillisSerializer::class)
+    val timeLimit: Duration = Duration.INFINITE,
+    val sizeLimitBytes: Long = 0L,
+    /** Record public (free) shows. */
+    val recordPublic: Boolean = true,
+    /** Treat a free-spy private show as worth recording; paid spy still needs [autoPaySpy]. */
+    val recordFreeSpy: Boolean = true,
+    val autoPayTicket: Boolean = false,
+    val autoPaySpy: Boolean = false,
+    val pkey: String = "",
+)

--- a/src/main/kotlin/github/rikacelery/v3/events/Commands.kt
+++ b/src/main/kotlin/github/rikacelery/v3/events/Commands.kt
@@ -143,6 +143,10 @@ object GetArmedRoomIds : Request {
 object GetRoomDetailedStatus : Request {
     override fun toString() = "GetRoomDetailedStatus"
 }
+/** Why each armed room is not recording right now; rooms with nothing to explain are absent. */
+object GetRecordingHints : Request {
+    override fun toString() = "GetRecordingHints"
+}
 data class GetValidPaymentAccount(val price: Long) : Request {
     override fun toString() = "GetValidPaymentAccount(price=$price)"
 }
@@ -165,6 +169,9 @@ data class RoomConfigResponse(
     val settings: github.rikacelery.v3.data.RoomSettings
 ) : Response {
     override fun toString() = "RoomConfigResponse(quality=${settings.quality}, timeLimit=${settings.timeLimit}, sizeLimitBytes=${settings.sizeLimitBytes})"
+}
+data class RecordingHintsResponse(val hints: Map<Long, github.rikacelery.v3.data.RoomHint>) : Response {
+    override fun toString() = "RecordingHintsResponse(count=${hints.size})"
 }
 data class ConfigResponse(val value: Any?) : Response {
     override fun toString() = "ConfigResponse(value=$value)"

--- a/src/main/kotlin/github/rikacelery/v3/events/Commands.kt
+++ b/src/main/kotlin/github/rikacelery/v3/events/Commands.kt
@@ -28,8 +28,20 @@ data class SetRoomTimeLimit(val roomId: Long, val limit: Duration) : Request {
 data class SetRoomSizeLimit(val roomId: Long, val limitBytes: Long) : Request {
     override fun toString() = "SetRoomSizeLimit(roomId=$roomId, limitBytes=$limitBytes)"
 }
-/** The per-room recording switches a user can flip (issue #130). */
-enum class RecordingFilterKind { PUBLIC, FREE_SPY, TICKET, PAID_SPY }
+/**
+ * The per-room recording switches a user can flip (issue #130). [wireName] is the spelling
+ * used by the HTTP API and the dashboard.
+ */
+enum class RecordingFilterKind(val wireName: String) {
+    PUBLIC("public"),
+    FREE_SPY("freespy"),
+    TICKET("ticket"),
+    PAID_SPY("paidspy");
+
+    companion object {
+        fun fromWire(value: String?): RecordingFilterKind? = entries.firstOrNull { it.wireName == value }
+    }
+}
 
 data class SetRoomFilter(val roomId: Long, val kind: RecordingFilterKind, val value: Boolean) : Request {
     override fun toString() = "SetRoomFilter(roomId=$roomId, kind=$kind, value=$value)"

--- a/src/main/kotlin/github/rikacelery/v3/events/Commands.kt
+++ b/src/main/kotlin/github/rikacelery/v3/events/Commands.kt
@@ -28,17 +28,17 @@ data class SetRoomTimeLimit(val roomId: Long, val limit: Duration) : Request {
 data class SetRoomSizeLimit(val roomId: Long, val limitBytes: Long) : Request {
     override fun toString() = "SetRoomSizeLimit(roomId=$roomId, limitBytes=$limitBytes)"
 }
-enum class AutoPayKind { GROUP_SHOW, PRIVATE }
+/** The per-room recording switches a user can flip (issue #130). */
+enum class RecordingFilterKind { PUBLIC, FREE_SPY, TICKET, PAID_SPY }
 
-data class SetRoomAutoPay(val roomId: Long, val kind: AutoPayKind, val autoPay: Boolean) : Request {
-    override fun toString() = "SetRoomAutoPay(roomId=$roomId, kind=$kind, autoPay=$autoPay)"
+data class SetRoomFilter(val roomId: Long, val kind: RecordingFilterKind, val value: Boolean) : Request {
+    override fun toString() = "SetRoomFilter(roomId=$roomId, kind=$kind, value=$value)"
 }
 data class AddRoom(
-    val name: String, val quality: String, val pkey: String = "",
-    val timeLimit: Duration = Duration.INFINITE, val sizeLimitBytes: Long = 0,
-    val autoPayTicket: Boolean = false, val autoPaySpy: Boolean = false
+    val name: String,
+    val settings: github.rikacelery.v3.data.RoomSettings = github.rikacelery.v3.data.RoomSettings()
 ) : Request {
-    override fun toString() = "AddRoom(name=$name, quality=$quality)"
+    override fun toString() = "AddRoom(name=$name, quality=${settings.quality})"
 }
 data class RemoveRoom(val roomId: Long) : Request {
     override fun toString() = "RemoveRoom(roomId=$roomId)"
@@ -150,14 +150,9 @@ data class RoomNameResponse(val name: String) : Response {
     override fun toString() = "RoomNameResponse(name=$name)"
 }
 data class RoomConfigResponse(
-    val quality: String,
-    val timeLimit: Duration,
-    val sizeLimitBytes: Long,
-    val autoPayTicket: Boolean = false,
-    val autoPaySpy: Boolean = false,
-    val pkey: String = ""
+    val settings: github.rikacelery.v3.data.RoomSettings
 ) : Response {
-    override fun toString() = "RoomConfigResponse(quality=$quality, timeLimit=$timeLimit, sizeLimitBytes=$sizeLimitBytes)"
+    override fun toString() = "RoomConfigResponse(quality=${settings.quality}, timeLimit=${settings.timeLimit}, sizeLimitBytes=${settings.sizeLimitBytes})"
 }
 data class ConfigResponse(val value: Any?) : Response {
     override fun toString() = "ConfigResponse(value=$value)"

--- a/src/main/kotlin/github/rikacelery/v3/events/Events.kt
+++ b/src/main/kotlin/github/rikacelery/v3/events/Events.kt
@@ -148,6 +148,20 @@ data class RoomSizeLimitChanged(val roomId: Long, val limitBytes: Long) {
     override fun toString() = "RoomSizeLimitChanged(roomId=$roomId, limitBytes=$limitBytes)"
 }
 
+/**
+ * Published whenever a room's recording settings change, carrying the new settings and the
+ * room's current status. The scheduler mirrors both, so a switch flipped in the UI takes
+ * effect on a room that is already armed or recording — an armed room never refreshes its
+ * configuration on its own while it is not recordable (issue #130).
+ */
+data class RoomSettingsChanged(
+    val roomId: Long,
+    val settings: github.rikacelery.v3.data.RoomSettings,
+    val status: String
+) {
+    override fun toString() = "RoomSettingsChanged(roomId=$roomId, status=$status, settings=$settings)"
+}
+
 // ── Misc ──
 
 enum class EndReason { SizeLimit, TimeLimit, StreamEnd, UserStop, NewInit, StatusChanged }

--- a/src/main/kotlin/github/rikacelery/v3/events/Events.kt
+++ b/src/main/kotlin/github/rikacelery/v3/events/Events.kt
@@ -2,7 +2,6 @@ package github.rikacelery.v3.events
 
 import kotlinx.serialization.json.JsonObject
 import java.io.File
-import kotlin.time.Duration
 
 data class Segment(val url: String, val index: Int) {
     override fun toString() = "Segment(#$index $url)"
@@ -141,13 +140,6 @@ data class QualityChangeHint(val roomId: Long) {
 data class QualityChangeRequested(val roomId: Long, val newQuality: String) {
     override fun toString() = "QualityChangeRequested(roomId=$roomId, quality=$newQuality)"
 }
-data class RoomTimeLimitChanged(val roomId: Long, val limit: Duration) {
-    override fun toString() = "RoomTimeLimitChanged(roomId=$roomId, limit=$limit)"
-}
-data class RoomSizeLimitChanged(val roomId: Long, val limitBytes: Long) {
-    override fun toString() = "RoomSizeLimitChanged(roomId=$roomId, limitBytes=$limitBytes)"
-}
-
 /**
  * Published whenever a room's recording settings change, carrying the new settings and the
  * room's current status. The scheduler mirrors both, so a switch flipped in the UI takes

--- a/src/main/resources/vue.html
+++ b/src/main/resources/vue.html
@@ -322,9 +322,9 @@
                                     :class="!sort['Status'] ? 'fa-sort text-slate-300' : (sort['Status'] === 1 ? 'fa-sort-down text-indigo-500' : 'fa-sort-up text-indigo-500')"></i>
                             </th>
                             <th class="px-2 py-2.5 cursor-pointer hover:bg-slate-100 transition-colors select-none text-center text-xs"
-                                @click="sortToggle('AutoPay')">
-                                {{ $t('Auto Pay') }} <i class="fa-solid ml-0.5 text-[9px]"
-                                    :class="!sort['AutoPay'] ? 'fa-sort text-slate-300' : (sort['AutoPay'] === 1 ? 'fa-sort-down text-indigo-500' : 'fa-sort-up text-indigo-500')"></i>
+                                @click="sortToggle('Filters')">
+                                {{ $t('Filters') }} <i class="fa-solid ml-0.5 text-[9px]"
+                                    :class="!sort['Filters'] ? 'fa-sort text-slate-300' : (sort['Filters'] === 1 ? 'fa-sort-down text-indigo-500' : 'fa-sort-up text-indigo-500')"></i>
                             </th>
                             <th class="px-2 py-2.5 text-center text-xs">{{ $t('Segments') }}</th>
                             <th class="px-2 py-2.5 cursor-pointer hover:bg-slate-100 transition-colors select-none text-right text-xs"
@@ -407,27 +407,13 @@
                                 </div>
                             </td>
                             <td class="px-2 py-1.5">
-                                <div class="flex flex-col gap-1.5 items-end text-xs">
-                                    <div class="flex items-center gap-1">
-                                        <span class="text-slate-500 font-mono text-right min-w-[3rem]">{{room.timeLimit > 0 ? (room.timeLimit / 1000) : '∞'}}s</span>
-                                        <input v-model.number="editLimits[room.id]" type="number" min="0"
-                                            class="w-14 px-1.5 py-0.5 text-xs border border-slate-200 rounded bg-white focus:outline-none focus:border-indigo-500"
-                                            :placeholder="$t('sec')">
-                                        <button @click="setLimit(room.id)" :title="$t('Set Time')"
-                                            class="text-emerald-600 hover:text-emerald-800 p-0.5 leading-none">
-                                            <i class="fa-solid fa-check text-[11px]"></i>
-                                        </button>
-                                    </div>
-                                    <div class="flex items-center gap-1">
-                                        <span class="text-slate-500 font-mono text-right min-w-[3rem]">{{room.sizeLimitBytes > 0 ? formatBytes(room.sizeLimitBytes) : '∞'}}</span>
-                                        <input v-model="editSizeLimits[room.id]" type="text"
-                                            class="w-14 px-1.5 py-0.5 text-xs border border-slate-200 rounded bg-white focus:outline-none focus:border-indigo-500"
-                                            :placeholder="$t('e.g. 1G')">
-                                        <button @click="setSizeLimit(room.id)" :title="$t('Set Size')"
-                                            class="text-emerald-600 hover:text-emerald-800 p-0.5 leading-none">
-                                            <i class="fa-solid fa-check text-[11px]"></i>
-                                        </button>
-                                    </div>
+                                <div class="flex flex-col gap-0.5 items-end text-xs font-mono text-slate-500">
+                                    <span :title="$t('Time limit')">
+                                        <i class="fa-regular fa-clock mr-1 text-[10px]"></i>{{room.timeLimit > 0 ? (room.timeLimit / 1000) : '∞'}}s
+                                    </span>
+                                    <span :title="$t('Size limit')">
+                                        <i class="fa-solid fa-database mr-1 text-[10px]"></i>{{room.sizeLimitBytes > 0 ? formatBytes(room.sizeLimitBytes) : '∞'}}
+                                    </span>
                                 </div>
                             </td>
                             <td class="px-2 py-1.5 text-center">
@@ -453,29 +439,11 @@
                                 </span>
                             </td>
                             <td class="px-1 py-1">
-                                <div class="flex flex-col gap-1.5 items-center">
-                                    <div class="flex flex-col items-center gap-0.5">
-                                        <label class="relative inline-flex items-center cursor-pointer"
-                                            :title="$t('Auto-pay for ticket/group shows')">
-                                            <input type="checkbox" v-model="room.autoPayTicket"
-                                                @change="setAutoPay($event.target.checked, room.id, 'ticket')" class="sr-only peer">
-                                            <div
-                                                class="w-7 h-4 bg-slate-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-indigo-600">
-                                            </div>
-                                        </label>
-                                        <span class="text-[9px] text-slate-500 leading-none">{{ $t('Ticket') }}</span>
-                                    </div>
-                                    <div class="flex flex-col items-center gap-0.5">
-                                        <label class="relative inline-flex items-center cursor-pointer"
-                                            :title="$t('Auto-pay for private shows')">
-                                            <input type="checkbox" v-model="room.autoPaySpy"
-                                                @change="setAutoPay($event.target.checked, room.id, 'private')" class="sr-only peer">
-                                            <div
-                                                class="w-7 h-4 bg-slate-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-indigo-600">
-                                            </div>
-                                        </label>
-                                        <span class="text-[9px] text-slate-500 leading-none">{{ $t('Private') }}</span>
-                                    </div>
+                                <div class="flex items-center justify-center gap-1" :title="$t('Click to change the recording filters')">
+                                    <span v-for="f in roomFilters(room)" :key="f.key"
+                                        class="px-1.5 py-0.5 rounded border text-[10px] font-mono cursor-pointer transition-colors"
+                                        :class="f.on ? 'bg-indigo-50 text-indigo-600 border-indigo-200 hover:bg-indigo-100' : 'bg-slate-50 text-slate-300 border-slate-200 hover:text-slate-400'"
+                                        :title="f.label" @click="openRoomSettings(room)">{{f.key}}</span>
                                 </div>
                             </td>
                             <td class="px-2 py-1.5">
@@ -508,6 +476,10 @@
                             <td class="px-2 py-1.5">
                                 <div
                                     class="flex items-center justify-center gap-1 opacity-70 group-hover:opacity-100 transition-opacity">
+                                    <button @click="openRoomSettings(room)" :title="$t('Room Settings')"
+                                        class="w-6 h-6 rounded bg-slate-100 text-slate-500 hover:bg-slate-600 hover:text-white transition-colors flex items-center justify-center">
+                                        <i class="fa-solid fa-sliders text-[10px]"></i>
+                                    </button>
                                     <button @click="action('activate',room.id)" :title="$t('Activate')"
                                         class="w-6 h-6 rounded bg-slate-100 text-emerald-600 hover:bg-emerald-600 hover:text-white transition-colors flex items-center justify-center">
                                         <i class="fa-solid fa-play text-[10px]"></i>
@@ -774,6 +746,65 @@
         </div>
     </div>
 
+    <!-- Room Settings Dialog -->
+    <div v-if="settingsRoom" class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+        @click.self="closeRoomSettings()">
+        <div class="bg-white dark:bg-slate-800 rounded-xl shadow-2xl p-6 w-[90vw] max-w-lg max-h-[85vh] overflow-y-auto">
+            <div class="flex justify-between items-center mb-4">
+                <h2 class="text-lg font-semibold text-slate-800 dark:text-slate-100">
+                    <i class="fa-solid fa-sliders text-indigo-500 mr-2"></i>
+                    {{ $t('Room Settings') }} - <span class="font-mono">{{settingsRoom.name}}</span>
+                </h2>
+                <button @click="closeRoomSettings()"
+                    class="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200">
+                    <i class="fas fa-times"></i>
+                </button>
+            </div>
+
+            <div class="text-xs font-semibold text-slate-500 dark:text-slate-400 mb-2">{{ $t('Recording filters') }}</div>
+            <div class="flex flex-col gap-2 mb-5">
+                <label v-for="f in filterRows" :key="f.key"
+                    class="flex items-start justify-between gap-3 p-2 rounded border border-slate-200 dark:border-slate-700 cursor-pointer">
+                    <span class="text-xs">
+                        <span class="block text-slate-700 dark:text-slate-200">{{f.label}}</span>
+                        <span class="block text-slate-400">{{f.hint}}</span>
+                    </span>
+                    <span class="relative inline-flex items-center shrink-0 mt-0.5">
+                        <input type="checkbox" class="sr-only peer" :checked="settingsRoom[f.field]"
+                            @change="setRoomFilter(f.key, $event.target.checked)">
+                        <span
+                            class="w-8 h-5 bg-slate-200 rounded-full peer-checked:bg-indigo-600 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border after:border-gray-300 after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-3"></span>
+                    </span>
+                </label>
+            </div>
+
+            <div class="text-xs font-semibold text-slate-500 dark:text-slate-400 mb-2">{{ $t('Limits') }}</div>
+            <div class="grid grid-cols-2 gap-3 mb-5">
+                <label class="text-xs text-slate-500 dark:text-slate-400">
+                    {{ $t('Time limit') }}
+                    <input v-model.number="settingsTime" type="number" min="0"
+                        class="mt-1 w-full px-2 py-1 text-xs border border-slate-200 rounded bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-200"
+                        :placeholder="$t('seconds, 0 = unlimited')">
+                </label>
+                <label class="text-xs text-slate-500 dark:text-slate-400">
+                    {{ $t('Size limit') }}
+                    <input v-model="settingsSize" type="text"
+                        class="mt-1 w-full px-2 py-1 text-xs border border-slate-200 rounded bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-200"
+                        :placeholder="$t('e.g. 1G, 0 = unlimited')">
+                </label>
+            </div>
+
+            <div class="flex justify-end gap-2">
+                <button @click="saveRoomLimits()"
+                    class="px-4 py-2 rounded bg-indigo-600 hover:bg-indigo-700 text-white text-sm">
+                    <i class="fa-solid fa-floppy-disk mr-1"></i>{{ $t('Save limits') }}
+                </button>
+                <button @click="closeRoomSettings()"
+                    class="px-4 py-2 rounded bg-slate-100 hover:bg-slate-200 dark:bg-slate-700 dark:hover:bg-slate-600 text-slate-700 dark:text-slate-200 text-sm">{{ $t('Close') }}</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Favorites Import Dialog -->
     <div v-if="favoritesDialog" class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
         @click.self="favoritesDialog=false">
@@ -900,8 +931,9 @@
                     addQuality: "highest",
                     sort: { "Room": 1, "Status": 1 },
                     roomInfo: {},
-                    editLimits: {}, // Cache for limits inputs to prevent overlap with polling
-                    editSizeLimits: {}, // Cache for size limits inputs to prevent overlap with polling
+                    settingsRoom: null, // room whose settings dialog is open
+                    settingsTime: 0,    // time limit shown in that dialog (seconds, 0 = unlimited)
+                    settingsSize: '',   // size limit shown in that dialog (e.g. "1G", empty = unlimited)
                     allUrls: [],
                     snapshotcache: {},
                     activeVideos: {},
@@ -989,6 +1021,19 @@
                             'Private': '私密',
                             'Auto-pay for ticket/group shows': '自动付费：票务/群秀',
                             'Auto-pay for private shows': '自动付费：私密秀',
+                            'Filters': '录制开关', 'Room Settings': '直播间设置',
+                            'Recording filters': '录制开关', 'Limits': '限制',
+                            'Public shows': '公开秀', 'Free spy': '免费偷窥',
+                            'Paid ticket': '付费票务', 'Paid private': '付费私密',
+                            'Record the public (free) shows': '录制公开（免费）秀',
+                            'Record private shows you can watch for free': '有免费偷窥额度时录制私密秀',
+                            'Buy a ticket to record group shows': '购买门票以录制群秀',
+                            'Spend tokens to record private shows': '花费代币录制私密秀',
+                            'Time limit': '时长限制', 'Size limit': '大小限制',
+                            'seconds, 0 = unlimited': '秒，0 表示不限',
+                            'e.g. 1G, 0 = unlimited': '例如 1G，0 表示不限',
+                            'Save limits': '保存限制',
+                            'Click to change the recording filters': '点击修改录制开关',
                             'ML Prediction': '机器学习预测', 'ML Model Status': '模型状态',
                             'Train Now': '立即训练', 'Trained': '已训练', 'Not Ready': '未就绪',
                             'CDN Model': 'CDN 模型', 'Schedule Model': '开播模型', 'trees': '棵树',
@@ -1015,6 +1060,14 @@
                 },
                 selectedFavoriteCount() {
                     return this.favoriteCandidates.filter(c => c.selected && !c.existing).length;
+                },
+                filterRows() {
+                    return [
+                        { key: 'public', field: 'recordPublic', label: this.$t('Public shows'), hint: this.$t('Record the public (free) shows') },
+                        { key: 'freespy', field: 'recordFreeSpy', label: this.$t('Free spy'), hint: this.$t('Record private shows you can watch for free') },
+                        { key: 'ticket', field: 'autoPayTicket', label: this.$t('Paid ticket'), hint: this.$t('Buy a ticket to record group shows') },
+                        { key: 'paidspy', field: 'autoPaySpy', label: this.$t('Paid private'), hint: this.$t('Spend tokens to record private shows') },
+                    ];
                 },
                 roomDisplay() {
                     const list = Object.values(this.roomInfo);
@@ -1043,8 +1096,10 @@
                             const res = parseQ(a.quality) - parseQ(b.quality);
                             if (!isNaN(res) && res !== 0) return this.sort["Quality"] === 1 ? res : -res;
                         }
-                        if (this.sort["AutoPay"] && a.autoPay !== b.autoPay) {
-                            return this.sort["AutoPay"] === 1 ? (a.autoPay ? -1 : 1) : (a.autoPay ? 1 : -1);
+                        if (this.sort["Filters"]) {
+                            const aOn = this.enabledFilterCount(a);
+                            const bOn = this.enabledFilterCount(b);
+                            if (aOn !== bOn) return this.sort["Filters"] === 1 ? bOn - aOn : aOn - bOn;
                         }
                         if (this.sort["ID"] && a.id !== b.id) {
                             return this.sort["ID"] === 1 ? b.id - a.id : a.id - b.id;
@@ -1232,34 +1287,42 @@
                         this.showToast(await r1.text());
                     } catch (e) { this.showToast(this.$t('Network Error'), "error"); }
                 },
-                async setAutoPay(value, roomId, kind) {
+                // ── Room settings dialog ───────────────────────────────────
+                openRoomSettings(room) {
+                    this.settingsRoom = room;
+                    this.settingsTime = room.timeLimit > 0 ? Math.round(room.timeLimit / 1000) : 0;
+                    this.settingsSize = room.sizeLimitBytes > 0 ? this.formatBytes(room.sizeLimitBytes) : '';
+                },
+                closeRoomSettings() {
+                    this.settingsRoom = null;
+                },
+                roomFilters(room) {
+                    return [
+                        { key: 'P', on: !!room.recordPublic, label: this.$t('Public shows') },
+                        { key: 'F', on: !!room.recordFreeSpy, label: this.$t('Free spy') },
+                        { key: 'T', on: !!room.autoPayTicket, label: this.$t('Paid ticket') },
+                        { key: 'S', on: !!room.autoPaySpy, label: this.$t('Paid private') },
+                    ];
+                },
+                enabledFilterCount(room) {
+                    return this.roomFilters(room).filter(f => f.on).length;
+                },
+                async setRoomFilter(kind, value) {
+                    if (!this.settingsRoom) return;
                     try {
-                        const r1 = await fetch(`${HOST}/autopay?id=${roomId}&v=${value}&kind=${kind}`);
-                        this.showToast(await r1.text());
+                        const r = await fetch(`${HOST}/filter?id=${this.settingsRoom.id}&kind=${kind}&v=${value}`);
+                        this.showToast(await r.text());
                     } catch (e) { this.showToast(this.$t('Network Error'), "error"); }
                 },
-                async setLimit(roomId) {
-                    const newLimit = this.editLimits[roomId];
-                    if (newLimit === undefined || newLimit === null || newLimit < 0) {
-                        this.showToast(this.$t('Invalid limit value'), "error");
-                        return;
-                    }
+                async saveRoomLimits() {
+                    if (!this.settingsRoom) return;
+                    const seconds = this.settingsTime > 0 ? Math.floor(this.settingsTime) : 0;
+                    const size = (this.settingsSize || '').trim() || '0';
                     try {
-                        const r1 = await fetch(`${HOST}/limit?id=${roomId}&v=${newLimit}`);
+                        const r1 = await fetch(`${HOST}/limit?id=${this.settingsRoom.id}&v=${seconds}`);
                         this.showToast(await r1.text());
-                        this.editLimits[roomId] = null;
-                    } catch (e) { this.showToast(this.$t('Network Error'), "error"); }
-                },
-                async setSizeLimit(roomId) {
-                    const newLimit = this.editSizeLimits[roomId];
-                    if (!newLimit) {
-                        this.showToast(this.$t('Invalid size value'), "error");
-                        return;
-                    }
-                    try {
-                        const r1 = await fetch(`${HOST}/sizelimit?id=${roomId}&v=${newLimit}`);
-                        this.showToast(await r1.text());
-                        this.editSizeLimits[roomId] = null;
+                        const r2 = await fetch(`${HOST}/sizelimit?id=${this.settingsRoom.id}&v=${encodeURIComponent(size)}`);
+                        this.showToast(await r2.text());
                     } catch (e) { this.showToast(this.$t('Network Error'), "error"); }
                 },
                 async action(actionType, roomId) {

--- a/src/main/resources/vue.html
+++ b/src/main/resources/vue.html
@@ -1238,6 +1238,17 @@
                 sortToggle(by) {
                     this.sort[by] = this.sort[by] === 1 ? 2 : (this.sort[by] === 2 ? undefined : 1);
                 },
+                // Token the size field round-trips through /sizelimit (e.g. "1Gi", "1536Mi",
+                // raw bytes for values no unit divides evenly) — unlike formatBytes, which is
+                // for display and produces "1.50 GB" that the parser rejects.
+                sizeLimitToken(bytes) {
+                    if (!bytes || bytes <= 0) return '';
+                    const units = [['Ti', 1099511627776], ['Gi', 1073741824], ['Mi', 1048576], ['Ki', 1024]];
+                    for (const [unit, factor] of units) {
+                        if (bytes % factor === 0) return (bytes / factor) + unit;
+                    }
+                    return String(bytes);
+                },
                 formatBytes(bytes) {
                     if (!bytes) return '0 B';
                     const units = ["B", "KB", "MB", "GB", "TB"];
@@ -1291,7 +1302,7 @@
                 openRoomSettings(room) {
                     this.settingsRoom = room;
                     this.settingsTime = room.timeLimit > 0 ? Math.round(room.timeLimit / 1000) : 0;
-                    this.settingsSize = room.sizeLimitBytes > 0 ? this.formatBytes(room.sizeLimitBytes) : '';
+                    this.settingsSize = this.sizeLimitToken(room.sizeLimitBytes);
                 },
                 closeRoomSettings() {
                     this.settingsRoom = null;

--- a/src/main/resources/vue.html
+++ b/src/main/resources/vue.html
@@ -364,8 +364,9 @@
                             </td>
                             <td class="px-2 py-1.5 text-center text-xs text-slate-500">
                                 {{room.roomStatus}}
-                                <span v-if="room.hint" class="block mt-0.5 text-[10px] text-amber-600 leading-tight"
-                                    :title="room.hint.detail || ''">
+                                <span v-if="room.hint"
+                                    class="block mx-auto mt-0.5 max-w-[11rem] truncate text-[10px] text-amber-700 leading-tight"
+                                    :title="hintText(room.hint)">
                                     <i class="fa-solid fa-circle-question mr-0.5"></i>{{hintText(room.hint)}}
                                 </span>
                             </td>

--- a/src/main/resources/vue.html
+++ b/src/main/resources/vue.html
@@ -364,6 +364,10 @@
                             </td>
                             <td class="px-2 py-1.5 text-center text-xs text-slate-500">
                                 {{room.roomStatus}}
+                                <span v-if="room.hint" class="block mt-0.5 text-[10px] text-amber-600 leading-tight"
+                                    :title="room.hint.detail || ''">
+                                    <i class="fa-solid fa-circle-question mr-0.5"></i>{{hintText(room.hint)}}
+                                </span>
                             </td>
                             <td class="px-2 py-1.5 text-center">
                                 <div class="thumb-container">
@@ -1034,6 +1038,11 @@
                             'e.g. 1G, 0 = unlimited': '例如 1G，0 表示不限',
                             'Save limits': '保存限制',
                             'Click to change the recording filters': '点击修改录制开关',
+                            'Public recording off': '已关闭公开录制',
+                            'Ticket purchase off': '已关闭门票购买',
+                            'Private recording off': '已关闭私密录制',
+                            'No free spy access': '无免费偷窥额度',
+                            'Not recordable': '暂时无法录制',
                             'ML Prediction': '机器学习预测', 'ML Model Status': '模型状态',
                             'Train Now': '立即训练', 'Trained': '已训练', 'Not Ready': '未就绪',
                             'CDN Model': 'CDN 模型', 'Schedule Model': '开播模型', 'trees': '棵树',
@@ -1306,6 +1315,19 @@
                 },
                 closeRoomSettings() {
                     this.settingsRoom = null;
+                },
+                // Why a room is not recording, as returned by /dashboard. The detail is the raw
+                // platform-level reason (for example "no account") and stays untranslated.
+                hintText(hint) {
+                    const keys = {
+                        public_filter_off: 'Public recording off',
+                        ticket_purchase_off: 'Ticket purchase off',
+                        private_filter_off: 'Private recording off',
+                        no_free_spy: 'No free spy access',
+                        preconfig_failed: 'Not recordable',
+                    };
+                    const label = keys[hint.code] ? this.$t(keys[hint.code]) : hint.code;
+                    return hint.detail ? `${label} (${hint.detail})` : label;
                 },
                 roomFilters(room) {
                     return [

--- a/src/test/kotlin/github/rikacelery/v3/components/HttpRoutesTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/HttpRoutesTest.kt
@@ -101,6 +101,23 @@ class HttpRoutesTest {
         }
     }
 
+    @Test
+    fun `the dashboard page ships the room settings dialog`() = testApplication {
+        val harness = RouteHarness()
+        try {
+            application { harness.server.installApplication(this, stopEngine = {}) }
+
+            val response = client.get("/")
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val html = response.bodyAsText()
+            assertTrue(html.contains("Room Settings"), "the dashboard must carry the room settings dialog")
+            assertTrue(html.contains("/filter?id="), "the dialog must call the recording filter route")
+        } finally {
+            harness.close()
+        }
+    }
+
     private class RouteHarness(runtimeTuning: RuntimeTuning = RuntimeTuning()) {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val eventBus = EventBus()

--- a/src/test/kotlin/github/rikacelery/v3/components/RoomComponentTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/RoomComponentTest.kt
@@ -4,6 +4,7 @@ import github.rikacelery.v3.api.ApiClient
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
 import github.rikacelery.v3.data.FavoriteCandidate
+import github.rikacelery.v3.data.RoomSettings
 import github.rikacelery.v3.data.RuntimeTuning
 import github.rikacelery.v3.data.User
 import github.rikacelery.v3.events.CommandAck
@@ -74,7 +75,7 @@ class RoomComponentTest {
         )
         component.start()
         advanceUntilIdle()
-        component.internalAdd(1, "model", "highest", Duration.INFINITE, 0, false, false)
+        component.internalAdd(1, "model", RoomSettings())
         eventBus.publish(RoomStatusChanged(1, "", "public"))
         advanceUntilIdle()
         observed.clear()
@@ -119,7 +120,7 @@ class RoomComponentTest {
         )
         component.start()
         advanceUntilIdle()
-        component.internalAdd(1001, "model-a", "720p", Duration.INFINITE, 0, false, false)
+        component.internalAdd(1001, "model-a", RoomSettings(quality = "720p"))
 
         val candidates = component.favoriteCandidates(listOf(User("cookie-1", 42L, "tester", 100L)))
         advanceUntilIdle()
@@ -173,7 +174,7 @@ class RoomComponentTest {
         )
         component.start()
         advanceUntilIdle()
-        component.internalAdd(1001, "model-one", "720p", Duration.INFINITE, 0, false, false)
+        component.internalAdd(1001, "model-one", RoomSettings(quality = "720p"))
         observed.clear()
 
         // the user picked 1002 and 1003; 1001 is already a room and must stay untouched

--- a/src/test/kotlin/github/rikacelery/v3/components/RuntimeInjectionTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/RuntimeInjectionTest.kt
@@ -4,9 +4,10 @@ import github.rikacelery.v3.api.ApiClient
 import github.rikacelery.v3.core.DataChannel
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
-import github.rikacelery.v3.data.RuntimeTuning
-import github.rikacelery.v3.data.StreamData
 import github.rikacelery.v3.data.Hosts
+import github.rikacelery.v3.data.StreamData
+import github.rikacelery.v3.data.RoomSettings
+import github.rikacelery.v3.data.RuntimeTuning
 import github.rikacelery.v3.events.CommandAck
 import github.rikacelery.v3.events.CommandEnvelope
 import github.rikacelery.v3.events.ConfigResponse
@@ -84,7 +85,7 @@ class RuntimeInjectionTest {
         )
 
         try {
-            component.internalAdd(7, "model", "highest", Duration.INFINITE, 0, false, false)
+            component.internalAdd(7, "model", RoomSettings())
             component.start()
             runCurrent()
             assertEquals("http://127.0.0.1:18080/api/front/v1/broadcasts/model", requestEvents.receive())
@@ -222,7 +223,7 @@ class RuntimeInjectionTest {
                 }
             }
         )
-        val entry = SchedulerEntry(7, "model", scheduler).apply { pkey = "room-key" }
+        val entry = SchedulerEntry(7, "model", scheduler).apply { settings = RoomSettings(pkey = "room-key") }
         val oldCdnHosts = CdnSelector.hosts
         CdnSelector.updateHosts(emptyList())
 
@@ -372,7 +373,7 @@ class RuntimeInjectionTest {
             override suspend fun intercept(event: Any): Any? {
                 if (event is CommandEnvelope) {
                     val answer = when (event.command) {
-                        is GetRoomConfig -> RoomConfigResponse("highest", Duration.INFINITE, 0, pkey = "room-key")
+                        is GetRoomConfig -> RoomConfigResponse(RoomSettings(pkey = "room-key"))
                         is MatchDecryptKeys -> DecryptKeyMatch("key-id", "decrypt-key")
                         is GetDecryptKey -> ConfigResponse("decrypt-key")
                         else -> null

--- a/src/test/kotlin/github/rikacelery/v3/components/SchedulerFilterGuardTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/SchedulerFilterGuardTest.kt
@@ -1,0 +1,99 @@
+package github.rikacelery.v3.components
+
+import github.rikacelery.v3.api.ApiClient
+import github.rikacelery.v3.core.DataChannel
+import github.rikacelery.v3.core.EventBus
+import github.rikacelery.v3.core.RequestBus
+import github.rikacelery.v3.data.RoomSettings
+import github.rikacelery.v3.data.RuntimeTuning
+import github.rikacelery.v3.events.CommandAck
+import github.rikacelery.v3.events.CommandEnvelope
+import github.rikacelery.v3.events.EndReason
+import github.rikacelery.v3.events.GetRoomConfig
+import github.rikacelery.v3.events.RoomConfigResponse
+import github.rikacelery.v3.events.RoomStatusChanged
+import github.rikacelery.v3.hooks.EventHook
+import github.rikacelery.v3.m3u8.M3u8Parser
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.hours
+
+/**
+ * Guard for issue #130: a session that ends on its own limit is normally restarted, but only
+ * while the room is still recordable. Without that check, switching public recording off while
+ * a limited session is running would silently start a fresh public recording.
+ */
+class SchedulerFilterGuardTest {
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun `a session that ended on its limit is not restarted once the room is no longer recordable`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val settings = RoomSettings(recordPublic = false, pkey = "streamKey")
+            val eventBus = EventBus()
+            val requestBus = RequestBus(eventBus, backgroundScope)
+            val dataChannel = DataChannel()
+            val downloader = DownloaderComponent(dataChannel, eventBus = eventBus, parentScope = backgroundScope)
+            val session = SessionComponent(dataChannel, downloader, M3u8Parser, requestBus, eventBus, backgroundScope)
+            val scheduler = SchedulerComponent(
+                requestBus,
+                session,
+                // a dead loopback host: the preconfig attempts fail immediately instead of touching the network
+                ApiClient(listOf("127.0.0.1:1")),
+                "streamKey",
+                eventBus,
+                backgroundScope,
+                runtimeTuning = RuntimeTuning(preconfigRetryInterval = 1.hours)
+            )
+            eventBus.installHook(object : EventHook {
+                override suspend fun intercept(event: Any): Any? {
+                    if (event is CommandEnvelope && event.command is GetRoomConfig) {
+                        eventBus.publish(CommandAck(event.id, RoomConfigResponse(settings)))
+                    }
+                    return event
+                }
+            })
+            scheduler.start()
+            advanceUntilIdle()
+
+            try {
+                val entry = scheduler.internalAdd(42, "model", settings, isArmed = true)!!
+                scheduler.tell(SchedulerSignal(42, SchedulerEvent.RoomStatusChanged, SchedulerDriveData(roomStatus = "public")))
+                advanceUntilIdle()
+
+                scheduler.tell(SchedulerSignal(42, SchedulerEvent.BeginPreconfig, null))
+                advanceUntilIdle()
+                scheduler.tell(
+                    SchedulerSignal(
+                        42,
+                        SchedulerEvent.PreconfigDone,
+                        SchedulerDriveData(playlistUrl = "http://127.0.0.1:1/playlist.m3u8", quality = "720p")
+                    )
+                )
+                advanceUntilIdle()
+                assertEquals(
+                    SchedulerState.Recording,
+                    entry.fsm.currentState,
+                    "precondition: the room is recording while its status makes it recordable"
+                )
+
+                // the session hits its time limit while public recording is switched off
+                scheduler.tell(
+                    SchedulerSignal(42, SchedulerEvent.SessionExit, SchedulerDriveData(exitReason = EndReason.TimeLimit))
+                )
+                advanceUntilIdle()
+
+                assertEquals(
+                    SchedulerState.Armed,
+                    entry.fsm.currentState,
+                    "a room whose public recording is off must not be restarted"
+                )
+            } finally {
+                scheduler.stop()
+            }
+        }
+}

--- a/src/test/kotlin/github/rikacelery/v3/components/SchedulerRoomRemovalTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/SchedulerRoomRemovalTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import github.rikacelery.v3.data.RoomSettings
 
 /**
  * Regression for issue #141: removing a room while it is armed/recording must
@@ -34,7 +35,7 @@ class SchedulerRoomRemovalTest {
         advanceUntilIdle()
 
         try {
-            scheduler.internalAdd(42, "model", "highest", "", isArmed = true, autoPayTicket = false, autoPaySpy = false)
+            scheduler.internalAdd(42, "model", RoomSettings(), isArmed = true)
             advanceUntilIdle()
             assertEquals(listOf(42L), requestBus.request<List<Long>>(GetArmedRoomIds))
 

--- a/src/test/kotlin/github/rikacelery/v3/integration/RecordingFilterIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/RecordingFilterIntegrationTest.kt
@@ -87,4 +87,114 @@ class RecordingFilterIntegrationTest {
             "no new preconfig may run after public recording was turned off"
         )
     }
+
+    @Test
+    fun `a private show is recorded for free when the account has free spy access`() = withFixture { fx ->
+        fx.ready()
+        val room = fx.mock.addRoom(1001, "model", status = "off")
+        room.freeSpyAccess = true
+        room.modelToken = "spy-token"
+
+        // paid spy stays off: only the free privilege may start this recording
+        fx.get("/add?name=model&active=false").expectOk("Room added: model")
+        fx.get("/activate?id=1001").expectOk("Activated")
+        fx.mock.startSegments(1001, 30.milliseconds)
+        fx.awaitRoomSubscribed(1001)
+        fx.mock.setRoomStatus(1001, "p2p")
+
+        fx.awaitSession(1001, SessionState.Recording)
+        fx.awaitEvent<SegmentDownloaded>(10.seconds) { it.roomId == 1001L }
+        assertTrue(
+            fx.mock.requests().none { it.method == "PUT" && it.path.contains("/spy") },
+            "a free spy show must not be purchased: ${fx.mock.requests().map { "${it.method} ${it.path}" }}"
+        )
+    }
+
+    @Test
+    fun `a room without free spy access is probed once per private show`() = withFixture { fx ->
+        fx.ready()
+        fx.mock.addRoom(1001, "model", status = "off")   // freeSpyAccess defaults to false
+
+        // paid spy stays off, so the free privilege is the only possible way in
+        fx.get("/add?name=model&active=false").expectOk("Room added: model")
+        fx.get("/activate?id=1001").expectOk("Activated")
+        fx.mock.startSegments(1001, 30.milliseconds)
+        fx.awaitRoomSubscribed(1001)
+        val before = fx.mock.requests().size
+        fx.mock.setRoomStatus(1001, "p2p")
+
+        // the preconfig loop retries every 100ms in tests: an unthrottled probe would ask
+        // the platform about the privilege ~20 times in this window
+        delay(2000)
+        val probes = fx.mock.requests().drop(before)
+            .count { it.path.contains("/api/front/v2/models/1001/cam") }
+
+        assertTrue(probes <= 3, "the free spy privilege must be probed once per private show, saw $probes probes")
+        assertTrue(
+            fx.sessions().none { it.roomId == 1001L && it.state == SessionState.Recording },
+            "a private show without free spy access must not be recorded"
+        )
+    }
+
+    @Test
+    fun `the room filters are persisted to list conf`() = withFixture { fx ->
+        fx.ready()
+        fx.mock.addRoom(1001, "model", status = "off")
+        fx.get("/add?name=model&active=false").expectOk("Room added: model")
+
+        fx.get("/filter?id=1001&kind=public&v=false").expectOk("Filter public set to false")
+        fx.get("/filter?id=1001&kind=freespy&v=false").expectOk("Filter freespy set to false")
+
+        val line = fx.awaitListConf(15.seconds) { it.contains("nopublic") }
+        assertTrue(line.contains("nofreespy"), "both filters must be written: $line")
+        assertTrue(line.contains("q:highest"), "the rest of the line stays untouched: $line")
+    }
+
+    @Test
+    fun `a private show is not recorded when free spy recording is disabled`() = withFixture { fx ->
+        fx.ready()
+        val room = fx.mock.addRoom(1001, "model", status = "off")
+        room.freeSpyAccess = true
+        room.modelToken = "spy-token"
+
+        fx.get("/add?name=model&active=false").expectOk("Room added: model")
+        fx.get("/filter?id=1001&kind=freespy&v=false").expectOk("Filter freespy set to false")
+        fx.get("/activate?id=1001").expectOk("Activated")
+        fx.mock.startSegments(1001, 30.milliseconds)
+        fx.awaitRoomSubscribed(1001)
+        fx.mock.setRoomStatus(1001, "p2p")
+
+        delay(1500)
+        assertTrue(
+            fx.sessions().none { it.roomId == 1001L && it.state == SessionState.Recording },
+            "free spy recording is off, so the private show must not be recorded"
+        )
+        assertTrue(fx.events.filterIsInstance<SegmentDownloaded>().isEmpty())
+    }
+
+    @Test
+    fun `a later private show probes for the free spy privilege again`() = withFixture { fx ->
+        fx.ready()
+        fx.mock.addRoom(1001, "model", status = "off")
+        fx.get("/add?name=model&active=false").expectOk("Room added: model")
+        fx.get("/activate?id=1001").expectOk("Activated")
+        fx.mock.startSegments(1001, 30.milliseconds)
+        fx.awaitRoomSubscribed(1001)
+
+        fx.mock.setRoomStatus(1001, "p2p")
+        delay(750)
+        val firstShow = fx.mock.requests().count { it.path.contains("/api/front/v2/models/1001/cam") }
+        assertTrue(firstShow > 0, "the privilege must be probed when the private show starts")
+
+        fx.mock.setRoomStatus(1001, "off")
+        delay(250)
+        fx.mock.setRoomStatus(1001, "p2p")
+        delay(750)
+
+        val secondShow = fx.mock.requests().count { it.path.contains("/api/front/v2/models/1001/cam") }
+        assertTrue(
+            secondShow > firstShow,
+            "the next private show must probe again instead of staying exhausted forever"
+        )
+    }
 }

--- a/src/test/kotlin/github/rikacelery/v3/integration/RecordingFilterIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/RecordingFilterIntegrationTest.kt
@@ -4,6 +4,7 @@ import github.rikacelery.v3.components.SessionState
 import github.rikacelery.v3.events.EndReason
 import github.rikacelery.v3.events.FileReady
 import github.rikacelery.v3.events.SegmentDownloaded
+import kotlinx.serialization.json.jsonObject
 import kotlinx.coroutines.delay
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -134,6 +135,60 @@ class RecordingFilterIntegrationTest {
             fx.sessions().none { it.roomId == 1001L && it.state == SessionState.Recording },
             "a private show without free spy access must not be recorded"
         )
+    }
+
+    @Test
+    fun `the dashboard explains the filters that keep a room quiet`() = withFixture { fx ->
+        fx.ready()
+        fx.mock.addRoom(1001, "quiet", status = "public")
+        fx.mock.addRoom(1002, "ticketed", status = "groupShow")
+
+        fx.get("/add?name=quiet&active=false").expectOk("Room added: quiet")
+        fx.get("/filter?id=1001&kind=public&v=false").expectOk("Filter public set to false")
+        fx.get("/activate?id=1001").expectOk("Activated")
+        fx.get("/add?name=ticketed&active=false").expectOk("Room added: ticketed")
+        fx.get("/activate?id=1002").expectOk("Activated")
+
+        val quiet = fx.awaitRoom("quiet") { it.path("room.hint.code") == "public_filter_off" }
+        assertEquals("public_filter_off", quiet.path("room.hint.code"))
+        val ticketed = fx.awaitRoom("ticketed") { it.path("room.hint.code") == "ticket_purchase_off" }
+        assertEquals("ticket_purchase_off", ticketed.path("room.hint.code"))
+    }
+
+    @Test
+    fun `the dashboard explains a private show it cannot watch for free`() = withFixture { fx ->
+        fx.ready()
+        fx.mock.addRoom(1001, "model", status = "off")
+        fx.get("/add?name=model&active=false").expectOk("Room added: model")
+        fx.get("/activate?id=1001").expectOk("Activated")
+        fx.awaitRoomSubscribed(1001)
+        fx.mock.setRoomStatus(1001, "p2p")
+
+        val room = fx.awaitRoom("model") { it.path("room.hint.code") == "no_free_spy" }
+        assertEquals("no_free_spy", room.path("room.hint.code"))
+    }
+
+    @Test
+    fun `the dashboard explains a failed preconfig with its reason`() = withFixture { fx ->
+        fx.ready(users = emptyList())
+        fx.mock.addRoom(1001, "model", status = "off")
+        fx.get("/add?name=model&active=false&autoPaySpy=true").expectOk("Room added: model")
+        fx.get("/activate?id=1001").expectOk("Activated")
+        fx.awaitRoomSubscribed(1001)
+        fx.mock.setRoomStatus(1001, "p2p")
+
+        val room = fx.awaitRoom("model") { it.path("room.hint.code") == "preconfig_failed" }
+        assertEquals("preconfig_failed", room.path("room.hint.code"))
+        assertEquals("no account", room.path("room.hint.detail"))
+    }
+
+    @Test
+    fun `a recording room has no hint`() = withFixture { fx ->
+        fx.ready()
+        fx.startRecording()
+
+        val room = fx.awaitRoom("model") { it.boolField("listening") }
+        assertTrue(room["room"]!!.jsonObject["hint"] == null, "a recording room needs no explanation: $room")
     }
 
     @Test

--- a/src/test/kotlin/github/rikacelery/v3/integration/RecordingFilterIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/RecordingFilterIntegrationTest.kt
@@ -1,0 +1,90 @@
+package github.rikacelery.v3.integration
+
+import github.rikacelery.v3.components.SessionState
+import github.rikacelery.v3.events.EndReason
+import github.rikacelery.v3.events.FileReady
+import github.rikacelery.v3.events.SegmentDownloaded
+import kotlinx.coroutines.delay
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Per-room recording filters (issue #130): the switches decide which kinds of show a room is
+ * armed for, and turning one off must take effect on a room that is already armed.
+ */
+class RecordingFilterIntegrationTest {
+
+    @Test
+    fun `public show is not recorded when public recording is disabled`() = withFixture { fx ->
+        fx.ready()
+        fx.mock.addRoom(1001, "model", status = "off")
+        fx.get("/add?name=model&active=false").expectOk("Room added: model")
+
+        fx.get("/filter?id=1001&kind=public&v=false").expectOk("Filter public set to false")
+
+        fx.get("/activate?id=1001").expectOk("Activated")
+        fx.mock.startSegments(1001, 30.milliseconds)
+        fx.awaitRoomSubscribed(1001)
+        fx.mock.setRoomStatus(1001, "public")
+
+        // bounded negative: the room must stay quiet while public recording is off
+        delay(1500)
+        assertTrue(
+            fx.sessions().none { it.roomId == 1001L && it.state == SessionState.Recording },
+            "a public show must not be recorded while public recording is off: ${fx.sessions()}"
+        )
+        assertTrue(
+            fx.events.filterIsInstance<SegmentDownloaded>().isEmpty(),
+            "no segment may be fetched while public recording is off"
+        )
+    }
+
+    @Test
+    fun `enabling public recording starts an already armed room`() = withFixture { fx ->
+        fx.ready()
+        fx.mock.addRoom(1001, "model", status = "off")
+        fx.get("/add?name=model&active=false").expectOk("Room added: model")
+        fx.get("/filter?id=1001&kind=public&v=false").expectOk("Filter public set to false")
+
+        fx.get("/activate?id=1001").expectOk("Activated")
+        fx.mock.startSegments(1001, 30.milliseconds)
+        fx.awaitRoomSubscribed(1001)
+        fx.mock.setRoomStatus(1001, "public")
+        delay(750)
+        assertTrue(
+            fx.sessions().none { it.roomId == 1001L && it.state == SessionState.Recording },
+            "precondition: the armed room stays quiet while public recording is off"
+        )
+
+        fx.get("/filter?id=1001&kind=public&v=true").expectOk("Filter public set to true")
+
+        // the room is already public: turning the filter back on must start it without a status change
+        fx.awaitSession(1001, SessionState.Recording)
+        fx.awaitEvent<SegmentDownloaded>(10.seconds) { it.roomId == 1001L }
+    }
+
+    @Test
+    fun `disabling public recording stops a running recording`() = withFixture { fx ->
+        fx.ready()
+        fx.startRecording()
+
+        fx.get("/filter?id=1001&kind=public&v=false").expectOk("Filter public set to false")
+
+        val file = fx.awaitEvent<FileReady>(15.seconds) { it.roomId == 1001L }
+        assertEquals(EndReason.StatusChanged, file.reason)
+
+        // bounded negative: the new filter must keep the room quiet, not restart it
+        delay(750)
+        assertTrue(
+            fx.sessions().none { it.roomId == 1001L && it.state == SessionState.Recording },
+            "a public show must stay stopped after the filter was turned off: ${fx.sessions()}"
+        )
+        assertTrue(
+            fx.mock.requests().none { it.path.contains("/hls/1001/master") && it.atMs > file.endTime },
+            "no new preconfig may run after public recording was turned off"
+        )
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/integration/RoomRoutesIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/RoomRoutesIntegrationTest.kt
@@ -19,6 +19,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Test
 import java.io.File
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -310,6 +311,43 @@ class RoomRoutesIntegrationTest {
 
         fx.get("/deactivate?id=1001").expectOk("Deactivated")
         fx.awaitListConf(15.seconds) { it.contains("model") && it.trimStart().startsWith("#") }
+    }
+
+    @Test
+    fun `the dashboard exposes the room filters`() = withFixture { fx ->
+        fx.ready()
+        fx.mock.addRoom(1001, "model", status = "off")
+        fx.get("/add?name=model&active=false").expectOk("Room added: model")
+        fx.get("/filter?id=1001&kind=public&v=false").expectOk("Filter public set to false")
+
+        val displayed = fx.awaitRoom("model") { it.path("room.recordPublic") == "false" }
+        val room = displayed["room"]!!.jsonObject
+        assertFalse(room.boolField("recordPublic"), "the dashboard must show the public filter")
+        assertTrue(room.boolField("recordFreeSpy"), "untouched filters keep their defaults")
+    }
+
+    @Test
+    fun `the filter route rejects unknown kinds and missing values`() = withFixture { fx ->
+        fx.ready()
+        fx.mock.addRoom(1001, "model", status = "off")
+        fx.get("/add?name=model&active=false").expectOk("Room added: model")
+
+        assertEquals(HttpStatusCode.BadRequest, fx.get("/filter?id=1001&kind=bogus&v=true").status)
+        assertEquals(HttpStatusCode.BadRequest, fx.get("/filter?id=1001&kind=public").status)
+        assertEquals(HttpStatusCode.BadRequest, fx.get("/filter?id=1001&kind=public&v=maybe").status)
+        assertEquals(HttpStatusCode.BadRequest, fx.get("/filter?kind=public&v=true").status)
+    }
+
+    @Test
+    fun `bootstrap reloads the room filters from list conf`() = withFixture { fx ->
+        fx.mock.addRoom(1001, "model", status = "off")
+        File(fx.listConfPath).writeText("#https://mock/model q:highest nopublic nofreespy\n")
+
+        fx.bootstrap()
+
+        val room = fx.rooms().single { it.id == 1001L }
+        assertFalse(room.recordPublic, "nopublic must turn public recording off")
+        assertFalse(room.recordFreeSpy, "nofreespy must turn free spy recording off")
     }
 
     @Test

--- a/src/test/kotlin/github/rikacelery/v3/integration/RoomRoutesIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/RoomRoutesIntegrationTest.kt
@@ -91,8 +91,8 @@ class RoomRoutesIntegrationTest {
         assertEquals(HttpStatusCode.BadRequest, fx.get("/quality").status)
         assertEquals(HttpStatusCode.BadRequest, fx.get("/limit").status)
         assertEquals(HttpStatusCode.BadRequest, fx.get("/sizelimit").status)
-        assertEquals(HttpStatusCode.BadRequest, fx.get("/autopay?id=1001").status)
-        assertEquals(HttpStatusCode.BadRequest, fx.get("/autopay?id=1001&v=true&kind=bogus").status)
+        assertEquals(HttpStatusCode.BadRequest, fx.get("/filter?id=1001&kind=public").status)
+        assertEquals(HttpStatusCode.BadRequest, fx.get("/filter?id=1001&kind=bogus&v=true").status)
     }
 
     @Test
@@ -199,6 +199,31 @@ class RoomRoutesIntegrationTest {
 
         val ready = fx.awaitEvent<FileReady>(20.seconds) { it.roomId == 1001L }
         assertEquals(EndReason.TimeLimit, ready.reason)
+    }
+
+    @Test
+    fun `a time limit changed while recording applies to the restarted session`() = withFixture { fx ->
+        fx.ready()
+        fx.mock.addRoom(1001, "model", status = "public")
+        fx.mock.startSegments(1001, 30.milliseconds)
+
+        fx.get("/add?name=model&limit=1").expectOk("Room added: model")
+        fx.get("/activate?id=1001").expectOk("Activated")
+        fx.awaitSession(1001, SessionState.Recording)
+        fx.awaitEvent<SegmentDownloaded>(15.seconds) { it.roomId == 1001L }
+
+        // lift the limit while the first session runs: the limit-driven restart must pick it up
+        fx.get("/limit?id=1001&v=0").expectOk("Time limit set to 0s")
+
+        fx.awaitEventCount<FileReady>(1, 20.seconds) { it.roomId == 1001L && it.reason == EndReason.TimeLimit }
+        delay(2_500)
+
+        assertEquals(
+            1,
+            fx.events.filterIsInstance<FileReady>()
+                .count { it.roomId == 1001L && it.reason == EndReason.TimeLimit },
+            "the restarted session must use the new limit instead of the stale one"
+        )
     }
 
     @Test
@@ -336,6 +361,19 @@ class RoomRoutesIntegrationTest {
         assertEquals(HttpStatusCode.BadRequest, fx.get("/filter?id=1001&kind=public").status)
         assertEquals(HttpStatusCode.BadRequest, fx.get("/filter?id=1001&kind=public&v=maybe").status)
         assertEquals(HttpStatusCode.BadRequest, fx.get("/filter?kind=public&v=true").status)
+    }
+
+    @Test
+    fun `list conf accepts a commented room with a space after the marker`() = withFixture { fx ->
+        fx.mock.addRoom(1001, "model", status = "off")
+        File(fx.listConfPath).writeText("# https://mock/model q:720p nopublic\n")
+
+        fx.bootstrap()
+
+        val room = fx.rooms().single { it.id == 1001L }
+        assertEquals("720p", room.quality)
+        assertFalse(room.recordPublic, "filters on a commented line are parsed too")
+        assertTrue(fx.sessions().isEmpty(), "a commented room must not be armed")
     }
 
     @Test


### PR DESCRIPTION
## Background

Implements (and closes) #130: a room was armed or not, and once armed the recorder decided what to
record from the room status alone — a public show was always recorded. This adds four per-room
recording filters, so a user who only wants spy/private material can say so, and folds the growing
per-room control surface into one place in the dashboard.

## The four filters

| switch | meaning | default |
|---|---|---|
| `recordPublic` | record public (free) shows | on |
| `recordFreeSpy` | a free-spy privilege counts as a reason to record a private show | on |
| `autoPayTicket` | buy a ticket to record a group show | off |
| `autoPaySpy` | spend tokens to record a private show | off |

`canRecord` is still the single gate:

```kotlin
RoomStatus.isPublic(status)    -> settings.recordPublic
RoomStatus.isGroupShow(status) -> settings.autoPayTicket
RoomStatus.isPrivate(status)   -> settings.autoPaySpy || (settings.recordFreeSpy && !freeSpyExhausted)
```

`recordFreeSpy` does not reorder token acquisition: the private path still tries the free privilege
first and only then pays, so switching the flag off never makes a room spend tokens it did not spend
before. Defaults keep every existing `list.conf` line behaving as before except one deliberate change
(below).

## How a switch reaches a room that is already running

An armed room refreshed its own copy of the settings only through a preconfig attempt — and a room
that is no longer recordable never makes one — so `canRecord` could not simply start reading a new
flag: a room switched off in the UI would never switch back on.

`RoomComponent` now publishes `RoomSettingsChanged(roomId, settings, status)` for every setting it
changes, and the scheduler mirrors it and drives a new `SchedulerEvent.SettingsChanged`, defined in
all four states:

| state | condition | action |
|---|---|---|
| Armed | recordable again | begin preconfig |
| Preconfiguring | no longer recordable | back to Armed (stops the retry loop) |
| Recording | no longer recordable | stop, cut the file as `StatusChanged` |
| Stopping | — | the restart guard decides |

The limit-driven restart (`EndReason.TimeLimit` / `SizeLimit`) is now guarded by `canRecord`, in both
`Recording` and `Stopping`: without it, a limit that expired while a room was being switched off
would start a fresh recording nobody asked for.

## Free spy without hammering the platform

The privilege belongs to the account, not to the show, so it is probed once per private episode: a
`TokenFailure.NoFreeSpy` result sets `freeSpyExhausted`, the FSM returns to Armed, and the preconfig
loop stops asking. The flag is re-armed whenever the room leaves the private status or the user flips
a switch. Decisions read a typed `TokenFailure`; `lastFailReason` stays a log/hint string and is never
parsed.

## Persistence and HTTP

- `list.conf` gains opt-out tokens, written only when a filter is off: `nopublic`, `nofreespy`.
- `GET /filter?id=&kind=public|freespy|ticket|paidspy&v=` replaces the old `/autopay` route, which
  nothing but its own tests called; `/autopay` and `AutoPayKind` are gone.
- `/dashboard` carries the two flags per room plus a new `hint` explaining an armed room that is not
  recording: `public_filter_off`, `ticket_purchase_off`, `private_filter_off`, `no_free_spy`, or
  `preconfig_failed` with the raw platform reason as `detail`. `SchedulerEntry.hint()` answers
  `GetRecordingHints` for the whole scheduler in one request; recording rooms stay silent.

## Dashboard

- The `Auto Pay` column becomes a read-only `P·F·T·S` summary (clicking it opens the dialog).
- One per-room settings dialog holds all four switches, each with a tooltip stating who pays, plus
  the time and size limits that used to live in the table cells.
- The room row shows the hint in amber under its status, with the full text as a tooltip.

## Fixed along the way

Three pre-existing defects surfaced while testing this change:

1. A commented `list.conf` line **with a space** after the marker (`# https://…`, the spelling the
   docs show) was read with `#` as its URL, so the room was silently dropped at startup; only the
   writer's `#https://…` form worked. Both parse now.
2. Changing a time/size limit in the dashboard did not reach an armed room, because
   `RoomTimeLimitChanged` / `RoomSizeLimitChanged` were published but never subscribed — and were
   removed in favour of the `RoomSettingsChanged` snapshot. A limit-driven restart now re-cuts with
   the new limit instead of the stale one.
3. The settings dialog pre-filled the size limit with `formatBytes` output (`1.50 GB`), which
   `/sizelimit` rejects; it now pre-fills an exact token (`1Gi`, `1536Mi`, or raw bytes).

## Behaviour change to note

`recordFreeSpy` defaults to on: a room with `autoPaySpy = false` that has a free-spy privilege will
now record private shows it previously ignored, at the cost of one privilege probe per private
episode. README (both languages) documents the tokens, the defaults and the new route.

## Tests

258 tests pass locally (`./gradlew test`), each behaviour written test-first and watched failing:
the public filter (404 on `/filter`), the runtime toggle (timed out waiting for a session), turning
the filter off mid-recording, the free-spy path (no session), the probe throttle (16 probes in 2s),
the episode reset, the list.conf round-trip, the limit-change restart (3 cuts instead of 1). The
restart guard has a state-machine test that fails without it (`expected Armed but was Recording`).

The dashboard was also checked visually: the page was rendered with a stub `/dashboard` payload in
headless Chromium and the screenshots read back by a vision model — dialog, badges and hints verified
in both `en` and `zh-CN` (four of five fixture rooms annotated, correct text per code, no clipping;
one real fix came out of it: the hint colour was below the WCAG AA contrast ratio).

## Out of scope

- The broader filter idea sketched in #130 (by datetime, viewers, model goal progress, Lovense
  events) — a different order of magnitude, needing data this change does not collect.
- A global default with per-room overrides.
- Restarting a running session when a limit changes: limits apply from the next session.
