### PR TITLE
fix: keep an armed room retrying instead of stalling silently

### DIFF
--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -39,7 +39,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.JsonObject
 import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
@@ -448,14 +448,22 @@ class SchedulerEntry(
         return CdnSelector.resolve(url)
     }
 
-    /** Verify the resolved variant playlist is actually fetchable before handing it to the Session. */
+    /**
+     * Verify the resolved variant playlist is actually fetchable before handing it to the Session.
+     *
+     * A probe that outlives the watchdog is a *failed probe*, not a cancellation of the caller:
+     * [withTimeoutOrNull] consumes the timeout so the answer stays `false` and the preconfig loop
+     * can retry. Letting the timeout escape as a `CancellationException` (which the catch below
+     * rethrows, as [SchedulerEntry.preconfigSignal] does) silently cancelled that loop, leaving
+     * the room stuck in `Preconfiguring` with no log, no hint and no retry.
+     */
     private suspend fun playlistUsable(url: String): Boolean {
         return try {
-            withTimeout(5.seconds) {
+            withTimeoutOrNull(component.runtimeTuning.preconfigProbeTimeout) {
                 val client = component.httpClientProvider.proxied("preconfig_$roomId")
                 val response = withRetry(2) { client.get(url) }
                 response.status.value in 200..299
-            }
+            } ?: false
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -491,6 +499,12 @@ private fun buildSchedulerFsm(ctx: SchedulerEntry) =
             on(SchedulerEvent.RestartRecording) to KEEP
             on(SchedulerEvent.BackToArmed) to KEEP
             on(SchedulerEvent.StopAndWait) to KEEP
+            // A preconfig attempt runs off the actor loop, so its answer can already be in the
+            // mailbox when BackToArmed cancels the loop. The room is armed because it is no longer
+            // recordable (or was restarted), so the late answer is dropped instead of being an
+            // illegal transition.
+            on(SchedulerEvent.PreconfigDone) to KEEP
+            on(SchedulerEvent.PreconfigFailed) to KEEP
             on(SchedulerEvent.SettingsChanged) to KEEP action { d ->
                 val st = d?.roomStatus ?: return@action
                 roomStatus = st
@@ -555,6 +569,11 @@ private fun buildSchedulerFsm(ctx: SchedulerEntry) =
             on(SchedulerEvent.BackToArmed) to SchedulerState.Armed action { stopPreconfigLoop() }
             on(SchedulerEvent.RestartRecording) to KEEP
             on(SchedulerEvent.StopAndWait) to KEEP
+            // No session of this entry is running yet — recording only starts on PreconfigDone — so
+            // an exit surfacing here belongs to an earlier incarnation of the room (the session the
+            // dashboard stopped before re-activating it). It carries nothing to act on, and taking
+            // its lastIndex would restart the next recording at the wrong segment.
+            on(SchedulerEvent.SessionExit) to KEEP
             on(SchedulerEvent.SettingsChanged) to KEEP action { d ->
                 if (d?.roomStatus != null) roomStatus = d.roomStatus
                 if (!canRecord(roomStatus)) self(SchedulerEvent.BackToArmed)

--- a/src/main/kotlin/github/rikacelery/v3/core/Actor.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/Actor.kt
@@ -3,7 +3,11 @@ package github.rikacelery.v3.core
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.reflect.KClass
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 abstract class Actor<T : Any>(
     val name: String,
@@ -26,12 +30,40 @@ abstract class Actor<T : Any>(
 
     private var started = false
 
+    // —— Subscription readiness ——
+    // `start()` only launches the loop: the bus subscriptions registered in `onStart` attach to the
+    // shared flow a moment later, and the bus drops events for subscribers that have not attached
+    // yet. Callers that publish right after starting a component (the test fixture does, the UI
+    // routes do once the server is up) can await this instead of racing with it.
+    private val subscriptionsRegistered = AtomicInteger(0)
+    private val subscriptionsAttached = AtomicInteger(0)
+    private val startCompleted = AtomicBoolean(false)
+    private val subscriptionsReady = CompletableDeferred<Unit>()
+
+    private fun signalSubscriptionsReady() {
+        if (startCompleted.get() && subscriptionsAttached.get() >= subscriptionsRegistered.get()) {
+            subscriptionsReady.complete(Unit)
+        }
+    }
+
+    /**
+     * Suspends until [onStart] has returned and every subscription it registered has attached to
+     * the bus, so an event published after this returns cannot be missed. Returns false when the
+     * subscriptions are still not attached after [timeout].
+     */
+    suspend fun awaitSubscribed(timeout: Duration = 10.seconds): Boolean {
+        signalSubscriptionsReady()
+        return withTimeoutOrNull(timeout) { subscriptionsReady.await() } != null
+    }
+
     fun start() {
         check(!started) { "$name already started" }
         started = true
 
         scope.launch {
             onStart(scope)
+            startCompleted.set(true)
+            signalSubscriptionsReady()
             for (msg in mailbox) {
                 try {
                     val start = System.nanoTime()
@@ -63,7 +95,15 @@ abstract class Actor<T : Any>(
     }
 
     protected suspend fun <E : Any> subscribe(kClass: KClass<E>) {
-        eventBus.subscribe(scope, kClass) { event ->
+        subscriptionsRegistered.incrementAndGet()
+        eventBus.subscribe(
+            scope = scope,
+            eventType = kClass,
+            onAttached = {
+                subscriptionsAttached.incrementAndGet()
+                signalSubscriptionsReady()
+            }
+        ) { event ->
             wrapEvent(event)?.let { mailbox.send(it) }
         }
     }

--- a/src/main/kotlin/github/rikacelery/v3/core/EventBus.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/EventBus.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
 import kotlin.reflect.KClass
@@ -95,13 +96,25 @@ class EventBus {
         }
     }
 
+    /**
+     * Collects [eventType] on [scope] and feeds every value to [handler].
+     *
+     * The collector attaches to the shared flow asynchronously, and the flow does not replay, so
+     * anything published before the attach is missed by this subscriber. [onAttached] fires once
+     * the subscription is live, which lets a caller wait for it (see `Actor.awaitSubscribed`).
+     */
     fun <E : Any> subscribe(
         scope: CoroutineScope,
         eventType: KClass<E>,
+        onAttached: (() -> Unit)? = null,
         handler: suspend (E) -> Unit
     ) {
         scope.launch {
-            events.filterIsInstance(eventType).collect { handler(it) }
+            // onSubscription fires once the subscription is registered on the shared flow, which is
+            // the moment from which this collector can no longer miss an emission.
+            events.onSubscription { onAttached?.invoke() }
+                .filterIsInstance(eventType)
+                .collect { handler(it) }
         }
     }
 }

--- a/src/main/kotlin/github/rikacelery/v3/core/RequestBus.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/RequestBus.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.*
 import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 class RequestTimeoutException(cmd: Request, timeoutMs: Long) :
     RuntimeException("Request $cmd timed out after ${timeoutMs}ms")
@@ -24,11 +26,19 @@ class RequestBus(
     private val idGen = AtomicLong(0)
     private val logger = LoggerFactory.getLogger("v3.RequestBus")
 
+    // The ack collector attaches asynchronously and the bus does not replay, so a caller that can
+    // race with startup should await this before issuing its first request.
+    private val ackAttached = CompletableDeferred<Unit>()
+
     init {
-        eventBus.subscribe(scope, CommandAck::class) { ack ->
+        eventBus.subscribe(scope, CommandAck::class, onAttached = { ackAttached.complete(Unit) }) { ack ->
             pending.remove(ack.requestId)?.complete(ack.body)
         }
     }
+
+    /** Suspends until this bus is collecting [CommandAck]s, so no reply can be missed. */
+    suspend fun awaitSubscribed(timeout: Duration = 10.seconds): Boolean =
+        withTimeoutOrNull(timeout) { ackAttached.await() } != null
 
     @Suppress("UNCHECKED_CAST")
     suspend fun <T> request(cmd: Request, timeoutMs: Long = defaultTimeoutMs): T {

--- a/src/main/kotlin/github/rikacelery/v3/data/RuntimeTuning.kt
+++ b/src/main/kotlin/github/rikacelery/v3/data/RuntimeTuning.kt
@@ -11,6 +11,8 @@ data class RuntimeTuning(
     val webSocketReconnectInitial: Duration = 1.seconds,
     val webSocketReconnectMax: Duration = 30.seconds,
     val preconfigRetryInterval: Duration = 15.seconds,
+    /** Watchdog for the "is the selected variant playlist fetchable?" probe of a preconfig attempt. */
+    val preconfigProbeTimeout: Duration = 5.seconds,
     val playlistPollInterval: Duration = 3.seconds,
     val playlistFetchTimeout: Duration = 10.seconds,
     val httpRestartDelay: Duration = 500.milliseconds,

--- a/src/test/kotlin/github/rikacelery/v3/components/SchedulerPreconfigProbeTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/SchedulerPreconfigProbeTest.kt
@@ -1,0 +1,288 @@
+package github.rikacelery.v3.components
+
+import github.rikacelery.v3.api.ApiClient
+import github.rikacelery.v3.core.DataChannel
+import github.rikacelery.v3.core.EventBus
+import github.rikacelery.v3.core.RequestBus
+import github.rikacelery.v3.data.RoomSettings
+import github.rikacelery.v3.data.RuntimeTuning
+import github.rikacelery.v3.events.CommandAck
+import github.rikacelery.v3.events.CommandEnvelope
+import github.rikacelery.v3.events.ConfigResponse
+import github.rikacelery.v3.events.DecryptKeyMatch
+import github.rikacelery.v3.events.GetDecryptKey
+import github.rikacelery.v3.events.GetRoomConfig
+import github.rikacelery.v3.events.MatchDecryptKeys
+import github.rikacelery.v3.events.RoomConfigResponse
+import github.rikacelery.v3.hooks.EventHook
+import github.rikacelery.v3.m3u8.M3u8Parser
+import github.rikacelery.v3.utils.CdnSelector
+import github.rikacelery.v3.utils.HttpClientProvider
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.headersOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.jupiter.api.Test
+import java.net.ServerSocket
+import java.net.Socket
+import java.util.Collections
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Regression guard: the probe of the selected variant playlist runs under a watchdog. A probe
+ * that outlives it is a *failed probe*, not a cancellation of its caller — the room has to stay
+ * in `Preconfiguring` and retry on the next tick.
+ *
+ * When the watchdog result escaped as a `CancellationException` ([SchedulerEntry.preconfigSignal]
+ * rethrows it) the preconfig loop cancelled itself silently: no `Preconfig failed` log, no
+ * dashboard hint, no retry. A room whose CDN path stalls once therefore stayed armed forever
+ * while the dashboard kept showing it as merely "listening".
+ */
+class SchedulerPreconfigProbeTest {
+
+    @Test
+    fun `a playlist probe that outlives its watchdog is retried instead of killing the preconfig loop`() =
+        runBlocking {
+            val probes = AtomicInteger()
+            val client = HttpClient(MockEngine { request ->
+                val url = request.url.toString()
+                when {
+                    url.endsWith("/api/front/v1/broadcasts/model") ->
+                        respond("""{"item":{"status":"public"}}""", headers = jsonHeaders)
+
+                    request.url.encodedPath.startsWith("/master/") -> respond(masterPlaylist)
+
+                    request.url.encodedPath == "/media/model.m3u8" -> {
+                        // the first probe stalls far past the watchdog; every later probe answers
+                        if (probes.getAndIncrement() == 0) delay(30.seconds)
+                        respond("#EXTM3U")
+                    }
+
+                    else -> error("unexpected request $url")
+                }
+            }) { expectSuccess = true }
+            val provider = SingleClientProvider(client)
+            val eventBus = EventBus()
+            installRequestAnswers(eventBus)
+            val testScope = CoroutineScope(coroutineContext + SupervisorJob())
+            val requestBus = RequestBus(eventBus, testScope)
+            val dataChannel = DataChannel()
+            val downloader = DownloaderComponent(dataChannel, eventBus = eventBus, parentScope = testScope)
+            val session = SessionComponent(dataChannel, downloader, M3u8Parser, requestBus, eventBus, testScope)
+            val scheduler = SchedulerComponent(
+                requestBus = requestBus,
+                sessionComponent = session,
+                apiClient = ApiClient(listOf("ignored.invalid"), provider) { "http://127.0.0.1:18082" },
+                streamAuthKey = "stream-key",
+                eventBus = eventBus,
+                parentScope = testScope,
+                httpClientProvider = provider,
+                runtimeTuning = RuntimeTuning(
+                    preconfigRetryInterval = 150.milliseconds,
+                    preconfigProbeTimeout = 200.milliseconds
+                ),
+                masterUrlCandidates = { roomId, pkey, _ ->
+                    listOf("http://127.0.0.1:18082/master/$roomId?pkey=$pkey")
+                }
+            )
+            val oldCdnHosts = CdnSelector.hosts
+            CdnSelector.updateHosts(emptyList())
+
+            try {
+                scheduler.start()
+                val entry = scheduler.internalAdd(7, "model", RoomSettings(pkey = "room-key"), isArmed = true)!!
+                scheduler.tell(
+                    SchedulerSignal(7, SchedulerEvent.RoomStatusChanged, SchedulerDriveData(roomStatus = "public"))
+                )
+
+                val retried = withTimeoutOrNull(5.seconds) {
+                    while (probes.get() < 2) delay(20.milliseconds)
+                    true
+                }
+
+                assertEquals(
+                    true,
+                    retried,
+                    "the preconfig loop must survive a probe that outlives its watchdog (probes=${probes.get()}, " +
+                            "state=${entry.fsm.currentState})"
+                )
+                assertEquals(
+                    SchedulerState.Recording,
+                    entry.fsm.currentState,
+                    "the retried probe succeeds, so the room must go on to record"
+                )
+            } finally {
+                scheduler.stop()
+                CdnSelector.updateHosts(oldCdnHosts)
+                testScope.cancel()
+                client.close()
+            }
+        }
+
+    /**
+     * The other half of the same question: a *client* timeout (Ktor/OkHttp giving up on its own
+     * request budget) is an `IOException` — `HttpRequestTimeoutException` — not a cancellation, so
+     * it already lands in the `catch (e: Exception) -> false` branch. This guards that end to end
+     * against a real engine and a real socket that accepts but never answers.
+     */
+    @Test
+    fun `a client request timeout is a failed probe, not a cancellation of the preconfig loop`() = runBlocking {
+        val silent = ServerSocket(0)
+        val connections = AtomicInteger()
+        val held = Collections.synchronizedList(mutableListOf<Socket>())
+        val acceptor = thread(isDaemon = true, name = "silent-playlist") {
+            while (!silent.isClosed) {
+                val socket = try {
+                    silent.accept()
+                } catch (e: Exception) {
+                    break
+                }
+                if (connections.getAndIncrement() < 2) {
+                    // accepted but never answered: each of these two probes ends in a client timeout
+                    held += socket
+                } else {
+                    runCatching {
+                        socket.getOutputStream().write(
+                            "HTTP/1.1 200 OK\r\nContent-Length: 7\r\nConnection: close\r\n\r\n#EXTM3U".toByteArray()
+                        )
+                        socket.getOutputStream().flush()
+                    }
+                    runCatching { socket.close() }
+                }
+            }
+            held.forEach { runCatching { it.close() } }
+        }
+
+        val variantUrl = "http://127.0.0.1:${silent.localPort}/media/model.m3u8"
+        val timeoutClient = HttpClient(OkHttp) {
+            install(HttpTimeout) {
+                requestTimeoutMillis = 200
+                socketTimeoutMillis = 200
+                connectTimeoutMillis = 500
+            }
+        }
+        val mockClient = HttpClient(MockEngine { request ->
+            val url = request.url.toString()
+            when {
+                url.endsWith("/api/front/v1/broadcasts/model") ->
+                    respond("""{"item":{"status":"public"}}""", headers = jsonHeaders)
+
+                request.url.encodedPath.startsWith("/master/") -> respond(masterPlaylistWith(variantUrl))
+
+                else -> error("unexpected request $url")
+            }
+        }) { expectSuccess = true }
+        val provider = PreconfigClientProvider(timeoutClient, mockClient)
+        val eventBus = EventBus()
+        installRequestAnswers(eventBus)
+        val testScope = CoroutineScope(coroutineContext + SupervisorJob())
+        val requestBus = RequestBus(eventBus, testScope)
+        val dataChannel = DataChannel()
+        val downloader = DownloaderComponent(dataChannel, eventBus = eventBus, parentScope = testScope)
+        val session = SessionComponent(dataChannel, downloader, M3u8Parser, requestBus, eventBus, testScope)
+        val scheduler = SchedulerComponent(
+            requestBus = requestBus,
+            sessionComponent = session,
+            apiClient = ApiClient(listOf("ignored.invalid"), provider) { "http://127.0.0.1:18082" },
+            streamAuthKey = "stream-key",
+            eventBus = eventBus,
+            parentScope = testScope,
+            httpClientProvider = provider,
+            runtimeTuning = RuntimeTuning(
+                preconfigRetryInterval = 150.milliseconds,
+                // far beyond the client's own budget: the client timeout is the one that fires
+                preconfigProbeTimeout = 10.seconds
+            ),
+            masterUrlCandidates = { roomId, pkey, _ ->
+                listOf("http://127.0.0.1:18082/master/$roomId?pkey=$pkey")
+            }
+        )
+        val oldCdnHosts = CdnSelector.hosts
+        CdnSelector.updateHosts(emptyList())
+
+        try {
+            scheduler.start()
+            val entry = scheduler.internalAdd(7, "model", RoomSettings(pkey = "room-key"), isArmed = true)!!
+            scheduler.tell(
+                SchedulerSignal(7, SchedulerEvent.RoomStatusChanged, SchedulerDriveData(roomStatus = "public"))
+            )
+
+            withTimeoutOrNull(10.seconds) {
+                while (entry.fsm.currentState != SchedulerState.Recording) delay(20.milliseconds)
+            }
+
+            assertEquals(
+                SchedulerState.Recording,
+                entry.fsm.currentState,
+                "a client request timeout is a failed probe: the loop must retry and then record " +
+                        "(connections=${connections.get()})"
+            )
+        } finally {
+            scheduler.stop()
+            CdnSelector.updateHosts(oldCdnHosts)
+            testScope.cancel()
+            timeoutClient.close()
+            mockClient.close()
+            silent.close()
+        }
+    }
+
+    private fun installRequestAnswers(eventBus: EventBus) {
+        eventBus.installHook(object : EventHook {
+            override suspend fun intercept(event: Any): Any? {
+                if (event is CommandEnvelope) {
+                    val answer = when (event.command) {
+                        is GetRoomConfig -> RoomConfigResponse(RoomSettings(pkey = "room-key"))
+                        is MatchDecryptKeys -> DecryptKeyMatch("key-id", "decrypt-key")
+                        is GetDecryptKey -> ConfigResponse("decrypt-key")
+                        else -> null
+                    }
+                    if (answer != null) eventBus.publish(CommandAck(event.id, answer))
+                }
+                return event
+            }
+        })
+    }
+
+    private class SingleClientProvider(private val client: HttpClient) : HttpClientProvider {
+        override fun direct(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient = client
+        override fun proxied(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient = client
+    }
+
+    /** Real engine for the playlist probe, mock engine for everything else. */
+    private class PreconfigClientProvider(
+        private val preconfigClient: HttpClient,
+        private val otherClient: HttpClient
+    ) : HttpClientProvider {
+        override fun direct(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient = otherClient
+        override fun proxied(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient =
+            if (key.startsWith("preconfig_")) preconfigClient else otherClient
+    }
+
+    private companion object {
+        val jsonHeaders = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+
+        fun masterPlaylistWith(variantUrl: String) = """
+            #EXTM3U
+            #EXT-X-MOUFLON:PSCH:key-id
+            #EXT-X-STREAM-INF:BANDWIDTH=1000,RESOLUTION=640x360,FRAME-RATE=30
+            $variantUrl
+        """.trimIndent()
+
+        val masterPlaylist = masterPlaylistWith("http://127.0.0.1:18082/media/model.m3u8")
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/components/SchedulerPreconfigProbeTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/SchedulerPreconfigProbeTest.kt
@@ -120,10 +120,18 @@ class SchedulerPreconfigProbeTest {
                     "the preconfig loop must survive a probe that outlives its watchdog (probes=${probes.get()}, " +
                             "state=${entry.fsm.currentState})"
                 )
+
+                // the retried probe reaches the room through the actor mailbox, so wait for the
+                // transition instead of assuming it already happened when the request was made
+                val recorded = withTimeoutOrNull(5.seconds) {
+                    while (entry.fsm.currentState != SchedulerState.Recording) delay(20.milliseconds)
+                    true
+                }
                 assertEquals(
-                    SchedulerState.Recording,
-                    entry.fsm.currentState,
-                    "the retried probe succeeds, so the room must go on to record"
+                    true,
+                    recorded,
+                    "the retried probe succeeds, so the room must go on to record " +
+                            "(probes=${probes.get()}, state=${entry.fsm.currentState})"
                 )
             } finally {
                 scheduler.stop()

--- a/src/test/kotlin/github/rikacelery/v3/components/SchedulerStaleEventTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/SchedulerStaleEventTest.kt
@@ -1,0 +1,108 @@
+package github.rikacelery.v3.components
+
+import github.rikacelery.v3.api.ApiClient
+import github.rikacelery.v3.core.DataChannel
+import github.rikacelery.v3.core.EventBus
+import github.rikacelery.v3.core.RequestBus
+import github.rikacelery.v3.data.RoomSettings
+import github.rikacelery.v3.data.RuntimeTuning
+import github.rikacelery.v3.events.EndReason
+import github.rikacelery.v3.m3u8.M3u8Parser
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.hours
+
+/**
+ * The scheduler FSM is deliberately exhaustive: an undefined (state, event) pair is a bug and is
+ * reported as an ILLEGAL TRANSITION with a transition dump. Two pairs were reachable in normal use,
+ * and each one spammed that dump instead of being handled:
+ *
+ *  - `Preconfiguring` + `SessionExit` — a session publishes its exit from `RecordingState.Closing`,
+ *    which is only reached asynchronously after `StopRecording`. Stopping a room (or removing it)
+ *    and then re-activating it therefore lets that stale exit land once the room is preconfiguring
+ *    again.
+ *  - `Armed` + `PreconfigDone`/`PreconfigFailed` — a preconfig attempt is answered off the actor
+ *    loop, so its signal can already be queued when `BackToArmed` cancels the loop.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SchedulerStaleEventTest {
+
+    @Test
+    fun `a session exit that lands while preconfiguring is ignored`() = runTest(UnconfinedTestDispatcher()) {
+        val entry = newEntry(backgroundScope)
+        try {
+            entry.fsm.drive(SchedulerEvent.BeginPreconfig)
+            entry.preconfigLoop.cancel() // this test exercises the transition, not the probe itself
+            assertEquals(SchedulerState.Preconfiguring, entry.fsm.currentState)
+
+            assertNull(
+                entry.fsm.driveCatch(
+                    SchedulerEvent.SessionExit,
+                    SchedulerDriveData(exitReason = EndReason.UserStop)
+                ),
+                "the exit of the session that was stopped before re-activating the room must be ignored"
+            )
+            assertEquals(
+                SchedulerState.Preconfiguring,
+                entry.fsm.currentState,
+                "a stale exit must not disturb the preconfig attempt in flight"
+            )
+        } finally {
+            entry.scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a preconfig answer that arrives after the loop was cancelled is ignored while armed`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val entry = newEntry(backgroundScope)
+            try {
+                entry.fsm.drive(SchedulerEvent.BeginPreconfig)
+                entry.fsm.drive(SchedulerEvent.BackToArmed) // the room stopped being recordable
+                assertEquals(SchedulerState.Armed, entry.fsm.currentState)
+
+                assertNull(
+                    entry.fsm.driveCatch(
+                        SchedulerEvent.PreconfigDone,
+                        SchedulerDriveData(playlistUrl = "http://127.0.0.1:1/live.m3u8")
+                    ),
+                    "a preconfig answer already in flight when the loop was cancelled must be ignored"
+                )
+                assertNull(
+                    entry.fsm.driveCatch(
+                        SchedulerEvent.PreconfigFailed,
+                        SchedulerDriveData(failReason = "late")
+                    ),
+                    "a late preconfig failure must be ignored"
+                )
+                assertEquals(SchedulerState.Armed, entry.fsm.currentState)
+            } finally {
+                entry.scope.cancel()
+            }
+        }
+
+    private fun newEntry(scope: CoroutineScope): SchedulerEntry {
+        val eventBus = EventBus()
+        val requestBus = RequestBus(eventBus, scope)
+        val dataChannel = DataChannel()
+        val downloader = DownloaderComponent(dataChannel, eventBus = eventBus, parentScope = scope)
+        val session = SessionComponent(dataChannel, downloader, M3u8Parser, requestBus, eventBus, scope)
+        val scheduler = SchedulerComponent(
+            requestBus,
+            session,
+            // a dead loopback host: no component in this test reaches the network
+            ApiClient(listOf("127.0.0.1:1")),
+            "streamKey",
+            eventBus,
+            scope,
+            runtimeTuning = RuntimeTuning(preconfigRetryInterval = 1.hours)
+        )
+        return SchedulerEntry(7, "model", scheduler).apply { settings = RoomSettings(pkey = "room-key") }
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/core/ActorTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/core/ActorTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.reflect.KClass
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -127,4 +128,55 @@ class ActorTest {
         assertEquals(listOf("a1", "a2"), a.handled)
         assertEquals(listOf("b1", "b2"), b.handled)
     }
+
+    /**
+     * `start()` only launches the loop; the bus subscriptions registered in `onStart` attach a
+     * moment later, and the bus does not replay, so an event published in that window is dropped
+     * without a trace — a command published right after startup never gets its ack and the route
+     * waits for it until it times out. `awaitSubscribed()` is the barrier that closes that window.
+     */
+    @Test
+    fun `awaitSubscribed closes the window in which published events are dropped`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val bus = EventBus()
+            val actor = SubscribingActor("subscribing", bus, this)
+            actor.start()
+
+            assertTrue(actor.awaitSubscribed(), "the actor must report its subscriptions as attached")
+
+            bus.publish("first")
+            bus.publish("second")
+            actor.stop()
+
+            assertEquals(listOf("first", "second"), actor.seen)
+        }
+
+    @Test
+    fun `awaitSubscribed reports ready for an actor that subscribes to nothing`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val actor = TestActor("silent", EventBus(), this)
+            actor.start()
+            assertTrue(actor.awaitSubscribed())
+            actor.stop()
+        }
+}
+
+/** Subscribes to [String] events from `onStart`, so readiness covers a real subscription. */
+class SubscribingActor(
+    name: String,
+    eventBus: EventBus,
+    parentScope: CoroutineScope
+) : Actor<String>(name, eventBus, parentScope) {
+
+    val seen = CopyOnWriteArrayList<String>()
+
+    override suspend fun onStart(scope: CoroutineScope) {
+        subscribe(String::class)
+    }
+
+    override suspend fun handle(msg: String) {
+        seen += msg
+    }
+
+    override suspend fun wrapEvent(event: Any): String? = event as? String
 }

--- a/src/test/kotlin/github/rikacelery/v3/integration/XhrecIntegrationFixture.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/XhrecIntegrationFixture.kt
@@ -15,6 +15,7 @@ import github.rikacelery.v3.components.SchedulerComponent
 import github.rikacelery.v3.components.SessionComponent
 import github.rikacelery.v3.components.SessionState
 import github.rikacelery.v3.components.WriterComponent
+import github.rikacelery.v3.core.Actor
 import github.rikacelery.v3.core.DataChannel
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
@@ -139,7 +140,15 @@ class XhrecIntegrationFixture(
         listOf(url)
     }
 
-    fun start() {
+    /**
+     * Starts every component and waits until they are attached to the bus.
+     *
+     * `Actor.start()` only launches the message loop; the bus subscriptions attach a moment later,
+     * and the bus does not replay, so a command published before that attach is dropped in silence
+     * — the route then waits for its ack until it times out. Tests issue `/add` immediately after
+     * startup, so the wait belongs here rather than in each test.
+     */
+    suspend fun start() {
         eventBus.installHook(object : EventHook {
             override suspend fun intercept(event: Any): Any? {
                 events += event
@@ -243,6 +252,23 @@ class XhrecIntegrationFixture(
         writerComponent.start()
         sessionComponent.start()
         schedulerComponent.start()
+
+        val components: List<Pair<String, Actor<*>>> = listOf(
+            "config" to configComponent,
+            "auth" to authComponent,
+            "metric" to metricComponent,
+            "postProcessor" to postProcessorComponent,
+            "room" to roomComponent,
+            "liveEventSource" to liveEventSource,
+            "downloader" to downloaderComponent,
+            "writer" to writerComponent,
+            "session" to sessionComponent,
+            "scheduler" to schedulerComponent
+        )
+        components.forEach { (label, component) ->
+            check(component.awaitSubscribed()) { "$label did not subscribe to the event bus" }
+        }
+        check(requestBus.awaitSubscribed()) { "request bus did not subscribe to command acks" }
     }
 
     /** Marks the room list ready and loads one payable account for group/private flows. */


### PR DESCRIPTION
## 现象

一个已激活的房间可以永远停在仪表盘的 `listening`，同时平台侧状态是 `public`、`recordPublic=true`，而且**不显示任何原因**（没有 hint）。日志里既没有 `Preconfig failed`，也没有任何重试。

## 根因

`SchedulerEntry.playlistUsable()` 用 5s 看门狗探一次选定的变体播放列表。看门狗超时抛出的 `TimeoutCancellationException` 属于 `CancellationException`，被 `catch (e: CancellationException) { throw e }` 原样上抛，一路传到 `LoopTimer` 的协程里 —— **把预配置重试循环自己取消了**。于是：没有失败信号（`lastFailReason` 恒为 null，`hint()` 返回 null）、没有日志、没有重试；只有重启进程或手动重新激活能再换来（最多）一次尝试。

CDN 路径一旦慢过 5s 预算，**每次激活都会这样**，房间就再也录不上。这也解释了远程日志里 `master_` / `preconfig_` client 建好之后一片空白、以及满屏 `stall: no response within 5000ms` 的现象。

## 改动

**1. 探针看门狗**

- `playlistUsable` 改用 `withTimeoutOrNull`：超预算的探针 = 一次失败的探针，循环继续按 `preconfigRetryInterval` 重试；真正的作用域取消照旧上抛。
- 预算移到 `RuntimeTuning.preconfigProbeTimeout`（默认仍是 5s），便于测试注入。
- 顺带确认：Ktor/OkHttp 的**客户端请求超时**是 `HttpRequestTimeoutException`（`extends IOException`），本来就走 `catch (e: Exception) -> false`，不受此 bug 影响 —— 已用真实引擎 + 静默 socket 加了守卫测试。

**2. FSM 缺格**

本地复现「deactivate → activate → remove → add+activate」时，状态机还会刷两处可达的未定义转移（每次都 dump 一整屏 transition history）：

- `Preconfiguring` + `SessionExit`：会话的 exit 是在 `RecordingState.Closing` 收到 `CutPointDone` 后才**异步**发出的，所以「停录/移除 → 重新激活」会让上一场会话的 exit 落在已经重新预配置的房间上。语义是**忽略**，并且刻意**不取它的 `lastIndex`**（陈旧值会把下次录制的续录位置搞错）。
- `Armed` + `PreconfigDone`/`PreconfigFailed`：预配置脱离 actor 循环执行，`BackToArmed` 取消循环时结果信号可能已在信箱里排队。房间处于 Armed 是因为它已不可录，迟到的答案应当丢弃。

两处都与修复前的**状态结果完全一致**，区别只是不再抛异常、不再刷错误横幅。

## 测试

- `SchedulerPreconfigProbeTest`（新增）
  - 看门狗超时后必须重试并进入 `Recording` —— **修复前失败**（`probes=1, state=Preconfiguring`）
  - 真实 OkHttp 请求超时不是取消，循环必须存活 —— 修复前后均通过（守住边界）
- `SchedulerStaleEventTest`（新增）
  - 两个陈旧事件组合都必须被忽略 —— **修复前两者都以 `FsmException$IllegalTransition` 失败**

FSM 矩阵已用脚本校验：4 个状态 × 11 个事件全部有定义。

全量：`./gradlew cleanTest test` → **262 项通过**。

## 手工验证

重建 jar 后本地 server 跑原始触发序列 `deactivate → activate → remove → add?active=true`：

- 修复前：必现 `FSM ILLEGAL TRANSITION: No transition defined for state [Preconfiguring] event [SessionExit]`
- 修复后：ILLEGAL TRANSITION 计数 **0**，房间约 10s 后重新落盘录制

远程服务器未做任何改动。
