### PR TITLE
Move p2p from PRIVATE_VARIANTS to RTC_SHOW

### DIFF
--- a/src/main/kotlin/github/rikacelery/v3/data/RoomStatus.kt
+++ b/src/main/kotlin/github/rikacelery/v3/data/RoomStatus.kt
@@ -1,24 +1,27 @@
 package github.rikacelery.v3.data
 
 /**
- * Room status classification. The platform uses several variants for paid shows
- * (private / p2p / virtualPrivate / ...) and the list can grow, so anything that is
- * not public / groupShow / offline is treated as a paid (private) show. The paid-flow
- * guards (autoPaySpy, price/token availability) bound the risk of unknown statuses.
+ * Room status classification. The platform uses several variants for paid shows (private /
+ * virtualPrivate / ...) and the list can grow, so anything that is not public / groupShow / offline
+ * is treated as a paid (private) show. The paid-flow guards (autoPaySpy, price/token availability)
+ * bound the risk of unknown statuses. p2p is special bacause it's WebRTC and likely cannot be
+ * recorded.
  */
 object RoomStatus {
     const val PUBLIC = "public"
     const val GROUP_SHOW = "groupShow"
+    const val RTC_SHOW = "p2p"
 
     // known private variants (informative; isPrivate() also falls back to "everything else")
-    val PRIVATE_VARIANTS = setOf("private", "p2p", "virtualPrivate")
+    val PRIVATE_VARIANTS = setOf("private", "virtualPrivate")
 
     // statuses meaning the model is not streaming
     val OFFLINE_VARIANTS = setOf("off", "offline", "idle")
 
     fun isPublic(status: String): Boolean = status == PUBLIC
     fun isGroupShow(status: String): Boolean = status == GROUP_SHOW
-    fun isOffline(status: String): Boolean = status in OFFLINE_VARIANTS
+    fun isOffline(status: String): Boolean = status in OFFLINE_VARIANTS || status == RTC_SHOW
+    fun isRtc(status: String): Boolean = status == RTC_SHOW
 
     /** Paid-show status: a known private variant, or any unknown non-offline status. */
     fun isPrivate(status: String): Boolean =

--- a/src/test/kotlin/github/rikacelery/v3/components/RoomComponentTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/RoomComponentTest.kt
@@ -46,7 +46,7 @@ class RoomComponentTest {
         val mockServer = HttpClient(MockEngine { request ->
             assertEquals("https://mock.platform/broadcasts/model", request.url.toString())
             respond(
-                content = """{"item":{"status":"p2p"}}""",
+                content = """{"item":{"status":"private"}}""",
                 status = HttpStatusCode.OK,
                 headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
             )
@@ -85,7 +85,7 @@ class RoomComponentTest {
 
         assertEquals(
             listOf(
-                RoomStatusChanged(1, "public", "p2p"),
+                RoomStatusChanged(1, "public", "private"),
                 CommandAck(1, OkResponse)
             ),
             observed

--- a/src/test/kotlin/github/rikacelery/v3/integration/MockPlatformServerTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/MockPlatformServerTest.kt
@@ -56,9 +56,9 @@ class MockPlatformServerTest {
             assertEquals("public", broadcast.jsonPath("item.status"))
             assertEquals(7L, broadcast.jsonPath("item.modelId").toLong())
 
-            mock.setRoomStatus(room.id, "p2p")
+            mock.setRoomStatus(room.id, "private")
             assertEquals(
-                "p2p",
+                "private",
                 client.get("${mock.baseUrl}/api/front/v1/broadcasts/model").bodyAsText().jsonPath("item.status")
             )
 

--- a/src/test/kotlin/github/rikacelery/v3/integration/RecordingFilterIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/RecordingFilterIntegrationTest.kt
@@ -101,7 +101,7 @@ class RecordingFilterIntegrationTest {
         fx.get("/activate?id=1001").expectOk("Activated")
         fx.mock.startSegments(1001, 30.milliseconds)
         fx.awaitRoomSubscribed(1001)
-        fx.mock.setRoomStatus(1001, "p2p")
+        fx.mock.setRoomStatus(1001, "private")
 
         fx.awaitSession(1001, SessionState.Recording)
         fx.awaitEvent<SegmentDownloaded>(10.seconds) { it.roomId == 1001L }
@@ -122,7 +122,7 @@ class RecordingFilterIntegrationTest {
         fx.mock.startSegments(1001, 30.milliseconds)
         fx.awaitRoomSubscribed(1001)
         val before = fx.mock.requests().size
-        fx.mock.setRoomStatus(1001, "p2p")
+        fx.mock.setRoomStatus(1001, "private")
 
         // the preconfig loop retries every 100ms in tests: an unthrottled probe would ask
         // the platform about the privilege ~20 times in this window
@@ -162,7 +162,7 @@ class RecordingFilterIntegrationTest {
         fx.get("/add?name=model&active=false").expectOk("Room added: model")
         fx.get("/activate?id=1001").expectOk("Activated")
         fx.awaitRoomSubscribed(1001)
-        fx.mock.setRoomStatus(1001, "p2p")
+        fx.mock.setRoomStatus(1001, "private")
 
         val room = fx.awaitRoom("model") { it.path("room.hint.code") == "no_free_spy" }
         assertEquals("no_free_spy", room.path("room.hint.code"))
@@ -175,7 +175,7 @@ class RecordingFilterIntegrationTest {
         fx.get("/add?name=model&active=false&autoPaySpy=true").expectOk("Room added: model")
         fx.get("/activate?id=1001").expectOk("Activated")
         fx.awaitRoomSubscribed(1001)
-        fx.mock.setRoomStatus(1001, "p2p")
+        fx.mock.setRoomStatus(1001, "private")
 
         val room = fx.awaitRoom("model") { it.path("room.hint.code") == "preconfig_failed" }
         assertEquals("preconfig_failed", room.path("room.hint.code"))
@@ -217,7 +217,7 @@ class RecordingFilterIntegrationTest {
         fx.get("/activate?id=1001").expectOk("Activated")
         fx.mock.startSegments(1001, 30.milliseconds)
         fx.awaitRoomSubscribed(1001)
-        fx.mock.setRoomStatus(1001, "p2p")
+        fx.mock.setRoomStatus(1001, "private")
 
         delay(1500)
         assertTrue(
@@ -236,14 +236,14 @@ class RecordingFilterIntegrationTest {
         fx.mock.startSegments(1001, 30.milliseconds)
         fx.awaitRoomSubscribed(1001)
 
-        fx.mock.setRoomStatus(1001, "p2p")
+        fx.mock.setRoomStatus(1001, "private")
         delay(750)
         val firstShow = fx.mock.requests().count { it.path.contains("/api/front/v2/models/1001/cam") }
         assertTrue(firstShow > 0, "the privilege must be probed when the private show starts")
 
         fx.mock.setRoomStatus(1001, "off")
         delay(250)
-        fx.mock.setRoomStatus(1001, "p2p")
+        fx.mock.setRoomStatus(1001, "private")
         delay(750)
 
         val secondShow = fx.mock.requests().count { it.path.contains("/api/front/v2/models/1001/cam") }

--- a/src/test/kotlin/github/rikacelery/v3/integration/RoomRoutesIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/RoomRoutesIntegrationTest.kt
@@ -286,7 +286,7 @@ class RoomRoutesIntegrationTest {
 
         // switch the room to a paid private show; the old recording is cut and a spy show is purchased
         fx.mock.room(1001).modelToken = ""
-        fx.mock.setRoomStatus(1001, "p2p")
+        fx.mock.setRoomStatus(1001, "private")
 
         fx.awaitEvent<FileReady>(15.seconds) { it.roomId == 1001L }
         // the stopped session still reports Recording while it closes, so waiting for the state


### PR DESCRIPTION
#154 
> I strongly suspect p2p is handled much differently, likely using WebRTC instead of HLS. This would obviously need to be handled much differently. If even possible, it probably doesn't need to be implemented. Since the user will almost always be able to save the recording through the site and download that recording with another tool.

I made a function isRtc(), but p2p still causes isOffline to be true because of handling elsewhere.