### PR TITLE
Add Dockerfile, docker-compose and entrypoint for testing or a templa…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ bin/
 /abc.conf
 /creampussyy.txt
 /Dockerfile
+/docker/config
+/docker/recordings
 /list.conf
 /list.txt
 ./logback.xml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM gradle:8-jdk17 AS builder
+WORKDIR /app
+# Copy project configuration files first to cache dependencies
+COPY gradle/ gradle/
+COPY build.gradle* settings.gradle* gradlew ./
+# Fetch dependencies
+RUN ./gradlew dependencies --no-daemon || true
+# Copy full source and build the ShadowJar executable
+COPY . .
+RUN ./gradlew shadowJar --no-daemon
+
+# --- Stage 2: Production Runtime ---
+FROM eclipse-temurin:17-jre-alpine
+RUN apk add --no-cache ffmpeg tzdata
+WORKDIR /app
+COPY --from=builder /app/build/libs/*-all.jar ./xhrec.jar
+COPY ./docker/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+VOLUME ["/app/config", "/app/recordings"]
+ENV TZ=America/Chicago
+EXPOSE 8090
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,28 @@
+---
+# This should work in place for testing, but to use it elsewhere, there are things
+# that you will need to update manually if you are familiar with docker.
+# For localhost use https://localhost:8090
+services:
+  xhrec:
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile
+    container_name: xhrec
+    restart: unless-stopped
+    ports:
+      - 8090:8090
+    dns:
+      - 9.9.9.9
+      - 149.112.112.112
+    environment:
+      - TZ=America/Chicago  # Update to your local time zone
+    volumes:
+      # Mount configuration files/templates directory
+      - ./config:/app/config
+      # Mount directory where recorded video streams are saved
+      - ./recordings:/app/recordings
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+# The "-post" CLI flag has a known parsing issue in some builds, so
+# instead we symlink the mounted postprocessor.json to the default
+# relative location the app looks for (./postprocessor.json under
+# WORKDIR /app). Same idea for xhrec.json so decrypt keys persist
+# across container recreation instead of resetting to defaults.
+if [ -f /app/config/postprocessor.json ]; then
+    ln -sf /app/config/postprocessor.json /app/postprocessor.json
+fi
+if [ -f /app/config/xhrec.json ]; then
+    ln -sf /app/config/xhrec.json /app/xhrec.json
+fi
+
+set -- -f /app/config/list.conf -o /app/recordings -p 8090
+
+if [ -f /app/config/users.txt ]; then
+    set -- "$@" -u /app/config/users.txt
+fi
+
+exec java -jar xhrec.jar "$@"


### PR DESCRIPTION
Add Dockerfile, docker-compose and entrypoint for testing or a template for prod
It's all in it's own subdir, but builds cleanly from there. It will or may create files in docker/config/ and docker/config/ so I put them into .gitignore.