### PR TITLE
ci: check compiler warnings on every pull request

### DIFF
--- a/.github/compile-warnings.baseline
+++ b/.github/compile-warnings.baseline
@@ -1,0 +1,3 @@
+# Kotlin compiler warnings this repository currently tolerates.
+# Regenerate with .github/scripts/check_compile_warnings.py --update-baseline
+# Entries: 0

--- a/.github/scripts/check_compile_warnings.py
+++ b/.github/scripts/check_compile_warnings.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Gate the Kotlin build on new compiler warnings.
+
+Compiles the main and test sources, reports every `w:` warning as a GitHub annotation and in
+the job summary, then fails when a warning appears that the baseline does not know about.
+
+The baseline exists because the tree already carries warnings; it is a ratchet, not an excuse:
+`.github/compile-warnings.baseline` is the set that is currently tolerated, and it can only be
+regenerated deliberately with `--update-baseline`.
+
+    .github/scripts/check_compile_warnings.py                     # gate (CI and local)
+    .github/scripts/check_compile_warnings.py --update-baseline    # accept the current warnings
+    .github/scripts/check_compile_warnings.py --log build/g.log    # parse a captured log
+
+Exit codes: 0 clean or unchanged, 1 new warnings, 2 the build itself failed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import unquote
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BASELINE = REPO_ROOT / ".github" / "compile-warnings.baseline"
+REPORT = REPO_ROOT / "build" / "compile-warnings.txt"
+
+# `w: file:///path/to/Repo/src/main/kotlin/Foo.kt:12:34 message`
+WARNING = re.compile(r"^w: file://(?P<file>.+):(?P<line>\d+):(?P<col>\d+) (?P<message>.*)$")
+ERROR = re.compile(r"^e: file://.+:\d+:\d+ .*$")
+
+GRADLE_ARGS = ["compileKotlin", "compileTestKotlin", "--no-daemon", "--no-build-cache", "--console=plain"]
+
+Warning = collections.namedtuple("Warning", "path line col message")
+
+
+def run_gradle() -> tuple[int, str]:
+    """Compiles both source sets from scratch, returning the exit code and the combined output."""
+    command = ["./gradlew", "clean", *GRADLE_ARGS]
+    print(f"$ {' '.join(command)}", flush=True)
+    completed = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    sys.stdout.write(completed.stdout)
+    return completed.returncode, completed.stdout
+
+
+def parse(log: str) -> tuple[list[Warning], list[str]]:
+    warnings: list[Warning] = []
+    errors: list[str] = []
+    for raw in log.splitlines():
+        line = raw.rstrip()
+        match = WARNING.match(line)
+        if match:
+            warnings.append(Warning(relative_path(match["file"]), int(match["line"]), int(match["col"]), match["message"]))
+        elif ERROR.match(line):
+            errors.append(line)
+    return warnings, errors
+
+
+def relative_path(url_path: str) -> str:
+    """Turns the compiler's percent-encoded absolute file URL into a repo-relative path.
+
+    The baseline is shared between machines, so it must never record where the checkout lives.
+    When the reported path does not sit under this working copy — a captured CI log, a symlinked
+    workspace — the path is cut at its source set instead. Files outside the project at all
+    (Gradle plugins, generated code) keep their name, which still tells them apart.
+    """
+    absolute = Path(unquote(url_path))
+    try:
+        return absolute.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        pass
+    as_posix = absolute.as_posix()
+    match = re.search(r"src/(?:main|test)/", as_posix)
+    if match:
+        return as_posix[match.start():]
+    return f"<external>/{absolute.name}"
+
+
+def key(warning: Warning) -> str:
+    """Identifies a warning across edits: line and column move, the text and file do not."""
+    return f"{warning.path}\t{warning.message}"
+
+
+def load_baseline() -> collections.Counter[str]:
+    if not BASELINE.exists():
+        return collections.Counter()
+    entries = [
+        line
+        for line in BASELINE.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.startswith("#")
+    ]
+    return collections.Counter(entries)
+
+
+def write_baseline(warnings: list[Warning]) -> None:
+    lines = sorted(key(warning) for warning in warnings)
+    header = [
+        "# Kotlin compiler warnings this repository currently tolerates.",
+        "# Regenerate with .github/scripts/check_compile_warnings.py --update-baseline",
+        f"# Entries: {len(lines)}",
+    ]
+    BASELINE.write_text("\n".join(header + lines) + "\n", encoding="utf-8")
+
+
+def escape_annotation(text: str) -> str:
+    return text.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def escape_property(text: str) -> str:
+    return escape_annotation(text).replace(":", "%3A").replace(",", "%2C")
+
+
+def annotate(warnings: list[Warning], new_keys: set[str]) -> None:
+    """Emits workflow commands so the warnings land on the PR diff."""
+    for warning in warnings:
+        level = "warning" if key(warning) in new_keys else "notice"
+        print(
+            f"::{level} file={escape_property(warning.path)},line={warning.line},"
+            f"col={warning.col},title=Kotlin compiler warning::"
+            f"{escape_annotation(warning.message)}"
+        )
+
+
+def summary(warnings: list[Warning], new: list[Warning], gone: list[Warning]) -> None:
+    by_file = collections.Counter(warning.path for warning in warnings)
+    lines = [
+        "## Kotlin compiler warnings",
+        "",
+        f"* warnings now: **{len(warnings)}**",
+        f"* new since baseline: **{len(new)}**",
+        f"* in baseline but gone: {len(gone)}",
+        "",
+    ]
+    if new:
+        lines += ["### New warnings — update the code, or the baseline if that is the intent", ""]
+        for warning in sorted(new, key=lambda w: (w.path, w.line)):
+            lines += [f"* `{warning.path}:{warning.line}:{warning.col}` — {warning.message}"]
+        lines += ["", "```", "./.github/scripts/check_compile_warnings.py --update-baseline", "```", ""]
+    if gone:
+        lines += ["### No longer reported (the baseline can shrink)", ""]
+        for warning in sorted(gone, key=lambda w: w.path):
+            lines += [f"* `{warning.path}` — {warning.message}"]
+        lines += [""]
+    if warnings:
+        lines += ["### All warnings by file", "", "| file | warnings |", "| --- | --- |"]
+        lines += [f"| `{path}` | {count} |" for path, count in sorted(by_file.items(), key=lambda kv: (-kv[1], kv[0]))]
+        lines += [""]
+
+    text = "\n".join(lines)
+    print(text)
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a", encoding="utf-8") as handle:
+            handle.write(text + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--update-baseline", action="store_true", help="rewrite the baseline from this run")
+    parser.add_argument("--log", type=Path, help="parse an existing Gradle log instead of compiling")
+    args = parser.parse_args()
+
+    if args.log:
+        status, log = 0, args.log.read_text(encoding="utf-8")
+    else:
+        status, log = run_gradle()
+
+    warnings, errors = parse(log)
+
+    REPORT.parent.mkdir(parents=True, exist_ok=True)
+    REPORT.write_text(
+        "\n".join(f"{w.path}:{w.line}:{w.col} {w.message}" for w in warnings) + ("\n" if warnings else ""),
+        encoding="utf-8",
+    )
+
+    if errors:
+        print(f"\n{len(errors)} compile error(s):", file=sys.stderr)
+        for line in errors[:20]:
+            print(f"  {line}", file=sys.stderr)
+        return 2
+    if status != 0:
+        print(f"\nGradle failed with exit code {status}", file=sys.stderr)
+        return 2
+
+    if args.update_baseline:
+        write_baseline(warnings)
+        print(f"\nBaseline written: {len(warnings)} warning(s) -> {BASELINE.relative_to(REPO_ROOT)}")
+        return 0
+
+    baseline = load_baseline()
+    current = collections.Counter(key(warning) for warning in warnings)
+    new_keys = set((current - baseline).elements())
+    gone_keys = set((baseline - current).elements())
+
+    annotate(warnings, new_keys)
+    summary(
+        warnings,
+        [warning for warning in warnings if key(warning) in new_keys],
+        [Warning(k.split("\t", 1)[0], 0, 0, k.split("\t", 1)[1]) for k in sorted(gone_keys)],
+    )
+
+    if new_keys:
+        counts = collections.Counter(key(warning) for warning in warnings)
+        for entry in sorted(new_keys):
+            path, message = entry.split("\t", 1)
+            print(f"::error title=New compiler warning::{path}: {message} (x{counts[entry]})")
+        print(f"\n{len(new_keys)} new compiler warning(s) not in the baseline", file=sys.stderr)
+        return 1
+
+    print(f"\nNo new compiler warnings ({len(warnings)} tolerated by the baseline)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/compile-warnings.yml
+++ b/.github/workflows/compile-warnings.yml
@@ -1,0 +1,55 @@
+name: Compile Warnings
+
+# Fails a pull request as soon as the Kotlin compiler reports a warning the baseline does not
+# know about. Runs on main too, so a warning that slips in through a direct push still shows up.
+# The check itself lives in .github/scripts/check_compile_warnings.py and can be run locally.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: compile-warnings-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  warnings:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v6
+        with:
+          java-version: '17'
+          distribution: zulu
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-provider: basic
+          # this job must compile from scratch to see every warning, so it never writes the cache
+          cache-read-only: true
+
+      - name: Collect compiler warnings
+        shell: bash
+        run: python3 .github/scripts/check_compile_warnings.py
+
+      - name: Upload the warning list
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: compile-warnings
+          path: build/compile-warnings.txt
+          if-no-files-found: ignore
+          retention-days: 7
+          overwrite: true

--- a/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
@@ -365,7 +365,7 @@ class HttpServerComponent(
                                         })
                                         put("active", s?.state == SessionState.Recording)
                                         put("quality", s?.quality ?: "")
-                                        put("startTime", if (isActive) s?.startTime?.toEpochMilli() ?: 0L else 0L)
+                                        put("startTime", if (isActive) s.startTime.toEpochMilli() else 0L)
                                     })
                                     put("listening", s != null || isArmed)
                                     put("room", buildJsonObject {

--- a/src/main/kotlin/github/rikacelery/v3/fsm/Fsm.kt
+++ b/src/main/kotlin/github/rikacelery/v3/fsm/Fsm.kt
@@ -41,7 +41,7 @@ data class TransitionRecord<S, E>(
         val targetStr = when (target) {
             is ERROR -> "ERROR"
             is KEEP -> "KEEP"
-            is NextState -> "-> ${(target as NextState<S>).state}"
+            is NextState -> "-> ${target.state}"
         }
         val dataStr = if (data != null) " [data=$data]" else ""
         return "[$timestamp] $fromState --($event)--> $targetStr$dataStr"

--- a/src/main/kotlin/github/rikacelery/v3/ml/Gbdt.kt
+++ b/src/main/kotlin/github/rikacelery/v3/ml/Gbdt.kt
@@ -129,8 +129,8 @@ class Gbdt(
         while (queue.isNotEmpty()) {
             val job = queue.removeFirst()
             val idxs = job.idxs
-            val gSum = idxs.sumOf { grad[it].toDouble() }
-            val hSum = idxs.sumOf { hess[it].toDouble() }
+            val gSum = idxs.sumOf { grad[it] }
+            val hSum = idxs.sumOf { hess[it] }
             val leafVal = -gSum / (hSum + l2)
 
             if (job.depth >= maxDepth || idxs.size < minLeaf * 2) {
@@ -158,10 +158,10 @@ class Gbdt(
                         t += step
                         continue
                     }
-                    val gl = left.sumOf { grad[it].toDouble() }
-                    val hl = left.sumOf { hess[it].toDouble() }
-                    val gr = right.sumOf { grad[it].toDouble() }
-                    val hr = right.sumOf { hess[it].toDouble() }
+                    val gl = left.sumOf { grad[it] }
+                    val hl = left.sumOf { hess[it] }
+                    val gr = right.sumOf { grad[it] }
+                    val hr = right.sumOf { hess[it] }
                     val gain = score(gl, hl) + score(gr, hr) - score(gSum, hSum)
                     if (gain > bestGain) {
                         bestGain = gain

--- a/src/test/kotlin/github/rikacelery/v3/components/PostProcessorComponentTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/PostProcessorComponentTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
 package github.rikacelery.v3.components
 
 import github.rikacelery.v3.core.EventBus

--- a/src/test/kotlin/github/rikacelery/v3/core/ActorTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/core/ActorTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
 package github.rikacelery.v3.core
 
 import kotlinx.coroutines.*

--- a/src/test/kotlin/github/rikacelery/v3/core/DataChannelTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/core/DataChannelTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
 package github.rikacelery.v3.core
 
 import github.rikacelery.v3.data.DataChannelMsg

--- a/src/test/kotlin/github/rikacelery/v3/core/EventBusTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/core/EventBusTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
 package github.rikacelery.v3.core
 
 import github.rikacelery.v3.hooks.EventHook

--- a/src/test/kotlin/github/rikacelery/v3/core/OrderedEmitterTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/core/OrderedEmitterTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
 package github.rikacelery.v3.core
 
 import github.rikacelery.v3.data.*

--- a/src/test/kotlin/github/rikacelery/v3/core/RequestBusTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/core/RequestBusTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
 package github.rikacelery.v3.core
 
 import github.rikacelery.v3.events.*

--- a/src/test/kotlin/github/rikacelery/v3/integration/StatusFlowIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/StatusFlowIntegrationTest.kt
@@ -29,7 +29,8 @@ class StatusFlowIntegrationTest {
         "groupShow,false,false,false",
         "groupShow,true,false,true",
         "p2p,false,false,false",
-        "p2p,false,true,true",
+        "p2p,false,true,false",
+        "private,false,true,true",
         "virtualPrivate,false,true,true",
         "weirdStatus,false,false,false",
         "weirdStatus,false,true,true"

--- a/src/test/kotlin/github/rikacelery/v3/ml/PerformanceBaselineTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/ml/PerformanceBaselineTest.kt
@@ -17,7 +17,7 @@ class PerformanceBaselineTest {
                 (i % 24).toDouble(),
                 (i % 7).toDouble(),
                 if ((i % 7) >= 5) 1.0 else 0.0,
-                (rng.nextDouble() * 100).toDouble(),
+                rng.nextDouble() * 100,
                 rng.nextDouble() * 300,
                 rng.nextDouble() * 60,
                 rng.nextInt(5).toDouble(),


### PR DESCRIPTION
新增一个 **Compile Warnings** 工作流，把 Kotlin 编译警告纳入 PR 门禁；同时把仓库里现存的 50 条警告清零，并顺手修掉 main 上的一处红灯。

## 1. 工作流 `.github/workflows/compile-warnings.yml`

- 触发：`pull_request` + `push: main`（直接推到 main 的警告也不会漏）
- `clean compileKotlin compileTestKotlin --no-daemon --no-build-cache --console=plain` —— 从头编译，保证警告不会被增量/构建缓存吃掉
- Gradle 缓存设为 `cache-read-only: true`：这个 job 只读不写，免得它的编译产物影响别的 job
- 每条警告以 `::warning file=…,line=…,col=…` **直接标注在 PR 的 diff 上**，并写进 Job Summary（按文件汇总 + 新增/消失清单）
- 上传 `build/compile-warnings.txt` 工件

## 2. 检查脚本 `.github/scripts/check_compile_warnings.py`

本地和 CI 跑同一份逻辑：

```bash
python3 .github/scripts/check_compile_warnings.py                     # 门禁
python3 .github/scripts/check_compile_warnings.py --update-baseline   # 显式豁免当前警告
python3 .github/scripts/check_compile_warnings.py --log build/x.log   # 复用已捕获日志
```

- **新增警告 → exit 1**；基线里有但已消失 → 只提示"基线可以收缩"，不拦
- 退出码：`0` 干净/无变化，`1` 有新增警告，`2` 编译本身失败（会先打印 `e:` 行）
- 比对用的是 `路径 + 消息`（不含行号列号），这样改动代码导致的位移不会误报
- 路径统一成**仓库相对路径**：Kotlin 输出的是 percent-encoded `file://` URL，脚本会解码；若日志来自别的 checkout（例如复用的 CI 日志），会按 `src/main|src/test` 截断，保证基线跨机器可用

`.github/compile-warnings.baseline` **当前是空的**，所以门禁等于零容忍；保留这个文件是为了给"确实要接受某条警告"留一条显式、可在 review 里看到的通道。

## 3. 现存 50 条警告全部清零

| 数量 | 警告 | 修法 |
| --- | --- | --- |
| 41 | 缺 `@OptIn(ExperimentalCoroutinesApi)` | 6 个测试文件加 `@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)` |
| 7 | `Redundant call of conversion method` | `Gbdt` 6 处、`PerformanceBaselineTest` 1 处：对已经是 `Double` 的值去掉 `.toDouble()` |
| 1 | `Unnecessary safe call on a non-null receiver of type 'RoomSession'` | `HttpServerComponent`：K2 已能通过 `isActive` 智能转换出 `s` 非空，且 `startTime` 本身非空，改为 `s.startTime.toEpochMilli()`（随之多余的 `?: 0L` 也去掉） |
| 1 | `No cast needed` | `Fsm.toString()`：`when` 分支已收窄类型，去掉 `as NextState<S>` |

这些改动都是**行为等价**的：去掉的转换和强制转换都是恒等操作，那两处安全调用和 elvis 永远不会走 fallback。

## 4. 顺带修 main 的红灯

`StatusFlowIntegrationTest` 的参数化 CSV 里 `"p2p,false,true,true"` 仍断言 p2p 会录制，而 #156 已把 p2p 归为 offline（`isOffline("p2p") == true`）。#156 把其它测试文件里的 `"p2p"` 换成了 `"private"`，但参数化的 CSV 没被覆盖到 —— 这就是 #156 合并前 CI 里剩下的那 1 个失败，也是 main 当前 CI 红灯的原因。

按同样意图改成 `"p2p,false,true,false"`（p2p 即使有免费 spy 也不录）+ `"private,false,true,true"`（保住"私密场凭免费 spy 录制"的覆盖）。

## 验证

- **端到端**：往 `Gbdt.kt` 注入一处真实的冗余转换 → 门禁 `exit 1`、`::error title=New compiler warning::src/main/kotlin/.../Gbdt.kt: Redundant call of conversion method.`；还原后 `exit 0`、`warnings now: 0`
- 另两条路径用合成日志验证：干净日志 `exit 0`；基线含已消失条目 → `exit 0` 且提示可收缩
- 路径可移植性：用 `/home/runner/work/...` 形式的合成 CI 日志验证能解析回 `src/main/kotlin/...`
- workflow YAML 用 ruby 解析通过；脚本 `py_compile` 通过
- **全量测试连跑两次全绿：265 用例，0 失败**

## 备注

- 基于 `main@77e6869`（含 #155/#156/#157）
- 三个提交互相独立，可单独 cherry-pick：`9e68928` 修 p2p 测试 / `a31ce02` 清警告 / `0636490` 加门禁
