### PR TITLE
fix(scheduler): stop a stale resume mark from stalling a room

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ xhrec.keystore
 
 /tmp/
 /doc/
+
+### local build cache used when ~/.gradle is unavailable
+.gradle-home/

--- a/README.md
+++ b/README.md
@@ -295,6 +295,8 @@ otherwise invisible:
 | `lastPollSegmentCount` | media segments the last playlist actually advertised |
 | `lastPollEnqueuedMedia` | whether any of them was queued for download |
 | `lastPollSkipped` | how many were skipped as already covered by the resume mark (normal) |
+| `lastPollGap` | how many ids the playlist jumped over this poll and never showed us (lost) |
+| `previousNewSegmentId` | the highest id this session has queued; the baseline for the gap check |
 | `lastSegmentId` | the resume mark; segments with an id at or below it are skipped |
 | `noProgressMs` | how long since the session last queued or received anything |
 
@@ -494,6 +496,20 @@ re-lists segments already written, so every healthy poll skips the overlap and e
 new. Those skips are counted in `xhrec_segments_skipped_total{roomId=…}`, which therefore rises
 steadily for *any* room that is recording. The signal to watch is that counter climbing while
 `xhrec_downloaded_total` stands still.
+
+The opposite failure is `xhrec_segment_missing_total{roomId=…}`: ids the stream published that the
+playlist never showed us. If one refresh ends at id 3 and the next already starts at 7, then 4, 5
+and 6 are gone — the playlist jumped over them. Nothing else in the pipeline can notice that (a
+segment we never hear about never fails and never reaches the downloader), so the session counts it
+itself and logs each jump at `DEBUG`:
+
+```
+DEBUG v3.SessionEntry - roomId=206236901 playlist went from segment id 1023 to 1028; 4 id(s) in between were never advertised
+```
+
+A gap at a session seam is deliberately not counted: after a limit cut, a `Break` or a re-arm the
+session has no earlier observation to compare against, so restarting the comparison would otherwise
+flag every ordinary cut as lost data.
 
 Per-poll detail is at `TRACE` — opt-in from the WebUI toolbar or `POST /log/level` — so it does not
 clutter the default `DEBUG` log:

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ curl -sk "https://localhost:8090/diagnose?actor=SessionComponent&section=entries
       "segmentIndex": 0,
       "lastSegmentId": 1750,
       "lastPollSegmentCount": 3,
+      "lastPollSkipped": 2,
       "lastPollEnqueuedMedia": false,
       "playlistLoopRunning": true,
       "skipStreak": { "skipped": 987, "minId": 1002, "maxId": 1004, "reported": true },
@@ -293,6 +294,7 @@ otherwise invisible:
 | --- | --- |
 | `lastPollSegmentCount` | media segments the last playlist actually advertised |
 | `lastPollEnqueuedMedia` | whether any of them was queued for download |
+| `lastPollSkipped` | how many were skipped as already covered by the resume mark (normal) |
 | `lastSegmentId` | the resume mark; segments with an id at or below it are skipped |
 | `noProgressMs` | how long since the session last queued or received anything |
 
@@ -487,26 +489,30 @@ level regardless.
 
 ### Diagnosing a stalled recording
 
-A session that keeps polling a healthy playlist without downloading anything now says so — once —
-instead of looking like a normal recording:
+**Skipping is the normal steady state, not a fault.** The media playlist is a sliding window that
+re-lists segments already written, so every healthy poll skips the overlap and enqueues only what is
+new. Those skips are counted in `xhrec_segments_skipped_total{roomId=…}`, which therefore rises
+steadily for *any* room that is recording. The signal to watch is that counter climbing while
+`xhrec_downloaded_total` stands still.
+
+Per-poll detail is at `TRACE` — opt-in from the WebUI toolbar or `POST /log/level` — so it does not
+clutter the default `DEBUG` log:
 
 ```
-WARN  v3.SessionEntry - roomId=206236901 recording stalled behind the resume mark: every advertised
-      segment id (1002..1004) is <= lastSegmentId=1750; 987 segment(s) skipped over 1932s and nothing downloaded
-INFO  v3.SessionEntry - roomId=206236901 caught up with the resume mark after 2154s; 1102 segment(s)
-      (id 1002..1789) were skipped, recording resumed
+TRACE v3.SessionEntry - roomId=206236901 skipped 3 segment(s) at or below the resume mark (id 1002..1004, lastSegmentId=1750)
 ```
 
-The resume mark (`lastSegmentId`) exists so a cut inside one stream does not re-download what was
-just written, so short overlaps after an ordinary cut stay silent; only a *persistent* streak is
-reported. At `DEBUG` you also get one aggregated line per poll, which shows *which* ids were dropped
-without logging per segment:
+When nothing new has arrived for `thresholdSkipLogDelay`, the session says so **once**, and says what
+actually happened rather than a count of skip events (the same ids repeat on every poll, so a running
+total would overstate it badly):
 
 ```
-DEBUG v3.SessionEntry - roomId=206236901 skipped 3 segment(s) at or below the resume mark (range 1002..1004, lastSegmentId=1750)
+WARN  v3.SessionEntry - roomId=170139817 no new segments for 32s: the playlist still advertises only id 1025..1027, all already covered by the resume mark (1027)
+INFO  v3.SessionEntry - roomId=206236901 caught up with the resume mark after 2154s; 1102 skip event(s) (id 1002..1789), recording resumed
 ```
 
-Two further lines are worth recognising:
+Short overlaps after an ordinary cut stay silent; only a *persistent* streak is reported. Two further
+lines are worth recognising:
 
 ```
 WARN  v3.SessionEntry - Recording stalled roomId=…: no segment for 90s (playlist carries 0 media segment(s));

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Platform domains and stream decryption key store. Created with defaults on first
   "thumbHost": "img.doppiocdn.org",
   "streamAuthKey": "default psch key, if failed to extract from master playlist",
   "maskSensitiveLogs": true,
+  "logLevel": "",
   "decryptKeys": {
     "psch key 1": "decrypt key",
     "psch key 2": "decrypt key"
@@ -96,6 +97,8 @@ Platform domains and stream decryption key store. Created with defaults on first
 | `thumbHost`        | Host used by the WebUI for thumbnail images. Default `img.doppiocdn.org`                                                                                |
 | `streamAuthKey`    | Default psch key for stream auth                                                                                                                        |
 | `maskSensitiveLogs`| Enable log masking (model names, cookies, tokens, proxy URLs). Toggle in WebUI or via `/mask/toggle`. Default `true`                                      |
+| `logLevel`         | Root log level (`TRACE`\|`DEBUG`\|`INFO`\|`WARN`\|`ERROR`\|`OFF`). Change it at runtime in the WebUI or via `/log/level`. Empty keeps whatever `logback.xml` configures                              |
+| `apiToken`         | When set, every endpoint except `/` requires it as `?token=` or `Authorization: Bearer …`                                                                 |
 | `decryptKeys`      | Key-value map of decryption keys (psch key → key)                                                                                                        |
 
 All domains can also be managed at runtime from the WebUI (network icon in the toolbar) or via
@@ -171,6 +174,9 @@ All endpoints return JSON unless noted. Parameters are passed as query strings.
 | `/status`    | Active room status (segments, bytes, running downloads) |
 | `/list`      | All rooms with status, session state, quality           |
 | `/dashboard` | Consolidated payload: rooms, statuses, listv2, metrics, and a per-room `hint` explaining why an armed room is not recording (`public_filter_off`, `ticket_purchase_off`, `private_filter_off`, `no_free_spy`, `preconfig_failed` plus an optional raw `detail`) |
+| `/diagnose`  | Internal state of every component: state machines, recent transitions, mailbox backlog |
+| `/debug/stream` | Live NDJSON tap on the request bus, the data channel and the event bus             |
+| `/log/level` | Read (GET) or change (POST) the root log level at runtime                          |
 | `/metrics`   | Prometheus metrics endpoint                             |
 
 | `/mask/toggle` | Toggle log masking on/off |
@@ -215,6 +221,163 @@ All endpoints return JSON unless noted. Parameters are passed as query strings.
   }
 }
 ```
+
+### Diagnostics & Debug Stream
+
+Use these when a room looks wrong but the logs are quiet — for example a room that reports
+`Recording` while nothing is being downloaded. They are read-only: playlist URLs are reduced to
+their path, and secrets (auth key, API token, decrypt keys, stream tokens) are only ever reported
+as present/absent, never by value.
+
+> If `apiToken` is set in `xhrec.json`, every endpoint except `/` requires it: append
+> `?token=<apiToken>` or send `Authorization: Bearer <apiToken>`.
+
+#### `/diagnose` — internal state of every component
+
+Without parameters it lists the live components, the sections each understands, and whether any
+debug tap is currently armed:
+
+```shell
+curl -sk https://localhost:8090/diagnose
+```
+
+```json
+{
+  "components": [
+    { "name": "SchedulerComponent", "sections": ["summary", "entries", "history"] },
+    { "name": "SessionComponent", "sections": ["summary", "entries", "history"] },
+    { "name": "DownloaderComponent", "sections": ["summary", "entries"] }
+  ],
+  "monitor": { "watched": [], "dropped": 0 }
+}
+```
+
+With `actor=` you get that component's view. Every component answers `summary` (identity, liveness,
+`mailboxDepth`); `section=entries` adds per-room or per-file detail; `section=history` returns the
+recent state-machine transitions. `room=<id>` narrows it to one room.
+
+```shell
+curl -sk "https://localhost:8090/diagnose?actor=SessionComponent&section=entries&room=206236901"
+```
+
+```json
+{
+  "actor": "SessionComponent",
+  "started": true,
+  "mailboxDepth": 0,
+  "sessionCount": 1,
+  "states": { "206236901": "Recording" },
+  "entries": [
+    {
+      "roomId": 206236901,
+      "roomName": "fox-yiyi",
+      "quality": "240p",
+      "playlistPath": "https://media-hls.doppiocdn.org/b-hls-22/206236901/206236901_240p_h264.m3u8",
+      "noProgressMs": 1932000,
+      "segmentIndex": 0,
+      "lastSegmentId": 1750,
+      "lastPollSegmentCount": 3,
+      "lastPollEnqueuedMedia": false,
+      "playlistLoopRunning": true,
+      "skipStreak": { "skipped": 987, "minId": 1002, "maxId": 1004, "reported": true },
+      "fsm": { "state": "Recording", "history": [ "…" ] }
+    }
+  ]
+}
+```
+
+**How to read a stuck room.** The three fields below tell the two failure modes apart, which is
+otherwise invisible:
+
+| Field | Meaning |
+| --- | --- |
+| `lastPollSegmentCount` | media segments the last playlist actually advertised |
+| `lastPollEnqueuedMedia` | whether any of them was queued for download |
+| `lastSegmentId` | the resume mark; segments with an id at or below it are skipped |
+| `noProgressMs` | how long since the session last queued or received anything |
+
+`lastPollSegmentCount > 0` with `lastPollEnqueuedMedia: false` means the playlist is healthy but
+every segment sits behind the resume mark — the stream has not caught up yet. `lastPollSegmentCount
+= 0` means the playlist itself is empty. A growing `mailboxDepth` on a component means its actor is
+falling behind rather than idle.
+
+`section=history` shows how a room reached its current state, which is usually where the answer is:
+
+```shell
+curl -sk "https://localhost:8090/diagnose?actor=SchedulerComponent&section=history&room=206236901"
+```
+
+```json
+{
+  "history": {
+    "206236901": [
+      { "at": "21:35:08.782", "from": "Preconfiguring", "event": "PreconfigFailed", "target": "KEEP", "data": "SchedulerDriveData(failReason=no free spy access, …)" },
+      { "at": "21:35:08.782", "from": "Preconfiguring", "event": "BackToArmed", "target": "-> Armed" },
+      { "at": "22:21:15.464", "from": "Armed", "event": "RoomStatusChanged", "target": "KEEP", "data": "SchedulerDriveData(roomStatus=public, …)" },
+      { "at": "22:21:15.464", "from": "Armed", "event": "BeginPreconfig", "target": "-> Preconfiguring" },
+      { "at": "22:21:49.002", "from": "Preconfiguring", "event": "PreconfigDone", "target": "-> Recording", "data": "SchedulerDriveData(quality=240p, …)" }
+    ]
+  }
+}
+```
+
+#### `/debug/stream` — live tap on the internal buses
+
+Streams the request bus, the data channel and the event bus as **one JSON object per line**
+(NDJSON). `types` is a comma-separated subset of `request`, `data`, `event` (default
+`request,data`):
+
+```shell
+curl -skN "https://localhost:8090/debug/stream?types=request,data"
+```
+
+```
+{"kind":"hello","types":["request","data"],"dropped":0}
+{"seq":1,"ts":1789140029897,"kind":"request","id":7,"cmd":"GetRooms","ms":1,"result":"[]"}
+{"seq":2,"ts":1789140029898,"kind":"request","id":8,"cmd":"GetRecordingHints","ms":0,"result":"RecordingHintsResponse(count=0)"}
+{"seq":3,"ts":1789140029899,"kind":"data","msg":"StreamData","room":206236901,"bytes":131072}
+{"kind":"heartbeat","dropped":0}
+```
+
+| `kind` | Fields |
+| --- | --- |
+| `hello` | first line: the accepted `types` and the `dropped` counter |
+| `request` | `id`, `cmd`, `ms` (latency), `result` (or the error / `TIMEOUT after Nms`) |
+| `data` | `msg` (`StreamStart`/`StreamData`/`StreamEnd`/`StreamEvent`), `room`, `bytes` |
+| `event` | `event` (type name), `detail` (shortened `toString`) |
+| `heartbeat` | written when idle; also how the server notices a dropped client |
+
+The taps are **opt-in and cost nothing while nobody is watching**: every producer checks whether a
+client wants that category before it builds a line. A slow client loses the oldest lines (they are
+counted in `dropped`) rather than stalling a download. Closing the connection releases the taps —
+`/diagnose` shows them under `monitor.watched`.
+
+Piping through `jq` is the usual way to use it:
+
+```shell
+# only slow round trips
+curl -skN "https://localhost:8090/debug/stream?types=request" | jq -c 'select(.kind=="request" and .ms > 100)'
+
+# follow one room's data flow
+curl -skN "https://localhost:8090/debug/stream?types=data" | jq -c 'select(.room==206236901)'
+```
+
+#### `/log/level` — change the log level at runtime
+
+```shell
+curl -sk https://localhost:8090/log/level
+# {"level":"DEBUG","levels":["TRACE","DEBUG","INFO","WARN","ERROR","OFF"]}
+
+curl -sk -X POST -d "level=TRACE" https://localhost:8090/log/level
+# TRACE
+
+curl -sk -X POST -d "level=LOUD" https://localhost:8090/log/level
+# HTTP 400: Unknown log level: LOUD
+```
+
+The level is applied to the root logger immediately and persisted to `xhrec.json` (`logLevel`), so
+it survives a restart. The noisy third-party loggers pinned in `logback.xml` (netty, ktor, jetty)
+keep their own level. The same control is in the WebUI toolbar (the bug icon).
 
 ## Post Processing
 
@@ -312,6 +475,51 @@ curl -k https://localhost:8090/mask/status     # current state
 ```
 
 The setting persists to `xhrec.json` (`maskSensitiveLogs` field).
+
+### Log Level
+
+The root log level can be changed without a restart — from the WebUI toolbar (the bug icon) or via
+`POST /log/level`, see [Diagnostics & Debug Stream](#diagnostics--debug-stream). It is persisted in
+`xhrec.json` (`logLevel`); leave that field empty to keep whatever `logback.xml` configures.
+`TRACE`/`DEBUG` are worth turning on while chasing a specific room; `INFO` keeps the file small the
+rest of the time. The noisy libraries pinned in `logback.xml` (netty, ktor, jetty) keep their own
+level regardless.
+
+### Diagnosing a stalled recording
+
+A session that keeps polling a healthy playlist without downloading anything now says so — once —
+instead of looking like a normal recording:
+
+```
+WARN  v3.SessionEntry - roomId=206236901 recording stalled behind the resume mark: every advertised
+      segment id (1002..1004) is <= lastSegmentId=1750; 987 segment(s) skipped over 1932s and nothing downloaded
+INFO  v3.SessionEntry - roomId=206236901 caught up with the resume mark after 2154s; 1102 segment(s)
+      (id 1002..1789) were skipped, recording resumed
+```
+
+The resume mark (`lastSegmentId`) exists so a cut inside one stream does not re-download what was
+just written, so short overlaps after an ordinary cut stay silent; only a *persistent* streak is
+reported. At `DEBUG` you also get one aggregated line per poll, which shows *which* ids were dropped
+without logging per segment:
+
+```
+DEBUG v3.SessionEntry - roomId=206236901 skipped 3 segment(s) at or below the resume mark (range 1002..1004, lastSegmentId=1750)
+```
+
+Two further lines are worth recognising:
+
+```
+WARN  v3.SessionEntry - Recording stalled roomId=…: no segment for 90s (playlist carries 0 media segment(s));
+      ending the session so the room re-resolves its stream
+WARN  v3.SchedulerEntry - Preconfig failed room=…: playlist unusable (HTTP 404)
+```
+
+The first is the stall watchdog ending a session that made no progress for `sessionStallTimeout`,
+after which the room re-runs preconfiguration. The second is a preconfig probe that could not use
+the variant playlist — an HTTP status, a probe timeout, or a request failure.
+
+When the log alone is not enough, `/diagnose` exposes the same state interactively; see
+[Diagnostics & Debug Stream](#diagnostics--debug-stream).
 
 Prometheus metrics are exposed at `/metrics`. Example Grafana dashboard:
 

--- a/README.md
+++ b/README.md
@@ -512,11 +512,17 @@ session has no earlier observation to compare against, so restarting the compari
 flag every ordinary cut as lost data.
 
 Per-poll detail is at `TRACE` — opt-in from the WebUI toolbar or `POST /log/level` — so it does not
-clutter the default `DEBUG` log:
+clutter the default `DEBUG` log. Read it as "N of the M ids this playlist advertised were already
+covered, and the mark then moved from A to B":
 
 ```
-TRACE v3.SessionEntry - roomId=206236901 skipped 3 segment(s) at or below the resume mark (id 1002..1004, lastSegmentId=1750)
+TRACE v3.SessionEntry - roomId=152807806 skipped 1 of 3 advertised segment(s): id 1063 already at or below the resume mark (mark 1063 -> 1065)
 ```
+
+`id` is the skipped set's own range — a single id when one entry was skipped, not the playlist's
+window — and the mark is printed as a transition because by then it has already advanced to this
+poll's newest id. So the line above means the window was `1063..1065`, the mark stood at `1063`, so
+1063 was already written and skipped while 1064 and 1065 were queued and moved the mark to 1065.
 
 When nothing new has arrived for `thresholdSkipLogDelay`, the session says so **once**, and says what
 actually happened rather than a count of skip events (the same ids repeat on every poll, so a running

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -269,6 +269,7 @@ curl -sk "https://localhost:8090/diagnose?actor=SessionComponent&section=entries
       "segmentIndex": 0,
       "lastSegmentId": 1750,
       "lastPollSegmentCount": 3,
+      "lastPollSkipped": 2,
       "lastPollEnqueuedMedia": false,
       "playlistLoopRunning": true,
       "skipStreak": { "skipped": 987, "minId": 1002, "maxId": 1004, "reported": true },
@@ -284,6 +285,7 @@ curl -sk "https://localhost:8090/diagnose?actor=SessionComponent&section=entries
 | --- | --- |
 | `lastPollSegmentCount` | 最近一次播放列表实际提供了多少个媒体分片 |
 | `lastPollEnqueuedMedia` | 其中是否有分片被真正排入下载队列 |
+| `lastPollSkipped` | 其中有多少因已被续传标记覆盖而跳过（正常现象） |
 | `lastSegmentId` | 续传标记；id 小于等于它的分片会被跳过 |
 | `noProgressMs` | 距离上一次排入或收到数据已经过了多久 |
 
@@ -470,24 +472,25 @@ curl -k https://localhost:8090/mask/status     # 查看当前状态
 
 ### 排查卡住的录制
 
-如果会话一直在轮询、播放列表也正常，却什么都没下载，现在会**明确报出来**（只报一次），而不是看起来一切正常：
+**跳过（skipped）是正常稳态，不是故障。** 播放列表是滑动窗口，每次轮询都会重复列出刚写过的分片，所以任何
+健康录制都会跳过重叠部分、只下载新增的。这些跳过次数计入 `xhrec_segments_skipped_total{roomId=…}`，因此对
+**任何正在录制的房间**它都会持续增长。真正要看的信号是：这个计数器在涨、而 `xhrec_downloaded_total` 不动。
+
+每次轮询的明细在 `TRACE`（可在 WebUI 工具栏或 `POST /log/level` 打开），所以不会污染默认的 `DEBUG` 日志：
 
 ```
-WARN  v3.SessionEntry - roomId=206236901 recording stalled behind the resume mark: every advertised
-      segment id (1002..1004) is <= lastSegmentId=1750; 987 segment(s) skipped over 1932s and nothing downloaded
-INFO  v3.SessionEntry - roomId=206236901 caught up with the resume mark after 2154s; 1102 segment(s)
-      (id 1002..1789) were skipped, recording resumed
+TRACE v3.SessionEntry - roomId=206236901 skipped 3 segment(s) at or below the resume mark (id 1002..1004, lastSegmentId=1750)
 ```
 
-续传标记（`lastSegmentId`）的作用是让同一条流内的切分不必重复下载已经写入的分片，所以普通切分后的短暂重叠
-是静默的；只有**持续**追不上才会报告。把等级调到 `DEBUG` 还能看到每次轮询的聚合行——它会告诉你被丢掉的
-具体是哪些 id，而不会为每个分片打一行日志：
+当超过 `thresholdSkipLogDelay` 一直没有新分片时，会话会**报告一次**，并且说的是真正发生的事，而不是累计的
+跳过事件数（同一批 id 每次轮询都会被重复计数，累计值会严重夸大）：
 
 ```
-DEBUG v3.SessionEntry - roomId=206236901 skipped 3 segment(s) at or below the resume mark (range 1002..1004, lastSegmentId=1750)
+WARN  v3.SessionEntry - roomId=170139817 no new segments for 32s: the playlist still advertises only id 1025..1027, all already covered by the resume mark (1027)
+INFO  v3.SessionEntry - roomId=206236901 caught up with the resume mark after 2154s; 1102 skip event(s) (id 1002..1789), recording resumed
 ```
 
-另外两类值得留意的日志：
+普通切分后的短暂重叠是静默的，只有**持续**无新分片才会报告。另外两类值得留意的日志：
 
 ```
 WARN  v3.SessionEntry - Recording stalled roomId=…: no segment for 90s (playlist carries 0 media segment(s));

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -489,11 +489,16 @@ DEBUG v3.SessionEntry - roomId=206236901 playlist went from segment id 1023 to 1
 **会话接缝处不计入缺失**：时限切分、`Break`、重新激活之后，会话没有更早的观测可以对比；若把重启当作基线重置之外
 还去比较，就会把每一次正常的切分都误报成丢数据。
 
-每次轮询的明细在 `TRACE`（可在 WebUI 工具栏或 `POST /log/level` 打开），所以不会污染默认的 `DEBUG` 日志：
+每次轮询的明细在 `TRACE`（可在 WebUI 工具栏或 `POST /log/level` 打开），所以不会污染默认的 `DEBUG` 日志。
+读法是"播放列表提供的 M 个 id 中有 N 个已被覆盖，随后标记从 A 推进到 B"：
 
 ```
-TRACE v3.SessionEntry - roomId=206236901 skipped 3 segment(s) at or below the resume mark (id 1002..1004, lastSegmentId=1750)
+TRACE v3.SessionEntry - roomId=152807806 skipped 1 of 3 advertised segment(s): id 1063 already at or below the resume mark (mark 1063 -> 1065)
 ```
+
+`id` 是**被跳过集合自身**的范围——只跳过一个时就是一个单值，不是播放列表窗口；而标记打印成 `A -> B`，是因为
+到这里它已经被本轮最新的 id 推进过了。所以上面这行表示：窗口是 `1063..1065`，进入本轮时标记是 `1063`，因此
+1063 已经写过被跳过，而 1064、1065 是新入队的并把标记推进到了 1065。
 
 当超过 `thresholdSkipLogDelay` 一直没有新分片时，会话会**报告一次**，并且说的是真正发生的事，而不是累计的
 跳过事件数（同一批 id 每次轮询都会被重复计数，累计值会严重夸大）：

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -76,6 +76,7 @@ https://stripchat.com/modelD q:highest nopublic nofreespy autopay:private
   "thumbHost": "img.doppiocdn.org",
   "streamAuthKey": "默认 psch 密钥，如果无法从 master playlist 中提取则使用此值",
   "maskSensitiveLogs": true,
+  "logLevel": "",
   "decryptKeys": {
     "psch 密钥 1": "解密密钥",
     "psch 密钥 2": "解密密钥"
@@ -94,6 +95,8 @@ https://stripchat.com/modelD q:highest nopublic nofreespy autopay:private
 | `thumbHost`         | WebUI 缩略图域名。默认 `img.doppiocdn.org`                                                                                                 |
 | `streamAuthKey`     | 用于流认证的默认 psch 密钥                                                                                                                   |
 | `maskSensitiveLogs` | 启用日志脱敏（主播名、cookie、token、代理地址）。可在 WebUI 中或通过 `/mask/toggle` 切换。默认 `true`                                         |
+| `logLevel`          | 根日志等级（`TRACE`\|`DEBUG`\|`INFO`\|`WARN`\|`ERROR`\|`OFF`）。可在 WebUI 中或通过 `/log/level` 运行时修改。留空则沿用 `logback.xml` 的配置        |
+| `apiToken`          | 设置后，除 `/` 外的所有接口都需要携带 `?token=` 或 `Authorization: Bearer …`                                                                  |
 | `decryptKeys`       | 解密密钥映射表（psch 密钥 → 解密密钥）                                                                                                         |
 
 所有域名也可以在运行时通过 WebUI（工具栏网络图标）或 `GET /config/hosts` / `POST /config/hosts` 管理，
@@ -165,6 +168,9 @@ cookie_string_here
 | `/status`   | 活跃房间状态（分段数、字节数、正在运行的下载任务）           |
 | `/list`     | 所有房间的状态、会话状态、画质                          |
 | `/dashboard`| 聚合数据: rooms, statuses, listv2, metrics，以及每个房间的 `hint`（解释已启用却未录制的原因: `public_filter_off`、`ticket_purchase_off`、`private_filter_off`、`no_free_spy`、`preconfig_failed`，可附带原始 `detail`） |
+| `/diagnose` | 每个组件的内部状态：状态机、最近的迁移历史、邮箱积压                        |
+| `/debug/stream` | 请求总线 / 数据通道 / 事件总线的实时 NDJSON 推送                      |
+| `/log/level`| 运行时读取（GET）或修改（POST）根日志等级                                |
 | `/metrics`  | Prometheus 指标接口                                 |
 
 | `/mask/toggle` | 切换日志脱敏开关      |
@@ -209,6 +215,157 @@ cookie_string_here
   }
 }
 ```
+
+## 诊断与调试流
+
+当某个房间看起来不对、日志却很安静时用这些接口——比如显示"录制中"却完全没有下载。它们都是只读的：
+播放列表 URL 只保留 path，密钥类信息（streamAuthKey、apiToken、解密密钥、推流 token）只报告"是否存在"，
+不会输出内容。
+
+> 如果 `xhrec.json` 中设置了 `apiToken`，除 `/` 外的所有接口都需要携带：追加 `?token=<apiToken>`，
+> 或发送 `Authorization: Bearer <apiToken>`。
+
+### `/diagnose` —— 查看每个组件的内部状态
+
+不带参数时列出当前存活的组件、各自支持的 section，以及是否有调试 tap 处于开启状态：
+
+```shell
+curl -sk https://localhost:8090/diagnose
+```
+
+```json
+{
+  "components": [
+    { "name": "SchedulerComponent", "sections": ["summary", "entries", "history"] },
+    { "name": "SessionComponent", "sections": ["summary", "entries", "history"] },
+    { "name": "DownloaderComponent", "sections": ["summary", "entries"] }
+  ],
+  "monitor": { "watched": [], "dropped": 0 }
+}
+```
+
+加上 `actor=` 返回该组件的视图。所有组件都支持 `summary`（身份、存活状态、`mailboxDepth`）；
+`section=entries` 增加逐房间 / 逐文件的细节；`section=history` 返回状态机最近的迁移记录；
+`room=<id>` 只保留指定房间。
+
+```shell
+curl -sk "https://localhost:8090/diagnose?actor=SessionComponent&section=entries&room=206236901"
+```
+
+```json
+{
+  "actor": "SessionComponent",
+  "started": true,
+  "mailboxDepth": 0,
+  "sessionCount": 1,
+  "states": { "206236901": "Recording" },
+  "entries": [
+    {
+      "roomId": 206236901,
+      "roomName": "fox-yiyi",
+      "quality": "240p",
+      "playlistPath": "https://media-hls.doppiocdn.org/b-hls-22/206236901/206236901_240p_h264.m3u8",
+      "noProgressMs": 1932000,
+      "segmentIndex": 0,
+      "lastSegmentId": 1750,
+      "lastPollSegmentCount": 3,
+      "lastPollEnqueuedMedia": false,
+      "playlistLoopRunning": true,
+      "skipStreak": { "skipped": 987, "minId": 1002, "maxId": 1004, "reported": true },
+      "fsm": { "state": "Recording", "history": [ "…" ] }
+    }
+  ]
+}
+```
+
+**怎么判断卡住的房间。** 下面几个字段能区分两种本来无法分辨的故障：
+
+| 字段 | 含义 |
+| --- | --- |
+| `lastPollSegmentCount` | 最近一次播放列表实际提供了多少个媒体分片 |
+| `lastPollEnqueuedMedia` | 其中是否有分片被真正排入下载队列 |
+| `lastSegmentId` | 续传标记；id 小于等于它的分片会被跳过 |
+| `noProgressMs` | 距离上一次排入或收到数据已经过了多久 |
+
+`lastPollSegmentCount > 0` 而 `lastPollEnqueuedMedia` 为 `false`，说明播放列表是正常的，但所有分片都落在
+续传标记之后——直播流还没追上标记。`lastPollSegmentCount = 0` 则说明播放列表本身就是空的。某个组件的
+`mailboxDepth` 持续增长，说明它的 actor 正在积压，而不是空闲。
+
+`section=history` 展示房间是如何走到当前状态的，答案通常就在这里：
+
+```shell
+curl -sk "https://localhost:8090/diagnose?actor=SchedulerComponent&section=history&room=206236901"
+```
+
+```json
+{
+  "history": {
+    "206236901": [
+      { "at": "21:35:08.782", "from": "Preconfiguring", "event": "PreconfigFailed", "target": "KEEP", "data": "SchedulerDriveData(failReason=no free spy access, …)" },
+      { "at": "21:35:08.782", "from": "Preconfiguring", "event": "BackToArmed", "target": "-> Armed" },
+      { "at": "22:21:15.464", "from": "Armed", "event": "RoomStatusChanged", "target": "KEEP", "data": "SchedulerDriveData(roomStatus=public, …)" },
+      { "at": "22:21:15.464", "from": "Armed", "event": "BeginPreconfig", "target": "-> Preconfiguring" },
+      { "at": "22:21:49.002", "from": "Preconfiguring", "event": "PreconfigDone", "target": "-> Recording", "data": "SchedulerDriveData(quality=240p, …)" }
+    ]
+  }
+}
+```
+
+### `/debug/stream` —— 内部总线的实时推送
+
+把请求总线、数据通道、事件总线以 **一行一个 JSON**（NDJSON）推送给客户端。`types` 是
+`request`、`data`、`event` 的逗号分隔子集（默认 `request,data`）：
+
+```shell
+curl -skN "https://localhost:8090/debug/stream?types=request,data"
+```
+
+```
+{"kind":"hello","types":["request","data"],"dropped":0}
+{"seq":1,"ts":1789140029897,"kind":"request","id":7,"cmd":"GetRooms","ms":1,"result":"[]"}
+{"seq":2,"ts":1789140029898,"kind":"request","id":8,"cmd":"GetRecordingHints","ms":0,"result":"RecordingHintsResponse(count=0)"}
+{"seq":3,"ts":1789140029899,"kind":"data","msg":"StreamData","room":206236901,"bytes":131072}
+{"kind":"heartbeat","dropped":0}
+```
+
+| `kind` | 字段 |
+| --- | --- |
+| `hello` | 首行：已接受的 `types` 与 `dropped` 计数 |
+| `request` | `id`、`cmd`、`ms`（耗时）、`result`（或错误 / `TIMEOUT after Nms`） |
+| `data` | `msg`（`StreamStart`/`StreamData`/`StreamEnd`/`StreamEvent`）、`room`、`bytes` |
+| `event` | `event`（类型名）、`detail`（截断后的 `toString`） |
+| `heartbeat` | 空闲时写出；同时也是服务端感知客户端断开的唯一途径 |
+
+这些 tap **默认关闭，且无人订阅时零开销**：每个生产者会先检查是否有客户端需要该类目，再决定是否构造这一行。
+客户端消费慢只会丢掉最旧的行（计入 `dropped`），绝不会阻塞下载。断开连接会自动释放 tap ——
+`/diagnose` 的 `monitor.watched` 可以看到当前状态。
+
+配合 `jq` 使用是最常见的方式：
+
+```shell
+# 只看耗时较长的请求
+curl -skN "https://localhost:8090/debug/stream?types=request" | jq -c 'select(.kind=="request" and .ms > 100)'
+
+# 跟踪某个房间的数据流
+curl -skN "https://localhost:8090/debug/stream?types=data" | jq -c 'select(.room==206236901)'
+```
+
+### `/log/level` —— 运行时修改日志等级
+
+```shell
+curl -sk https://localhost:8090/log/level
+# {"level":"DEBUG","levels":["TRACE","DEBUG","INFO","WARN","ERROR","OFF"]}
+
+curl -sk -X POST -d "level=TRACE" https://localhost:8090/log/level
+# TRACE
+
+curl -sk -X POST -d "level=LOUD" https://localhost:8090/log/level
+# HTTP 400: Unknown log level: LOUD
+```
+
+等级会立即作用于 root logger，并持久化到 `xhrec.json` 的 `logLevel` 字段，重启后依然生效。
+`logback.xml` 中单独固定等级的第三方库日志（netty、ktor、jetty）不受影响。WebUI 工具栏（虫子图标）
+提供同样的开关。
 
 ## 后处理
 
@@ -303,6 +460,45 @@ curl -k https://localhost:8090/mask/status     # 查看当前状态
 ```
 
 该设置持久化到 `xhrec.json` 的 `maskSensitiveLogs` 字段。
+
+### 日志等级
+
+根日志等级无需重启即可调整——WebUI 工具栏（虫子图标）或 `POST /log/level`，见
+[诊断与调试流](#诊断与调试流)。它会持久化到 `xhrec.json` 的 `logLevel` 字段；该字段留空则沿用
+`logback.xml` 的配置。排查某个具体房间时值得开到 `TRACE`/`DEBUG`，平时用 `INFO` 可以让日志文件小很多。
+`logback.xml` 中单独固定等级的第三方库（netty、ktor、jetty）不受影响。
+
+### 排查卡住的录制
+
+如果会话一直在轮询、播放列表也正常，却什么都没下载，现在会**明确报出来**（只报一次），而不是看起来一切正常：
+
+```
+WARN  v3.SessionEntry - roomId=206236901 recording stalled behind the resume mark: every advertised
+      segment id (1002..1004) is <= lastSegmentId=1750; 987 segment(s) skipped over 1932s and nothing downloaded
+INFO  v3.SessionEntry - roomId=206236901 caught up with the resume mark after 2154s; 1102 segment(s)
+      (id 1002..1789) were skipped, recording resumed
+```
+
+续传标记（`lastSegmentId`）的作用是让同一条流内的切分不必重复下载已经写入的分片，所以普通切分后的短暂重叠
+是静默的；只有**持续**追不上才会报告。把等级调到 `DEBUG` 还能看到每次轮询的聚合行——它会告诉你被丢掉的
+具体是哪些 id，而不会为每个分片打一行日志：
+
+```
+DEBUG v3.SessionEntry - roomId=206236901 skipped 3 segment(s) at or below the resume mark (range 1002..1004, lastSegmentId=1750)
+```
+
+另外两类值得留意的日志：
+
+```
+WARN  v3.SessionEntry - Recording stalled roomId=…: no segment for 90s (playlist carries 0 media segment(s));
+      ending the session so the room re-resolves its stream
+WARN  v3.SchedulerEntry - Preconfig failed room=…: playlist unusable (HTTP 404)
+```
+
+前者是看门狗在会话超过 `sessionStallTimeout` 没有任何进展时主动结束它，之后房间会重新执行 preconfig；
+后者是 preconfig 探测无法使用该清晰度播放列表——可能是 HTTP 状态码、探测超时，或请求失败。
+
+当日志不够用时，`/diagnose` 可以交互式地看到同样的状态，见 [诊断与调试流](#诊断与调试流)。
 
 Prometheus 指标暴露在 `/metrics`。Grafana 仪表盘示例：
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -286,6 +286,8 @@ curl -sk "https://localhost:8090/diagnose?actor=SessionComponent&section=entries
 | `lastPollSegmentCount` | 最近一次播放列表实际提供了多少个媒体分片 |
 | `lastPollEnqueuedMedia` | 其中是否有分片被真正排入下载队列 |
 | `lastPollSkipped` | 其中有多少因已被续传标记覆盖而跳过（正常现象） |
+| `lastPollGap` | 本次轮询播放列表跨过了多少个 id、从未展示给我们（已丢失） |
+| `previousNewSegmentId` | 本会话已排队的最大 id，也是缺失检测的基线 |
 | `lastSegmentId` | 续传标记；id 小于等于它的分片会被跳过 |
 | `noProgressMs` | 距离上一次排入或收到数据已经过了多久 |
 
@@ -475,6 +477,17 @@ curl -k https://localhost:8090/mask/status     # 查看当前状态
 **跳过（skipped）是正常稳态，不是故障。** 播放列表是滑动窗口，每次轮询都会重复列出刚写过的分片，所以任何
 健康录制都会跳过重叠部分、只下载新增的。这些跳过次数计入 `xhrec_segments_skipped_total{roomId=…}`，因此对
 **任何正在录制的房间**它都会持续增长。真正要看的信号是：这个计数器在涨、而 `xhrec_downloaded_total` 不动。
+
+相反方向的故障是 `xhrec_segment_missing_total{roomId=…}`：**流确实发布过、但播放列表从未告诉我们的 id**。
+比如上一次刷新停在 id 3，下一次直接是 7，那么 4、5、6 就丢了——播放列表跨过了它们。管线里其他环节都发现不了
+（一个我们从没听说过的分片，既不会失败、也永远不会到达下载器），所以由会话自己统计，并把每次跳跃记到 `DEBUG`：
+
+```
+DEBUG v3.SessionEntry - roomId=206236901 playlist went from segment id 1023 to 1028; 4 id(s) in between were never advertised
+```
+
+**会话接缝处不计入缺失**：时限切分、`Break`、重新激活之后，会话没有更早的观测可以对比；若把重启当作基线重置之外
+还去比较，就会把每一次正常的切分都误报成丢数据。
 
 每次轮询的明细在 `TRACE`（可在 WebUI 工具栏或 `POST /log/level` 打开），所以不会污染默认的 `DEBUG` 日志：
 

--- a/src/main/kotlin/github/rikacelery/v3/Main.kt
+++ b/src/main/kotlin/github/rikacelery/v3/Main.kt
@@ -15,6 +15,7 @@ import github.rikacelery.v3.m3u8.M3u8Parser
 import github.rikacelery.v3.ml.PredictionEngine
 import github.rikacelery.v3.utils.CdnSelector
 import github.rikacelery.v3.utils.DefaultHttpClientProvider
+import github.rikacelery.v3.utils.LogLevels
 import github.rikacelery.v3.utils.PredictionStore
 import github.rikacelery.v3.utils.SensitiveStringRegistry
 import kotlinx.coroutines.*
@@ -33,7 +34,8 @@ private data class PersistedConfig(
     val decryptKeys: Map<String, String>,
     val maskSensitiveLogs: Boolean,
     val hosts: HostsConfig,
-    val apiToken: String
+    val apiToken: String,
+    val logLevel: String
 )
 
 private val mainLogger = LoggerFactory.getLogger("v3.Main")
@@ -42,7 +44,7 @@ private fun loadPersistedConfig(configPath: String): PersistedConfig {
     val file = File(configPath)
     val key = "YzWScuyQRGAGcxx1KIJmiQ7BY9Vi35ftwLqUOVO8uoo="
     val pkey = "Fq6m2TO2ZeBkRPm9"
-    val default = PersistedConfig(pkey, mapOf(pkey to key), true, HostsConfig.DEFAULT, "")
+    val default = PersistedConfig(pkey, mapOf(pkey to key), true, HostsConfig.DEFAULT, "", "")
     if (!file.exists()) return default
     try {
         val json = Json.parseToJsonElement(file.readText()).jsonObject
@@ -52,7 +54,8 @@ private fun loadPersistedConfig(configPath: String): PersistedConfig {
         val mask = json["maskSensitiveLogs"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() ?: true
         val hosts = HostsConfig.fromJson(json)
         val apiToken = json["apiToken"]?.jsonPrimitive?.content ?: ""
-        return PersistedConfig(pkey, keys, mask, hosts, apiToken)
+        val logLevel = json["logLevel"]?.jsonPrimitive?.content ?: ""
+        return PersistedConfig(pkey, keys, mask, hosts, apiToken, logLevel)
     } catch (e: Exception) {
         mainLogger.error("Failed to load persisted config from $configPath", e)
         return default
@@ -96,7 +99,8 @@ fun main(vararg args: String) {
             listConfPath = cli.getOptionValue("file", "list.conf"),
             configPath = configPath,
             maskSensitiveLogs = persisted.maskSensitiveLogs,
-            apiToken = persisted.apiToken
+            apiToken = persisted.apiToken,
+            logLevel = persisted.logLevel
         )
 
         // Apply persisted runtime config before components start making API calls
@@ -106,6 +110,11 @@ fun main(vararg args: String) {
         val apiClient = ApiClient(persisted.hosts.platformHosts, httpClientProvider)
         CdnSelector.updateHosts(persisted.hosts.hlsHosts)
         SensitiveStringRegistry.enabled = persisted.maskSensitiveLogs
+        // Restore the dashboard's log level before the components start, so their startup logs
+        // already honor it. ConfigComponent re-applies it when it loads the file.
+        if (persisted.logLevel.isNotBlank() && LogLevels.apply(persisted.logLevel) == null) {
+            mainLogger.warn("Ignoring unknown persisted log level '{}'", persisted.logLevel)
+        }
 
         // 1. Core infrastructure
         val eventBus = EventBus()

--- a/src/main/kotlin/github/rikacelery/v3/components/ConfigComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/ConfigComponent.kt
@@ -8,6 +8,7 @@ import github.rikacelery.v3.data.HostsConfig
 import github.rikacelery.v3.data.SystemConfig
 import github.rikacelery.v3.events.*
 import github.rikacelery.v3.utils.CdnSelector
+import github.rikacelery.v3.utils.LogLevels
 import github.rikacelery.v3.utils.SensitiveStringRegistry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -17,7 +18,6 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.*
 import java.io.File
-
 sealed interface ConfigMsg
 data class HandleConfigQuery(val env: CommandEnvelope) : ConfigMsg
 
@@ -40,6 +40,8 @@ class ConfigComponent(
     private val persistedDecryptKeys = config.decryptKeys.toMutableMap()
     private var maskSensitiveLogs = config.maskSensitiveLogs
     private var apiToken: String = config.apiToken
+    /** Last log level chosen in the dashboard; `""` means "whatever logback.xml sets". */
+    private var logLevel: String = config.logLevel
     private var hostsConfig: HostsConfig = config.hosts
     /** Serializes writes: the startup save and a config-change save may otherwise interleave. */
     private val saveLock = Mutex()
@@ -56,8 +58,10 @@ class ConfigComponent(
             }
             json["maskSensitiveLogs"]?.jsonPrimitive?.content?.toBooleanStrictOrNull()?.let { maskSensitiveLogs = it }
             json["apiToken"]?.jsonPrimitive?.content?.let { apiToken = it }
+            json["logLevel"]?.jsonPrimitive?.content?.let { logLevel = it }
             hostsConfig = HostsConfig.fromJson(json)
             SensitiveStringRegistry.enabled = maskSensitiveLogs
+            applyLogLevel()
             applyHosts()
             logger.info("Loaded config from ${config.configPath}")
         } catch (e: Exception) {
@@ -79,6 +83,7 @@ class ConfigComponent(
                                 put("streamAuthKey", persistedStreamAuthKey)
                                 put("maskSensitiveLogs", maskSensitiveLogs)
                                 put("apiToken", apiToken)
+                                put("logLevel", logLevel)
                                 hostsConfig.toJson().forEach { (k, v) -> put(k, v) }
                                 put("decryptKeys", buildJsonObject {
                                     persistedDecryptKeys.forEach { (k, v) -> put(k, v) }
@@ -91,6 +96,19 @@ class ConfigComponent(
                     logger.error("Failed to save config to ${config.configPath}: ${e.message}", e)
                 }
             }
+        }
+    }
+
+    /** Re-apply the persisted log level; a blank value leaves logback.xml in charge. */
+    private fun applyLogLevel() {
+        if (logLevel.isBlank()) return
+        val applied = LogLevels.apply(logLevel)
+        if (applied == null) {
+            logger.warn("Ignoring unknown persisted log level '{}'", logLevel)
+            logLevel = ""
+        } else {
+            logLevel = applied
+            logger.info("Applied persisted log level {}", applied)
         }
     }
 
@@ -150,8 +168,52 @@ class ConfigComponent(
                 OkResponse
             }
 
+            // The effective level is read back from Logback rather than from `logLevel`, so the
+            // reported value is what is actually filtering logs even when logback.xml set it.
+            is GetLogLevel -> ConfigResponse(LogLevels.currentOrDefault())
+            is SetLogLevel -> {
+                val applied = LogLevels.apply(env.command.level)
+                if (applied == null) {
+                    logger.warn("Rejected unknown log level '{}'", env.command.level)
+                    ConfigResponse(null)
+                } else {
+                    logLevel = applied
+                    logger.info("Runtime log level set to {}", applied)
+                    scope.launch(Dispatchers.IO) { saveConfig() }
+                    ConfigResponse(applied)
+                }
+            }
+
             else -> return
         }
         eventBus.publish(CommandAck(env.id, ack))
     }
+
+    // —— Diagnostics ——
+
+    /**
+     * `/diagnose?actor=ConfigComponent`
+     *
+     * Secrets are reported as presence and length only — the auth key, API token and decrypt keys
+     * must never leave the process through a debug endpoint.
+     */
+    override suspend fun diagnose(section: String, args: Map<String, String>): JsonObject =
+        baseDiagnose(buildJsonObject {
+            put("maskSensitiveLogs", maskSensitiveLogs)
+            put("logLevel", logLevel.ifBlank { "(logback.xml)" })
+            put("effectiveLogLevel", LogLevels.currentOrDefault())
+            put("configPath", config.configPath)
+            put("hosts", JsonObject(hostsConfig.toJson()))
+            put("streamAuthKey", buildJsonObject {
+                put("present", persistedStreamAuthKey.isNotBlank())
+                put("length", persistedStreamAuthKey.length)
+            })
+            put("apiToken", buildJsonObject {
+                put("present", apiToken.isNotBlank())
+                put("length", apiToken.length)
+            })
+            put("decryptKeys", buildJsonArray {
+                persistedDecryptKeys.keys.forEach { add(JsonPrimitive(it)) }
+            })
+        })
 }

--- a/src/main/kotlin/github/rikacelery/v3/components/DownloaderComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/DownloaderComponent.kt
@@ -2,6 +2,7 @@ package github.rikacelery.v3.components
 
 import github.rikacelery.v3.core.Actor
 import github.rikacelery.v3.core.DataChannel
+import github.rikacelery.v3.core.Diagnosable
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.OrderedEmitter
 import github.rikacelery.v3.data.DownloadMeta
@@ -22,6 +23,10 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import java.io.ByteArrayOutputStream
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
@@ -438,5 +443,33 @@ class DownloaderComponent(
                 logger.debug("Probe failed for host={}", host)
             }
         }
+    }
+
+    // —— Diagnostics ——
+
+    override val diagnoseSections: List<String>
+        get() = listOf(Diagnosable.SECTION_SUMMARY, Diagnosable.SECTION_ENTRIES)
+
+    /** `/diagnose?actor=DownloaderComponent[&room=<id>]` — per-room queue depth and in-flight work. */
+    override suspend fun diagnose(section: String, args: Map<String, String>): JsonObject {
+        val roomFilter = args["room"]?.toLongOrNull()
+        val selected = rooms.entries
+            .filter { roomFilter == null || it.key == roomFilter }
+            .sortedBy { it.key }
+        return baseDiagnose(buildJsonObject {
+            put("roomCount", rooms.size)
+            put("initialConcurrency", initialConcurrency)
+            put("entries", buildJsonArray {
+                selected.forEach { (roomId, active) ->
+                    add(buildJsonObject {
+                        put("roomId", roomId)
+                        put("active", active.active)
+                        put("generation", active.generation)
+                        put("nextIndex", active.idx.get() + 1)
+                        put("inFlight", active.runningJobs.size)
+                    })
+                }
+            })
+        })
     }
 }

--- a/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
@@ -1,5 +1,8 @@
 package github.rikacelery.v3.components
 
+import github.rikacelery.v3.core.BusMonitor
+import github.rikacelery.v3.core.Diagnosable
+import github.rikacelery.v3.core.Diagnostics
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
 import github.rikacelery.v3.data.HostsConfig
@@ -9,6 +12,7 @@ import github.rikacelery.v3.data.RuntimeTuning
 import github.rikacelery.v3.events.*
 import github.rikacelery.v3.ml.PredictionEngine
 import github.rikacelery.v3.utils.CdnSelector
+import github.rikacelery.v3.utils.LogLevels
 import github.rikacelery.v3.utils.ModelSchedule
 import io.ktor.http.*
 import io.ktor.network.tls.certificates.*
@@ -23,6 +27,8 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.utils.io.ClosedWriteChannelException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.*
 import kotlinx.serialization.json.*
@@ -458,6 +464,132 @@ class HttpServerComponent(
                     } catch (e: Exception) {
                         logger.error("Failed to update hosts config", e)
                         call.respondText("Error: ${e.message}", status = HttpStatusCode.InternalServerError)
+                    }
+                }
+                // ── Dynamic log level ──────────────────────────────────────────────
+                get("/log/level") {
+                    val current = requestBus.request<ConfigResponse>(GetLogLevel).value as? String
+                    call.respond(buildJsonObject {
+                        put("level", current ?: LogLevels.DEFAULT)
+                        put("levels", buildJsonArray { LogLevels.LEVELS.forEach { add(it) } })
+                    })
+                }
+                post("/log/level") {
+                    val requested = call.receiveParameters()["level"].orEmpty()
+                    val applied = requestBus.request<ConfigResponse>(SetLogLevel(requested)).value as? String
+                    if (applied == null) {
+                        call.respondText(
+                            "Unknown log level: $requested",
+                            status = HttpStatusCode.BadRequest
+                        )
+                    } else {
+                        persistConfig()
+                        call.respondText(applied)
+                    }
+                }
+                // ── Introspection ──────────────────────────────────────────────────
+                // Internal state of every live component, with its state machines' current state
+                // and recent transitions. This is the endpoint to reach for when a room is stuck
+                // but the logs look healthy.
+                get("/diagnose") {
+                    val actor = call.request.queryParameters["actor"]
+                    if (actor.isNullOrBlank()) {
+                        call.respond(buildJsonObject {
+                            put("components", Diagnostics.index()["components"] ?: JsonArray(emptyList()))
+                            // Whether any debug tap is currently armed: the taps cost nothing while
+                            // this list is empty, so an operator can confirm they were released.
+                            put("monitor", buildJsonObject {
+                                put("watched", buildJsonArray {
+                                    BusMonitor.CATEGORIES.filter { BusMonitor.wants(it) }.forEach { add(JsonPrimitive(it)) }
+                                })
+                                put("dropped", BusMonitor.dropped.get())
+                            })
+                        })
+                        return@get
+                    }
+                    val component = Diagnostics.get(actor)
+                    if (component == null) {
+                        call.respondText(
+                            "Unknown actor: $actor; known: ${Diagnostics.names()}",
+                            status = HttpStatusCode.NotFound
+                        )
+                        return@get
+                    }
+                    val section = call.request.queryParameters["section"] ?: Diagnosable.SECTION_SUMMARY
+                    val args = call.request.queryParameters.entries().associate { it.key to it.value.first() }
+                    val body = try {
+                        component.diagnose(section, args)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        logger.error("diagnose failed actor={} section={}", actor, section, e)
+                        buildJsonObject { put("error", e.message ?: e::class.simpleName ?: "diagnose failed") }
+                    }
+                    call.respond(body)
+                }
+
+                // Live tap on the request bus / data channel / event bus: one JSON object per line.
+                // The taps are only armed while this connection is open, so nothing pays for them
+                // when nobody is watching. A slow client loses the oldest lines instead of stalling
+                // anything — the sink is a DROP_OLDEST shared flow.
+                get("/debug/stream") {
+                    val requested = (call.request.queryParameters["types"]
+                        ?: "${BusMonitor.REQUEST},${BusMonitor.DATA}")
+                        .split(',')
+                        .map { it.trim().lowercase() }
+                        .filter { it in BusMonitor.CATEGORIES }
+                        .distinct()
+                    if (requested.isEmpty()) {
+                        call.respondText(
+                            "No valid types; use a comma-separated subset of ${BusMonitor.CATEGORIES}",
+                            status = HttpStatusCode.BadRequest
+                        )
+                        return@get
+                    }
+                    call.respondTextWriter(contentType = ContentType.parse("application/x-ndjson")) {
+                        BusMonitor.watch(requested)
+                        try {
+                            coroutineScope {
+                                val out = Channel<JsonObject>(
+                                    capacity = 1024,
+                                    onBufferOverflow = BufferOverflow.DROP_OLDEST
+                                )
+                                val pump = launch {
+                                    BusMonitor.events.collect { line ->
+                                        val kind = line["kind"]?.jsonPrimitive?.content
+                                        if (kind != null && kind in requested) out.trySend(line)
+                                    }
+                                }
+                                try {
+                                    write(
+                                        buildJsonObject {
+                                            put("kind", "hello")
+                                            put("types", buildJsonArray { requested.forEach { add(JsonPrimitive(it)) } })
+                                            put("dropped", BusMonitor.dropped.get())
+                                        }.toString() + "\n"
+                                    )
+                                    flush()
+                                    while (true) {
+                                        // A heartbeat is not filler: writing is the only way to
+                                        // learn that the client went away, so an idle stream must
+                                        // still touch the socket or the taps would never be released.
+                                        val line = withTimeoutOrNull(runtimeTuning.debugStreamHeartbeat) {
+                                            out.receiveCatching().getOrNull()
+                                        }
+                                        val payload = line ?: buildJsonObject {
+                                            put("kind", "heartbeat")
+                                            put("dropped", BusMonitor.dropped.get())
+                                        }
+                                        write(payload.toString() + "\n")
+                                        flush()
+                                    }
+                                } finally {
+                                    pump.cancel()
+                                }
+                            }
+                        } finally {
+                            BusMonitor.unwatch(requested)
+                        }
                     }
                 }
                 // ── Favorites import ───────────────────────────────────────────────

--- a/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
@@ -130,7 +130,9 @@ class MetricComponent(
                 }
 
                 is SegmentGapDetected -> {
-                    metrics.getOrPut(e.roomId) { RoomMetrics() }.segmentMissing.set(e.gap.toLong())
+                    // accumulate: the metric is declared a counter and named _total, and one gap
+                    // event carries only that event's missing count
+                    metrics.getOrPut(e.roomId) { RoomMetrics() }.segmentMissing.addAndGet(e.gap.toLong())
                 }
 
                 is SegmentsSkipped -> {
@@ -213,7 +215,7 @@ class MetricComponent(
             sb.appendLine("# HELP xhrec_avg_latency_ms Average download latency ms")
             sb.appendLine("# TYPE xhrec_avg_latency_ms gauge")
             sb.appendLine("xhrec_avg_latency_ms{roomId=\"$roomId\"} $avgLatency")
-            sb.appendLine("# HELP xhrec_segment_missing_total Missing segments")
+            sb.appendLine("# HELP xhrec_segment_missing_total Segments the playlist never advertised (a jump in segment ids)")
             sb.appendLine("# TYPE xhrec_segment_missing_total counter")
             sb.appendLine("xhrec_segment_missing_total{roomId=\"$roomId\"} ${m.segmentMissing.get()}")
             sb.appendLine("# HELP xhrec_segments_skipped_total Playlist entries already covered by the resume mark")

--- a/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
@@ -36,6 +36,8 @@ data class RoomMetrics(
     val totalLatencyMs: AtomicLong = AtomicLong(0),
     val fileCount: AtomicLong = AtomicLong(0),
     val segmentMissing: AtomicLong = AtomicLong(0),
+    /** Playlist entries skipped because the resume mark already covered them (never reset). */
+    val segmentsSkipped: AtomicLong = AtomicLong(0),
     val runningUrls: ConcurrentHashMap<String, RunningUrlInfo> = ConcurrentHashMap()
 )
 
@@ -58,6 +60,7 @@ class MetricComponent(
         is DownloadError -> OnMetricEvent(event)
         is DownloadStarted -> OnMetricEvent(event)
         is SegmentGapDetected -> OnMetricEvent(event)
+        is SegmentsSkipped -> OnMetricEvent(event)
         is FileReady -> OnMetricEvent(event)
         is FileProcessed -> OnMetricEvent(event)
         is PlaylistRefreshed -> OnMetricEvent(event)
@@ -128,6 +131,10 @@ class MetricComponent(
 
                 is SegmentGapDetected -> {
                     metrics.getOrPut(e.roomId) { RoomMetrics() }.segmentMissing.set(e.gap.toLong())
+                }
+
+                is SegmentsSkipped -> {
+                    metrics.getOrPut(e.roomId) { RoomMetrics() }.segmentsSkipped.addAndGet(e.count.toLong())
                 }
 
                 is FileReady -> {
@@ -209,6 +216,9 @@ class MetricComponent(
             sb.appendLine("# HELP xhrec_segment_missing_total Missing segments")
             sb.appendLine("# TYPE xhrec_segment_missing_total counter")
             sb.appendLine("xhrec_segment_missing_total{roomId=\"$roomId\"} ${m.segmentMissing.get()}")
+            sb.appendLine("# HELP xhrec_segments_skipped_total Playlist entries already covered by the resume mark")
+            sb.appendLine("# TYPE xhrec_segments_skipped_total counter")
+            sb.appendLine("xhrec_segments_skipped_total{roomId=\"$roomId\"} ${m.segmentsSkipped.get()}")
             sb.appendLine("# HELP xhrec_files_total Files produced")
             sb.appendLine("# TYPE xhrec_files_total counter")
             sb.appendLine("xhrec_files_total{roomId=\"$roomId\"} ${m.fileCount.get()}")

--- a/src/main/kotlin/github/rikacelery/v3/components/RoomComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/RoomComponent.kt
@@ -19,6 +19,10 @@ import github.rikacelery.v3.utils.asString
 import kotlinx.coroutines.*
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.Duration
@@ -445,6 +449,35 @@ class RoomComponent(
         bytes >= 1024 * 1024 -> "${bytes / (1024 * 1024)}Mi"
         bytes >= 1024 -> "${bytes / 1024}Ki"
         else -> "${bytes}Bi"
+    }
+
+    // —— Diagnostics ——
+
+    /** `/diagnose?actor=RoomComponent[&room=<id>]` — the room registry the rest of the system reads. */
+    override suspend fun diagnose(section: String, args: Map<String, String>): JsonObject {
+        val roomFilter = args["room"]?.toLongOrNull()
+        val selected = rooms.values.filter { roomFilter == null || it.id == roomFilter }.sortedBy { it.id }
+        return baseDiagnose(buildJsonObject {
+            put("ready", ready)
+            put("roomCount", rooms.size)
+            put("listConfPath", listConfPath)
+            put("entries", buildJsonArray {
+                selected.forEach { room ->
+                    add(buildJsonObject {
+                        put("id", room.id)
+                        put("name", room.name)
+                        put("status", room.status)
+                        put("quality", room.quality)
+                        put("recordPublic", room.recordPublic)
+                        put("recordFreeSpy", room.recordFreeSpy)
+                        put("autoPayTicket", room.autoPayTicket)
+                        put("autoPaySpy", room.autoPaySpy)
+                        put("timeLimitSec", if (room.timeLimit == Duration.INFINITE) 0L else room.timeLimit.inWholeSeconds)
+                        put("sizeLimitBytes", room.sizeLimitBytes)
+                    })
+                }
+            })
+        })
     }
 }
 

--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -2,8 +2,11 @@ package github.rikacelery.v3.components
 
 import github.rikacelery.v3.api.ApiClient
 import github.rikacelery.v3.core.Actor
+import github.rikacelery.v3.core.BusMonitor
+import github.rikacelery.v3.core.Diagnosable
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
+import github.rikacelery.v3.core.diagnose
 import github.rikacelery.v3.data.Hosts
 import github.rikacelery.v3.data.Room
 import github.rikacelery.v3.data.RoomHint
@@ -28,6 +31,13 @@ import github.rikacelery.v3.utils.PathSingleOrNull
 import github.rikacelery.v3.utils.asInt
 import github.rikacelery.v3.utils.asString
 import github.rikacelery.v3.utils.withRetry
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.request.*
 import io.ktor.client.statement.bodyAsText
@@ -40,7 +50,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
-import kotlinx.serialization.json.JsonObject
 import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.abs
@@ -139,6 +148,20 @@ class SchedulerEntry(
     var configuredPkey: String = ""
 
     // —— Resume state ——
+    /**
+     * The last media segment id this room recorded, used as the resume mark for the *next*
+     * session of the *same* stream. It is passed to the session as `startIndex`, where anything
+     * with a segment id at or below it is skipped so a cut never re-downloads what was just
+     * written.
+     *
+     * The platform's segment ids restart with each broadcast, so this mark is only meaningful
+     * while one stream keeps running. Carrying it across a `BeginPreconfig` (the stream is
+     * resolved from scratch) or a `BackToArmed` would compare a fresh broadcast's low ids against
+     * a previous broadcast's high mark and silently skip *every* segment — the session then
+     * reports `Recording` while downloading nothing until the counter climbs past the stale mark.
+     * Every path that re-resolves the stream therefore clears it; only `RestartRecording`
+     * (a time/size limit cut inside one stream) keeps it.
+     */
     var lastIndex: Long? = null
     var lastFailReason: String? = null
     private var tokenFailure: TokenFailure? = null
@@ -259,8 +282,8 @@ class SchedulerEntry(
             val keyName = matchPkey(master)
             val variant = selectVariant(master, settings.quality)
             val url = resolveVariantUrl(variant, keyName, token)
-            if (!playlistUsable(url)) {
-                return SchedulerSignal(roomId, SchedulerEvent.PreconfigFailed, SchedulerDriveData(failReason = "playlist unusable"))
+            playlistProbe(url)?.let { reason ->
+                return SchedulerSignal(roomId, SchedulerEvent.PreconfigFailed, SchedulerDriveData(failReason = reason))
             }
             SchedulerSignal(
                 roomId, SchedulerEvent.PreconfigDone,
@@ -452,22 +475,35 @@ class SchedulerEntry(
      * Verify the resolved variant playlist is actually fetchable before handing it to the Session.
      *
      * A probe that outlives the watchdog is a *failed probe*, not a cancellation of the caller:
-     * [withTimeoutOrNull] consumes the timeout so the answer stays `false` and the preconfig loop
+     * [withTimeoutOrNull] consumes the timeout so the answer stays a reason and the preconfig loop
      * can retry. Letting the timeout escape as a `CancellationException` (which the catch below
      * rethrows, as [SchedulerEntry.preconfigSignal] does) silently cancelled that loop, leaving
      * the room stuck in `Preconfiguring` with no log, no hint and no retry.
+     *
+     * Returns `null` when the playlist is fetchable, or a human-readable reason when it is not.
+     * Note this deliberately checks *reachability only*: whether the playlist carries media
+     * segments is a property of the live stream that changes second to second, so rejecting on it
+     * here would refuse rooms that are about to be recordable. A stream that stops delivering is
+     * caught by the session's own stall watchdog instead.
      */
-    private suspend fun playlistUsable(url: String): Boolean {
-        return try {
+    private suspend fun playlistProbe(url: String): String? {
+        // The probe reports success as an *empty string*, not null: `withTimeoutOrNull` also yields
+        // null, so a null-able "ok" would be indistinguishable from a probe that ran out of time.
+        val reason: String? = try {
             withTimeoutOrNull(component.runtimeTuning.preconfigProbeTimeout) {
                 val client = component.httpClientProvider.proxied("preconfig_$roomId")
                 val response = withRetry(2) { client.get(url) }
-                response.status.value in 200..299
-            } ?: false
+                if (response.status.value in 200..299) "" else "playlist unusable (HTTP ${response.status.value})"
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            false
+            "playlist unusable (${e.message ?: e::class.simpleName})"
+        }
+        return when {
+            reason == null -> "playlist unusable (probe timed out)"
+            reason.isEmpty() -> null
+            else -> reason
         }
     }
 }
@@ -495,9 +531,14 @@ private fun buildSchedulerFsm(ctx: SchedulerEntry) =
                 if (d?.newQuality != null) settings = settings.copy(quality = d.newQuality)
             }
             on(SchedulerEvent.SessionExit) to KEEP
-            on(SchedulerEvent.BeginPreconfig) to SchedulerState.Preconfiguring action { startPreconfigLoop() }
+            // Entering preconfig means the stream is (re)resolved from scratch, so a resume mark
+            // from an earlier recording is meaningless here — see the note on `lastIndex`.
+            on(SchedulerEvent.BeginPreconfig) to SchedulerState.Preconfiguring action {
+                lastIndex = null
+                startPreconfigLoop()
+            }
             on(SchedulerEvent.RestartRecording) to KEEP
-            on(SchedulerEvent.BackToArmed) to KEEP
+            on(SchedulerEvent.BackToArmed) to KEEP action { lastIndex = null }
             on(SchedulerEvent.StopAndWait) to KEEP
             // A preconfig attempt runs off the actor loop, so its answer can already be in the
             // mailbox when BackToArmed cancels the loop. The room is armed because it is no longer
@@ -565,8 +606,11 @@ private fun buildSchedulerFsm(ctx: SchedulerEntry) =
             on(SchedulerEvent.ChangeQuality) to KEEP action { d ->
                 if (d?.newQuality != null) settings = settings.copy(quality = d.newQuality)
             }
-            on(SchedulerEvent.BeginPreconfig) to KEEP
-            on(SchedulerEvent.BackToArmed) to SchedulerState.Armed action { stopPreconfigLoop() }
+            on(SchedulerEvent.BeginPreconfig) to KEEP action { lastIndex = null }
+            on(SchedulerEvent.BackToArmed) to SchedulerState.Armed action {
+                lastIndex = null
+                stopPreconfigLoop()
+            }
             on(SchedulerEvent.RestartRecording) to KEEP
             on(SchedulerEvent.StopAndWait) to KEEP
             // No session of this entry is running yet — recording only starts on PreconfigDone — so
@@ -629,7 +673,10 @@ private fun buildSchedulerFsm(ctx: SchedulerEntry) =
                 }
             }
             on(SchedulerEvent.RestartRecording) to KEEP action { restartRecording() }
-            on(SchedulerEvent.BeginPreconfig) to SchedulerState.Preconfiguring action { startPreconfigLoop() }
+            on(SchedulerEvent.BeginPreconfig) to SchedulerState.Preconfiguring action {
+                lastIndex = null
+                startPreconfigLoop()
+            }
             on(SchedulerEvent.BackToArmed) to SchedulerState.Armed action {
                 currentKind = ""
                 lastIndex = null
@@ -668,7 +715,10 @@ private fun buildSchedulerFsm(ctx: SchedulerEntry) =
                 }
             }
             on(SchedulerEvent.RestartRecording) to SchedulerState.Recording action { restartRecording() }
-            on(SchedulerEvent.BeginPreconfig) to SchedulerState.Preconfiguring action { startPreconfigLoop() }
+            on(SchedulerEvent.BeginPreconfig) to SchedulerState.Preconfiguring action {
+                lastIndex = null
+                startPreconfigLoop()
+            }
             on(SchedulerEvent.BackToArmed) to SchedulerState.Armed action {
                 currentKind = ""
                 lastIndex = null
@@ -888,4 +938,63 @@ class SchedulerComponent(
         }
         eventBus.publish(CommandAck(env.id, ack))
     }
+
+    // —— Diagnostics ——
+
+    override val diagnoseSections: List<String>
+        get() = listOf(Diagnosable.SECTION_SUMMARY, Diagnosable.SECTION_ENTRIES, Diagnosable.SECTION_HISTORY)
+
+    /**
+     * `/diagnose?actor=SchedulerComponent[&section=entries|history][&room=<id>]`
+     *
+     * A room stuck mid-pipeline is usually explained by its transition history — e.g. a resume
+     * mark (`lastIndex`) carried across a stream change — so that is reported next to the state.
+     */
+    override suspend fun diagnose(section: String, args: Map<String, String>): JsonObject {
+        val roomFilter = args["room"]?.toLongOrNull()
+        val selected = entries.values
+            .filter { roomFilter == null || it.roomId == roomFilter }
+            .sortedBy { it.roomId }
+        return baseDiagnose(buildJsonObject {
+            put("gracefulStop", gracefulStop)
+            put("roomCount", entries.size)
+            put("states", buildJsonObject {
+                entries.forEach { (id, e) -> put(id.toString(), JsonPrimitive(e.fsm.currentState.toString())) }
+            })
+            if (section == Diagnosable.SECTION_HISTORY) {
+                put("history", buildJsonObject {
+                    selected.forEach { put(it.roomId.toString(), it.fsm.diagnose()["history"] ?: JsonArray(emptyList())) }
+                })
+            } else {
+                put("entries", buildJsonArray { selected.forEach { add(it.diagnoseJson()) } })
+            }
+        })
+    }
+}
+
+/**
+ * One scheduler entry as an operator needs to see it. URLs are reduced to their path and the
+ * configured token is never emitted: this view is served over HTTP and must not leak credentials.
+ */
+internal fun SchedulerEntry.diagnoseJson(): JsonObject = buildJsonObject {
+    put("roomId", roomId)
+    put("roomName", roomName)
+    put("roomStatus", roomStatus)
+    put("streamStatus", streamStatus)
+    put("kind", currentKind)
+    put("freeSpyExhausted", freeSpyExhausted)
+    put("lastIndex", lastIndex?.let { JsonPrimitive(it) } ?: JsonNull)
+    put("lastFailReason", lastFailReason?.let { JsonPrimitive(it) } ?: JsonNull)
+    put("playlistPath", JsonPrimitive(playlistUrl.substringBefore('?')))
+    put("configuredQuality", configuredQuality)
+    put("configuredPkey", configuredPkey)
+    put("preconfigLoopRunning", preconfigLoop.isRunning)
+    put("settings", buildJsonObject {
+        put("quality", settings.quality)
+        put("recordPublic", settings.recordPublic)
+        put("recordFreeSpy", settings.recordFreeSpy)
+        put("autoPayTicket", settings.autoPayTicket)
+        put("autoPaySpy", settings.autoPaySpy)
+    })
+    put("fsm", fsm.diagnose())
 }

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -102,6 +102,16 @@ data class SessionHandleCommand(val env: CommandEnvelope) : SessionMsg
 
 private val sessionLogger = LoggerFactory.getLogger("v3.SessionEntry")
 
+/**
+ * Renders a segment-id range for logs: a single id when both ends are the same, so a one-element
+ * set does not read as a typo (`id 1063` rather than `id 1063..1063`).
+ */
+internal fun formatIdRange(min: Long?, max: Long?): String = when {
+    min == null || max == null -> "?"
+    min == max -> min.toString()
+    else -> "$min..$max"
+}
+
 class CircleCache(private val capacity: Int) {
     private val set = LinkedHashSet<String>()
     @Synchronized fun add(url: String): Boolean {
@@ -242,6 +252,7 @@ class SessionEntry(
                 unseen.add(Segment(init, -1))
             }
         }
+        val markBefore = lastSegmentId
         var skipped = 0L
         var skippedMin = Long.MAX_VALUE
         var skippedMax = Long.MIN_VALUE
@@ -275,9 +286,13 @@ class SessionEntry(
             // TRACE, not DEBUG, because skipping is the *steady state* of a healthy recording — the
             // playlist is a sliding window that re-lists what was just written — so at DEBUG (the
             // default root level) it would be unconditional noise on every poll of every room.
+            //
+            // Both numbers matter and neither is the window: `id` is the skipped set's own range
+            // (a single id when one entry was skipped), and the mark is printed as a transition
+            // because it has already advanced to this poll's newest id by the time we get here.
             sessionLogger.trace(
-                "roomId={} skipped {} segment(s) at or below the resume mark (id {}..{}, lastSegmentId={})",
-                roomId, skipped, skippedMin, skippedMax, lastSegmentId
+                "roomId={} skipped {} of {} advertised segment(s): id {} already at or below the resume mark (mark {} -> {})",
+                roomId, skipped, parsed.segments.size, formatIdRange(skippedMin, skippedMax), markBefore, lastSegmentId
             )
         }
         return unseen
@@ -293,8 +308,8 @@ class SessionEntry(
         if (progressed) {
             if (skipStreakReported || waitedMs >= component.runtimeTuning.thresholdSkipLogDelay.inWholeMilliseconds) {
                 sessionLogger.info(
-                    "roomId={} caught up with the resume mark after {}s; {} skip event(s) (id {}..{}), recording resumed",
-                    roomId, waitedMs / 1000, skippedInStreak, skippedMinId, skippedMaxId
+                    "roomId={} caught up with the resume mark after {}s; {} skip event(s) (id {}), recording resumed",
+                    roomId, waitedMs / 1000, skippedInStreak, formatIdRange(skippedMinId, skippedMaxId)
                 )
             }
             resetSkipStreak()
@@ -305,8 +320,8 @@ class SessionEntry(
             // Report what actually happened — the playlist stopped advancing — rather than a count of
             // skip events, which repeats the same ids on every poll and greatly overstates the total.
             sessionLogger.warn(
-                "roomId={} no new segments for {}s: the playlist still advertises only id {}..{}, all already covered by the resume mark ({})",
-                roomId, waitedMs / 1000, skippedMinId, skippedMaxId, lastSegmentId
+                "roomId={} no new segments for {}s: the playlist still advertises only id {}, all already covered by the resume mark ({})",
+                roomId, waitedMs / 1000, formatIdRange(skippedMinId, skippedMaxId), lastSegmentId
             )
         }
     }

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -172,6 +172,20 @@ class SessionEntry(
 
     /** Playlist entries the most recent poll skipped because the resume mark already covered them. */
     var lastPollSkipped: Int = 0
+
+    /**
+     * Highest segment id this session has already queued, used to notice a *discontinuity*: if the
+     * playlist advances from id N to id M > N + 1 between two polls, the ids in between were
+     * published by the stream but never advertised to us, so they are lost.
+     *
+     * Deliberately session-local (reset on every `StartRecording`), unlike the resume mark: a room
+     * that was restarted, or was not being polled at all, has an expected gap at the seam, and
+     * counting that as data loss would flag every limit cut.
+     */
+    var previousNewSegmentId: Long? = null
+
+    /** Missing segments detected by the most recent poll (a discontinuity in the segment ids). */
+    var lastPollGap: Int = 0
     val circleCache = CircleCache(100)
 
     // —— scope / loop timer ——
@@ -231,6 +245,7 @@ class SessionEntry(
         var skipped = 0L
         var skippedMin = Long.MAX_VALUE
         var skippedMax = Long.MIN_VALUE
+        val newIds = mutableListOf<Long>()
         for (seg in parsed.segments) {
             val segId = component.m3u8Parser.segmentIDFromUrl(seg.url)?.toLong()
             if (segId != null) {
@@ -245,9 +260,11 @@ class SessionEntry(
             if (circleCache.add(seg.url)) {
                 unseen.add(seg)
                 lastPollEnqueuedMedia = true
-                if (segId != null) lastSegmentId = segId
+                if (segId != null) newIds += segId
             }
         }
+        if (newIds.isNotEmpty()) lastSegmentId = newIds.max()
+        noteSegmentGap(newIds)
         lastPollSkipped = skipped.toInt()
         if (skipped > 0) {
             if (skipStreakSince == null) skipStreakSince = Instant.now()
@@ -300,6 +317,39 @@ class SessionEntry(
         skippedMinId = null
         skippedMaxId = null
         skipStreakReported = false
+    }
+
+    /**
+     * Compares this poll's newly queued segment ids with the previous poll's to detect a
+     * discontinuity. Ids the stream published but never advertised to us — because the playlist
+     * advanced past them between two polls, or because the window itself carries a hole — are lost,
+     * and nothing else in the pipeline can see that: a segment we never hear about never fails and
+     * never reaches the downloader.
+     *
+     * Every id from `previous + 1` up to the newest id is expected exactly once, so the count is
+     * simply how many of those are absent. The first poll that queues anything only establishes the
+     * baseline: the session has no earlier observation to compare against, and after a restart the
+     * seam is expected rather than lost.
+     */
+    private fun noteSegmentGap(newIds: List<Long>) {
+        lastPollGap = 0
+        if (newIds.isEmpty()) return
+        val previous = previousNewSegmentId
+        previousNewSegmentId = if (previous == null) newIds.max() else maxOf(previous, newIds.max())
+        if (previous == null) return
+
+        var expected = previous + 1
+        var missing = 0L
+        for (id in newIds.sorted()) {
+            if (id >= expected) missing += id - expected
+            expected = maxOf(expected, id + 1)
+        }
+        if (missing <= 0) return
+        lastPollGap = missing.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+        sessionLogger.debug(
+            "roomId={} playlist went from segment id {} to {}; {} id(s) in between were never advertised",
+            roomId, previous, newIds.max(), missing
+        )
     }
 
     internal suspend fun fetchPlaylistSignal(): SessionMsg {
@@ -360,6 +410,8 @@ private fun buildSessionFsm(ctx: SessionEntry) =
                 totalBytes = 0L
                 retryCount = 0
                 resetSkipStreak()
+                previousNewSegmentId = null
+                lastPollGap = 0
                 circleCache.clear()   // a new file must re-download the init; media segments are skipped via the lastSegmentId threshold
                 launch { component.dataChannel.send(StreamStart(roomId, roomName, startTime, quality)) }
                 // LiveEventSource expands the WebSocket channel set and metrics start counting on this
@@ -392,6 +444,11 @@ private fun buildSessionFsm(ctx: SessionEntry) =
                 // "skips climbing while downloads stand still" is an alertable stall signal.
                 if (lastPollSkipped > 0) {
                     launch { component.publish(SegmentsSkipped(roomId, lastPollSkipped)) }
+                }
+                // A discontinuity is real data loss and nothing downstream can observe it: a segment
+                // that was never advertised never fails and never reaches the downloader.
+                if (lastPollGap > 0) {
+                    launch { component.publish(SegmentGapDetected(roomId, lastPollGap)) }
                 }
                 // An init-only (or segment-less) playlist is a stream that is not delivering:
                 // without this the session reports Recording forever and writes nothing.
@@ -645,6 +702,8 @@ internal fun SessionEntry.diagnoseJson(): JsonObject = buildJsonObject {
     put("playlistLoopRunning", playlistLoop.isRunning)
     put("lastPollSegmentCount", lastPollSegmentCount)
     put("lastPollSkipped", lastPollSkipped)
+    put("lastPollGap", lastPollGap)
+    put("previousNewSegmentId", previousNewSegmentId?.let { JsonPrimitive(it) } ?: JsonNull)
     put("lastPollEnqueuedMedia", lastPollEnqueuedMedia)
     put("skipStreak", buildJsonObject {
         put("since", skipStreakSince?.toString()?.let { JsonPrimitive(it) } ?: JsonNull)

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -2,8 +2,10 @@ package github.rikacelery.v3.components
 
 import github.rikacelery.v3.core.Actor
 import github.rikacelery.v3.core.DataChannel
+import github.rikacelery.v3.core.Diagnosable
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
+import github.rikacelery.v3.core.diagnose
 import github.rikacelery.v3.data.RuntimeTuning
 import github.rikacelery.v3.data.StreamStart
 import github.rikacelery.v3.events.*
@@ -21,6 +23,13 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.*
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.slf4j.LoggerFactory
 import java.security.SecureRandom
 import java.time.Instant
@@ -126,7 +135,40 @@ class SessionEntry(
     var segmentIndex: Int = 0
     var totalBytes: Long = 0L
     var startTime: Instant = Instant.now()
+
+    /**
+     * When this session last made progress: a new media segment entered the download queue, or one
+     * finished downloading. A session that keeps polling a playlist with no media segments would
+     * otherwise sit in `Recording` forever while the dashboard reports a recording that never
+     * writes a byte, so the poll loop watches this and ends the session once it goes stale.
+     */
+    var lastProgressAt: Instant = Instant.now()
     var retryCount: Int = 0
+
+    // —— Resume-mark skip accounting ——
+    // The playlist normally lists a window that overlaps what was already downloaded, so some
+    // segments are skipped on every poll. That is silent by design. A *persistent* skip streak
+    // means every advertised segment is at or below the resume mark — the stream has not caught
+    // up and nothing is being recorded — which is worth one log line, not one per poll.
+    var skipStreakSince: Instant? = null
+    var skippedInStreak: Long = 0L
+    var skippedMinId: Long? = null
+    var skippedMaxId: Long? = null
+    var skipStreakReported: Boolean = false
+
+    /**
+     * Whether the most recent poll enqueued at least one *media* segment. The init segment is
+     * enqueued regardless of the resume mark, so it must not count as progress: a session that
+     * only ever downloads the init is exactly the stall the skip streak reports.
+     */
+    var lastPollEnqueuedMedia: Boolean = false
+
+    /**
+     * Media segments advertised by the most recent playlist. Together with [lastPollEnqueuedMedia]
+     * and [lastSegmentId] this separates the two ways a session can idle in `Recording`: a playlist
+     * that carries no segments at all, versus one whose segments are all behind the resume mark.
+     */
+    var lastPollSegmentCount: Int = 0
     val circleCache = CircleCache(100)
 
     // —— scope / loop timer ——
@@ -163,6 +205,7 @@ class SessionEntry(
     internal fun onSegment(d: RecordingDriveData?) {
         val gen = d?.segGeneration ?: return
         if (gen != generation) return
+        lastProgressAt = Instant.now()
         totalBytes += d.segBytes ?: 0L
         if (sizeLimitBytes > 0 && totalBytes >= sizeLimitBytes) {
             launch {
@@ -175,23 +218,82 @@ class SessionEntry(
 
     internal fun computeUnseen(parsed: ParsedPlaylist): List<Segment> {
         val unseen = mutableListOf<Segment>()
+        lastPollEnqueuedMedia = false
+        lastPollSegmentCount = parsed.segments.size
         parsed.initUrl?.let { init ->
             if (circleCache.add(init)) {
                 unseen.add(Segment(init, -1))
             }
         }
+        var skipped = 0L
+        var skippedMin = Long.MAX_VALUE
+        var skippedMax = Long.MIN_VALUE
         for (seg in parsed.segments) {
             val segId = component.m3u8Parser.segmentIDFromUrl(seg.url)?.toLong()
             if (segId != null) {
                 val threshold = lastSegmentId
-                if (threshold != null && segId <= threshold) continue
+                if (threshold != null && segId <= threshold) {
+                    skipped++
+                    if (segId < skippedMin) skippedMin = segId
+                    if (segId > skippedMax) skippedMax = segId
+                    continue
+                }
             }
             if (circleCache.add(seg.url)) {
                 unseen.add(seg)
+                lastPollEnqueuedMedia = true
                 if (segId != null) lastSegmentId = segId
             }
         }
+        if (skipped > 0) {
+            if (skipStreakSince == null) skipStreakSince = Instant.now()
+            skippedInStreak += skipped
+            if (skippedMinId == null || skippedMin < skippedMinId!!) skippedMinId = skippedMin
+            if (skippedMaxId == null || skippedMax > skippedMaxId!!) skippedMaxId = skippedMax
+            // Which segments were dropped: one aggregated DEBUG line per poll, never per segment.
+            sessionLogger.debug(
+                "roomId={} skipped {} segment(s) at or below the resume mark (id {}{}..{}, lastSegmentId={})",
+                roomId, skipped,
+                if (parsed.segments.size > 1 || skipped > 1) "range " else "",
+                skippedMin, skippedMax, lastSegmentId
+            )
+        }
         return unseen
+    }
+
+    /**
+     * Called once per poll after the unseen set is known. Reports a skip streak that has lasted
+     * long enough to mean "this room is not recording", and the moment it catches up.
+     */
+    internal fun noteSkipOutcome(progressed: Boolean) {
+        val since = skipStreakSince ?: return
+        val waitedMs = JavaDuration.between(since, Instant.now()).toMillis()
+        if (progressed) {
+            if (skipStreakReported || waitedMs >= component.runtimeTuning.thresholdSkipLogDelay.inWholeMilliseconds) {
+                sessionLogger.info(
+                    "roomId={} caught up with the resume mark after {}s; {} segment(s) (id {}..{}) were skipped, recording resumed",
+                    roomId, waitedMs / 1000, skippedInStreak, skippedMinId, skippedMaxId
+                )
+            }
+            resetSkipStreak()
+            return
+        }
+        if (!skipStreakReported && waitedMs >= component.runtimeTuning.thresholdSkipLogDelay.inWholeMilliseconds) {
+            skipStreakReported = true
+            sessionLogger.warn(
+                "roomId={} recording stalled behind the resume mark: every advertised segment id ({}..{}) is <= lastSegmentId={}; " +
+                    "{} segment(s) skipped over {}s and nothing downloaded",
+                roomId, skippedMinId, skippedMaxId, lastSegmentId, skippedInStreak, waitedMs / 1000
+            )
+        }
+    }
+
+    internal fun resetSkipStreak() {
+        skipStreakSince = null
+        skippedInStreak = 0L
+        skippedMinId = null
+        skippedMaxId = null
+        skipStreakReported = false
     }
 
     internal suspend fun fetchPlaylistSignal(): SessionMsg {
@@ -247,9 +349,11 @@ private fun buildSessionFsm(ctx: SessionEntry) =
         state(RecordingState.Idle) {
             on(RecordingEvent.StartRecording) to RecordingState.Recording action {
                 startTime = Instant.now()
+                lastProgressAt = startTime
                 segmentIndex = 0
                 totalBytes = 0L
                 retryCount = 0
+                resetSkipStreak()
                 circleCache.clear()   // a new file must re-download the init; media segments are skipped via the lastSegmentId threshold
                 launch { component.dataChannel.send(StreamStart(roomId, roomName, startTime, quality)) }
                 // LiveEventSource expands the WebSocket channel set and metrics start counting on this
@@ -274,7 +378,28 @@ private fun buildSessionFsm(ctx: SessionEntry) =
                 val unseen = computeUnseen(parsed)
                 segmentIndex += unseen.size
                 if (unseen.isNotEmpty()) {
+                    lastProgressAt = Instant.now()
                     launch { component.downloader.tell(DoDownload(Download(roomId, unseen, segmentIndex, generation))) }
+                }
+                noteSkipOutcome(progressed = lastPollEnqueuedMedia)
+                // An init-only (or segment-less) playlist is a stream that is not delivering:
+                // without this the session reports Recording forever and writes nothing.
+                val stalledMs = JavaDuration.between(lastProgressAt, Instant.now()).toMillis()
+                if (stalledMs >= component.runtimeTuning.sessionStallTimeout.inWholeMilliseconds) {
+                    sessionLogger.warn(
+                        "Recording stalled roomId={}: no segment for {}s (playlist carries {} media segment(s)); " +
+                            "ending the session so the room re-resolves its stream",
+                        roomId, stalledMs / 1000, parsed.segments.size
+                    )
+                    launch {
+                        component.tell(
+                            SessionSignal(
+                                roomId, RecordingEvent.PlaylistUnusable,
+                                RecordingDriveData(failReason = "no segment for ${stalledMs / 1000}s")
+                            )
+                        )
+                    }
+                    return@action
                 }
                 val elapsedMs = JavaDuration.between(startTime, Instant.now()).toMillis()
                 if (timeLimit != Duration.INFINITE && elapsedMs >= timeLimit.inWholeMilliseconds) {
@@ -324,6 +449,13 @@ private fun buildSessionFsm(ctx: SessionEntry) =
             on(RecordingEvent.SegmentDownloaded) to KEEP
             on(RecordingEvent.LimitReached) to KEEP
             on(RecordingEvent.PlaylistRetryExhausted) to KEEP
+            // A playlist fetch already in flight when the cut started still answers after the
+            // transition. The session is closing, so the answer carries nothing to act on —
+            // dropping it is correct and keeps it from reading as an illegal transition.
+            on(RecordingEvent.PlaylistFetched) to KEEP
+            on(RecordingEvent.PlaylistFetchFailed) to KEEP
+            on(RecordingEvent.PlaylistUnusable) to KEEP
+            on(RecordingEvent.InitChanged) to KEEP
         }
     }
 
@@ -450,4 +582,64 @@ class SessionComponent(
             }
         }
     }
+
+    // —— Diagnostics ——
+
+    override val diagnoseSections: List<String>
+        get() = listOf(Diagnosable.SECTION_SUMMARY, Diagnosable.SECTION_ENTRIES, Diagnosable.SECTION_HISTORY)
+
+    /**
+     * `/diagnose?actor=SessionComponent[&section=entries|history][&room=<id>]`
+     *
+     * This is where a "recording but downloading nothing" room is explained: the resume mark
+     * (`lastSegmentId`), the segment counter, when the session last made progress, and whether
+     * the playlist poll loop is still running.
+     */
+    override suspend fun diagnose(section: String, args: Map<String, String>): JsonObject {
+        val roomFilter = args["room"]?.toLongOrNull()
+        val selected = entries.values
+            .filter { roomFilter == null || it.roomId == roomFilter }
+            .sortedBy { it.roomId }
+        return baseDiagnose(buildJsonObject {
+            put("sessionCount", entries.size)
+            put("states", buildJsonObject {
+                entries.forEach { (id, e) -> put(id.toString(), JsonPrimitive(e.fsm.currentState.toString())) }
+            })
+            if (section == Diagnosable.SECTION_HISTORY) {
+                put("history", buildJsonObject {
+                    selected.forEach { put(it.roomId.toString(), it.fsm.diagnose()["history"] ?: JsonArray(emptyList())) }
+                })
+            } else {
+                put("entries", buildJsonArray { selected.forEach { add(it.diagnoseJson()) } })
+            }
+        })
+    }
+}
+
+/** One session entry as an operator needs it; the playlist URL keeps only its path. */
+internal fun SessionEntry.diagnoseJson(): JsonObject = buildJsonObject {
+    put("roomId", roomId)
+    put("roomName", roomName)
+    put("quality", quality)
+    put("playlistPath", playlistUrl.substringBefore('?'))
+    put("startedAt", startTime.toString())
+    put("sinceStartMs", JavaDuration.between(startTime, Instant.now()).toMillis())
+    put("lastProgressAt", lastProgressAt.toString())
+    put("noProgressMs", JavaDuration.between(lastProgressAt, Instant.now()).toMillis())
+    put("segmentIndex", segmentIndex)
+    put("lastSegmentId", lastSegmentId?.let { JsonPrimitive(it) } ?: JsonNull)
+    put("lastInitUrl", lastInitUrl?.substringBefore('?')?.let { JsonPrimitive(it) } ?: JsonNull)
+    put("totalBytes", totalBytes)
+    put("retryCount", retryCount)
+    put("playlistLoopRunning", playlistLoop.isRunning)
+    put("lastPollSegmentCount", lastPollSegmentCount)
+    put("lastPollEnqueuedMedia", lastPollEnqueuedMedia)
+    put("skipStreak", buildJsonObject {
+        put("since", skipStreakSince?.toString()?.let { JsonPrimitive(it) } ?: JsonNull)
+        put("skipped", skippedInStreak)
+        put("minId", skippedMinId?.let { JsonPrimitive(it) } ?: JsonNull)
+        put("maxId", skippedMaxId?.let { JsonPrimitive(it) } ?: JsonNull)
+        put("reported", skipStreakReported)
+    })
+    put("fsm", fsm.diagnose())
 }

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -169,6 +169,9 @@ class SessionEntry(
      * that carries no segments at all, versus one whose segments are all behind the resume mark.
      */
     var lastPollSegmentCount: Int = 0
+
+    /** Playlist entries the most recent poll skipped because the resume mark already covered them. */
+    var lastPollSkipped: Int = 0
     val circleCache = CircleCache(100)
 
     // —— scope / loop timer ——
@@ -245,17 +248,19 @@ class SessionEntry(
                 if (segId != null) lastSegmentId = segId
             }
         }
+        lastPollSkipped = skipped.toInt()
         if (skipped > 0) {
             if (skipStreakSince == null) skipStreakSince = Instant.now()
             skippedInStreak += skipped
             if (skippedMinId == null || skippedMin < skippedMinId!!) skippedMinId = skippedMin
             if (skippedMaxId == null || skippedMax > skippedMaxId!!) skippedMaxId = skippedMax
-            // Which segments were dropped: one aggregated DEBUG line per poll, never per segment.
-            sessionLogger.debug(
-                "roomId={} skipped {} segment(s) at or below the resume mark (id {}{}..{}, lastSegmentId={})",
-                roomId, skipped,
-                if (parsed.segments.size > 1 || skipped > 1) "range " else "",
-                skippedMin, skippedMax, lastSegmentId
+            // Which entries were dropped: one aggregated line per poll, never per segment. This is
+            // TRACE, not DEBUG, because skipping is the *steady state* of a healthy recording — the
+            // playlist is a sliding window that re-lists what was just written — so at DEBUG (the
+            // default root level) it would be unconditional noise on every poll of every room.
+            sessionLogger.trace(
+                "roomId={} skipped {} segment(s) at or below the resume mark (id {}..{}, lastSegmentId={})",
+                roomId, skipped, skippedMin, skippedMax, lastSegmentId
             )
         }
         return unseen
@@ -271,7 +276,7 @@ class SessionEntry(
         if (progressed) {
             if (skipStreakReported || waitedMs >= component.runtimeTuning.thresholdSkipLogDelay.inWholeMilliseconds) {
                 sessionLogger.info(
-                    "roomId={} caught up with the resume mark after {}s; {} segment(s) (id {}..{}) were skipped, recording resumed",
+                    "roomId={} caught up with the resume mark after {}s; {} skip event(s) (id {}..{}), recording resumed",
                     roomId, waitedMs / 1000, skippedInStreak, skippedMinId, skippedMaxId
                 )
             }
@@ -280,10 +285,11 @@ class SessionEntry(
         }
         if (!skipStreakReported && waitedMs >= component.runtimeTuning.thresholdSkipLogDelay.inWholeMilliseconds) {
             skipStreakReported = true
+            // Report what actually happened — the playlist stopped advancing — rather than a count of
+            // skip events, which repeats the same ids on every poll and greatly overstates the total.
             sessionLogger.warn(
-                "roomId={} recording stalled behind the resume mark: every advertised segment id ({}..{}) is <= lastSegmentId={}; " +
-                    "{} segment(s) skipped over {}s and nothing downloaded",
-                roomId, skippedMinId, skippedMaxId, lastSegmentId, skippedInStreak, waitedMs / 1000
+                "roomId={} no new segments for {}s: the playlist still advertises only id {}..{}, all already covered by the resume mark ({})",
+                roomId, waitedMs / 1000, skippedMinId, skippedMaxId, lastSegmentId
             )
         }
     }
@@ -382,6 +388,11 @@ private fun buildSessionFsm(ctx: SessionEntry) =
                     launch { component.downloader.tell(DoDownload(Download(roomId, unseen, segmentIndex, generation))) }
                 }
                 noteSkipOutcome(progressed = lastPollEnqueuedMedia)
+                // Mirror the skip to the metrics so the number in the log is verifiable there, and so
+                // "skips climbing while downloads stand still" is an alertable stall signal.
+                if (lastPollSkipped > 0) {
+                    launch { component.publish(SegmentsSkipped(roomId, lastPollSkipped)) }
+                }
                 // An init-only (or segment-less) playlist is a stream that is not delivering:
                 // without this the session reports Recording forever and writes nothing.
                 val stalledMs = JavaDuration.between(lastProgressAt, Instant.now()).toMillis()
@@ -633,6 +644,7 @@ internal fun SessionEntry.diagnoseJson(): JsonObject = buildJsonObject {
     put("retryCount", retryCount)
     put("playlistLoopRunning", playlistLoop.isRunning)
     put("lastPollSegmentCount", lastPollSegmentCount)
+    put("lastPollSkipped", lastPollSkipped)
     put("lastPollEnqueuedMedia", lastPollEnqueuedMedia)
     put("skipStreak", buildJsonObject {
         put("since", skipStreakSince?.toString()?.let { JsonPrimitive(it) } ?: JsonNull)

--- a/src/main/kotlin/github/rikacelery/v3/components/WriterComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/WriterComponent.kt
@@ -2,6 +2,7 @@ package github.rikacelery.v3.components
 
 import github.rikacelery.v3.core.Actor
 import github.rikacelery.v3.core.DataChannel
+import github.rikacelery.v3.core.Diagnosable
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.data.StreamData
 import github.rikacelery.v3.data.StreamEnd
@@ -12,6 +13,10 @@ import github.rikacelery.v3.events.FileReady
 import github.rikacelery.v3.events.WriterFatal
 import github.rikacelery.v3.hooks.WriterHook
 import kotlinx.coroutines.*
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.io.FileOutputStream
@@ -212,5 +217,33 @@ class WriterComponent(
         val m = (ms % 3600_000) / 60_000
         val s = (ms % 60_000) / 1000
         return if (h > 0) "${h}h${m}m${s}s" else if (m > 0) "${m}m${s}s" else "${s}s"
+    }
+
+    // —— Diagnostics ——
+
+    override val diagnoseSections: List<String>
+        get() = listOf(Diagnosable.SECTION_SUMMARY, Diagnosable.SECTION_ENTRIES)
+
+    /** `/diagnose?actor=WriterComponent` — open files and their byte counts. */
+    override suspend fun diagnose(section: String, args: Map<String, String>): JsonObject {
+        val now = Instant.now()
+        return baseDiagnose(buildJsonObject {
+            put("openFiles", files.size)
+            put("minOutputBytes", minOutputBytes)
+            put("tmpDir", tmpDir.absolutePath)
+            put("entries", buildJsonArray {
+                files.values.sortedBy { it.roomId }.forEach { active ->
+                    add(buildJsonObject {
+                        put("roomId", active.roomId)
+                        put("roomName", active.roomName)
+                        put("quality", active.quality)
+                        put("bytesWritten", active.bytesWritten)
+                        put("willKeep", active.bytesWritten >= minOutputBytes)
+                        put("openMs", java.time.Duration.between(active.startTime, now).toMillis())
+                        put("file", active.file.absolutePath)
+                    })
+                }
+            })
+        })
     }
 }

--- a/src/main/kotlin/github/rikacelery/v3/core/Actor.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/Actor.kt
@@ -2,6 +2,9 @@ package github.rikacelery.v3.core
 
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.slf4j.LoggerFactory
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -13,10 +16,17 @@ abstract class Actor<T : Any>(
     val name: String,
     protected val eventBus: EventBus,
     parentScope: CoroutineScope,
-    mailboxCapacity: Int = 256,
+    private val mailboxCapacity: Int = 256,
     private val slowHandlerThresholdMs: Long = 500
-) {
+) : Diagnosable {
     private val mailbox = Channel<T>(capacity = mailboxCapacity)
+
+    /**
+     * Messages accepted but not yet handled. Kept by hand rather than read from the channel so it
+     * needs no experimental API, and it is the cheapest way to tell "this actor is behind" from
+     * "this actor is idle" when a component looks stuck.
+     */
+    private val mailboxDepth = AtomicInteger(0)
     protected val logger = LoggerFactory.getLogger(name)
     internal val scope =
         parentScope + SupervisorJob() + CoroutineName(name) + CoroutineExceptionHandler { context, throwable ->
@@ -59,6 +69,7 @@ abstract class Actor<T : Any>(
     fun start() {
         check(!started) { "$name already started" }
         started = true
+        Diagnostics.register(this)
 
         scope.launch {
             onStart(scope)
@@ -79,6 +90,8 @@ abstract class Actor<T : Any>(
                     throw e
                 } catch (e: Exception) {
                     onError(e, msg)
+                } finally {
+                    mailboxDepth.decrementAndGet()
                 }
             }
         }
@@ -86,12 +99,26 @@ abstract class Actor<T : Any>(
 
     fun stop() {
         started = false
+        Diagnostics.unregister(name)
         mailbox.close()
         scope.cancel()
     }
 
-    suspend fun tell(msg: T) {
-        mailbox.send(msg)
+    suspend fun tell(msg: T) = enqueue(msg)
+
+    /**
+     * Single funnel for every message entering the mailbox, so [mailboxDepth] stays truthful.
+     * Bus subscriptions enqueue directly rather than through [tell], and counting only one of the
+     * two paths made the depth drift negative.
+     */
+    private suspend fun enqueue(msg: T) {
+        mailboxDepth.incrementAndGet()
+        try {
+            mailbox.send(msg)
+        } catch (e: Throwable) {
+            mailboxDepth.decrementAndGet()
+            throw e
+        }
     }
 
     protected suspend fun <E : Any> subscribe(kClass: KClass<E>) {
@@ -104,7 +131,7 @@ abstract class Actor<T : Any>(
                 signalSubscriptionsReady()
             }
         ) { event ->
-            wrapEvent(event)?.let { mailbox.send(it) }
+            wrapEvent(event)?.let { enqueue(it) }
         }
     }
 
@@ -117,4 +144,26 @@ abstract class Actor<T : Any>(
     }
 
     open suspend fun wrapEvent(event: Any): T? = null
+
+    // —— Diagnostics ——
+    // Every actor answers `GET /diagnose?actor=<name>` out of the box. Components with real
+    // internal state (schedulers, sessions, the writer) override `diagnoseSections`/`diagnose`
+    // and merge [baseDiagnose] into their own object so liveness fields are always present.
+
+    override val diagnoseName: String get() = name
+
+    override val diagnoseSections: List<String>
+        get() = listOf(Diagnosable.SECTION_SUMMARY)
+
+    override suspend fun diagnose(section: String, args: Map<String, String>): JsonObject = baseDiagnose()
+
+    /** Fields every actor can report: identity, liveness and mailbox backlog. */
+    protected fun baseDiagnose(extra: JsonObject = JsonObject(emptyMap())): JsonObject = buildJsonObject {
+        put("actor", name)
+        put("type", this@Actor::class.simpleName ?: "")
+        put("started", started)
+        put("mailboxDepth", mailboxDepth.get())
+        put("mailboxCapacity", mailboxCapacity)
+        extra.forEach { (key, value) -> put(key, value) }
+    }
 }

--- a/src/main/kotlin/github/rikacelery/v3/core/BusMonitor.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/BusMonitor.kt
@@ -1,0 +1,87 @@
+package github.rikacelery.v3.core
+
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Live tap on the three internal transports, feeding the dashboard's debug stream.
+ *
+ * The taps are **off by default and cost nothing while nobody watches**: every producer checks
+ * [wants] before it builds an event, so an unwatched recorder never pays for serialization.
+ * A watcher declares the categories it cares about, and emissions go through a
+ * [MutableSharedFlow] with `DROP_OLDEST`, so a slow HTTP client can never stall a bus, a
+ * download or an actor — it just loses the oldest lines of a debug stream.
+ *
+ * Categories:
+ *  - `request`  — a [RequestBus] round trip (command, outcome, latency)
+ *  - `data`     — a [DataChannel] message (stream start/data/end/event)
+ *  - `event`    — an [EventBus] publish
+ */
+object BusMonitor {
+
+    const val REQUEST = "request"
+    const val DATA = "data"
+    const val EVENT = "event"
+
+    /** Every category a client may ask for. */
+    val CATEGORIES = listOf(REQUEST, DATA, EVENT)
+
+    private val _events = MutableSharedFlow<JsonObject>(
+        replay = 0,
+        extraBufferCapacity = 2048,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+
+    /** The wire feed: one [JsonObject] per line for every watched message. */
+    val events: SharedFlow<JsonObject> = _events.asSharedFlow()
+
+    /** Watchers per category; a category is produced only while at least one client wants it. */
+    private val watchers = ConcurrentHashMap<String, AtomicInteger>()
+
+    /** Lines dropped because no subscriber kept up. Surfaced to the client so it knows to narrow. */
+    val dropped = AtomicLong(0)
+
+    private val sequence = AtomicLong(0)
+
+    /** Registers one watcher for each of [types]; pair with [unwatch]. */
+    fun watch(types: Collection<String>) {
+        types.forEach { watchers.computeIfAbsent(it) { AtomicInteger() }.incrementAndGet() }
+    }
+
+    /** Removes the watcher registered by a matching [watch] call. */
+    fun unwatch(types: Collection<String>) {
+        types.forEach { watchers[it]?.decrementAndGet() }
+    }
+
+    /** True when at least one client is watching [type], i.e. the tap should build its event. */
+    fun wants(type: String): Boolean {
+        val counter = watchers[type] ?: return false
+        return counter.get() > 0
+    }
+
+    /** Emits one monitored line. Never suspends and never throws: debug must not break the pipeline. */
+    fun record(type: String, body: JsonObject) {
+        if (!wants(type)) return
+        val line = buildJsonObject {
+            put("seq", sequence.incrementAndGet())
+            put("ts", System.currentTimeMillis())
+            put("kind", type)
+            body.forEach { (k, v) -> put(k, v) }
+        }
+        if (!_events.tryEmit(line)) dropped.incrementAndGet()
+    }
+
+    /** Truncates a value for the wire so one huge payload cannot flood the stream. */
+    fun shorten(value: Any?, max: Int = 300): String {
+        val text = value?.toString() ?: "null"
+        return if (text.length <= max) text else text.take(max) + "…"
+    }
+}

--- a/src/main/kotlin/github/rikacelery/v3/core/DataChannel.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/DataChannel.kt
@@ -3,6 +3,8 @@ package github.rikacelery.v3.core
 import github.rikacelery.v3.data.DataChannelMsg
 import github.rikacelery.v3.hooks.DataHook
 import kotlinx.coroutines.channels.Channel
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.slf4j.LoggerFactory
 
 class DataChannel(capacity: Int = 256) {
@@ -23,6 +25,13 @@ class DataChannel(capacity: Int = 256) {
             m = hook.intercept(m ?: return)
         }
         val msg = m ?: return
+        if (BusMonitor.wants(BusMonitor.DATA)) {
+            BusMonitor.record(BusMonitor.DATA, buildJsonObject {
+                put("msg", msg::class.simpleName ?: "")
+                roomOf(msg)?.let { put("room", it) }
+                if (msg is github.rikacelery.v3.data.StreamData) put("bytes", msg.data.size)
+            })
+        }
         val result = channel.trySend(msg)
         if (result.isFailure) {
             logger.warn("DataChannel full, dropping {} (room={})", msg::class.simpleName, roomOf(msg))

--- a/src/main/kotlin/github/rikacelery/v3/core/Diagnose.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/Diagnose.kt
@@ -1,0 +1,110 @@
+package github.rikacelery.v3.core
+
+import github.rikacelery.v3.fsm.ERROR
+import github.rikacelery.v3.fsm.KEEP
+import github.rikacelery.v3.fsm.NextState
+import github.rikacelery.v3.fsm.StateMachine
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * An internal-state view of one component, served by `GET /diagnose`.
+ *
+ * Implementations are called from an HTTP coroutine, **not** from the actor loop, so they must
+ * read state that is safe to read concurrently (a `ConcurrentHashMap`, or a snapshot guarded by
+ * the owner). They are strictly best-effort observation: a diagnose call must never mutate
+ * component state, must never suspend on the actor's mailbox, and must stay cheap — this is the
+ * endpoint an operator reaches for when something is stuck.
+ *
+ * [section] selects a sub-view (`summary`, `entries`, `history`, …); [args] carries free-form
+ * filters such as `room=<id>` and `limit=<n>`. The returned object is embedded verbatim in the
+ * response, so the shape is owned by each component.
+ */
+interface Diagnosable {
+
+    /** Stable key used in `/diagnose?actor=<name>`; defaults to the actor name. */
+    val diagnoseName: String
+
+    /** Sections this component understands, `summary` first. */
+    val diagnoseSections: List<String> get() = listOf(SECTION_SUMMARY)
+
+    /** Builds the view for [section]. Unknown sections should fall back to the summary. */
+    suspend fun diagnose(section: String, args: Map<String, String>): JsonObject
+
+    companion object {
+        const val SECTION_SUMMARY = "summary"
+        const val SECTION_ENTRIES = "entries"
+        const val SECTION_HISTORY = "history"
+    }
+}
+
+/**
+ * Registry of live components, so the HTTP layer can enumerate them without holding a reference
+ * to every actor. `Actor` registers itself on start and removes itself on stop.
+ */
+object Diagnostics {
+
+    private val components = ConcurrentHashMap<String, Diagnosable>()
+
+    fun register(component: Diagnosable) {
+        components[component.diagnoseName] = component
+    }
+
+    fun unregister(name: String) {
+        components.remove(name)
+    }
+
+    fun names(): List<String> = components.keys.sorted()
+
+    fun get(name: String): Diagnosable? = components[name]
+
+    fun all(): List<Diagnosable> = components.values.sortedBy { it.diagnoseName }
+
+    /** Index of every registered component and the sections it exposes. */
+    fun index(): JsonObject = buildJsonObject {
+        put("components", buildJsonArray {
+            all().forEach { component ->
+                add(buildJsonObject {
+                    put("name", component.diagnoseName)
+                    put("sections", buildJsonArray {
+                        component.diagnoseSections.forEach { add(JsonPrimitive(it)) }
+                    })
+                })
+            }
+        })
+    }
+}
+
+/**
+ * Renders a state machine's current state plus its bounded transition history.
+ *
+ * History is the whole point: a stuck room is usually explained by *how* it got to its current
+ * state (e.g. a resume mark carried across a stream change), not by the state alone.
+ */
+fun <S, E, D, C> StateMachine<S, E, D, C>.diagnose(): JsonObject = buildJsonObject {
+    put("state", currentState.toString())
+    put("history", history.toJsonArray())
+}
+
+private fun <S, E> List<github.rikacelery.v3.fsm.TransitionRecord<S, E>>.toJsonArray(): JsonArray =
+    buildJsonArray {
+        this@toJsonArray.forEach { record ->
+            add(buildJsonObject {
+                put("at", record.timestamp)
+                put("from", record.fromState.toString())
+                put("event", record.event.toString())
+                put("target", when (val t = record.target) {
+                    is KEEP -> "KEEP"
+                    is ERROR -> "ERROR"
+                    is NextState -> "-> ${t.state}"
+                    else -> t.toString()
+                })
+                if (record.data != null) put("data", BusMonitor.shorten(record.data))
+            })
+        }
+    }

--- a/src/main/kotlin/github/rikacelery/v3/core/Diagnose.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/Diagnose.kt
@@ -102,7 +102,6 @@ private fun <S, E> List<github.rikacelery.v3.fsm.TransitionRecord<S, E>>.toJsonA
                     is KEEP -> "KEEP"
                     is ERROR -> "ERROR"
                     is NextState -> "-> ${t.state}"
-                    else -> t.toString()
                 })
                 if (record.data != null) put("data", BusMonitor.shorten(record.data))
             })

--- a/src/main/kotlin/github/rikacelery/v3/core/EventBus.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/EventBus.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.slf4j.LoggerFactory
 import kotlin.reflect.KClass
 
@@ -39,13 +41,21 @@ class EventBus {
             e = hook.intercept(e ?: return)
         }
         if (e == null) return
+        val published = e
 
-        if (_events.tryEmit(e)) {
+        if (BusMonitor.wants(BusMonitor.EVENT)) {
+            BusMonitor.record(BusMonitor.EVENT, buildJsonObject {
+                put("event", published::class.simpleName ?: "")
+                put("detail", BusMonitor.shorten(published, 200))
+            })
+        }
+
+        if (_events.tryEmit(published)) {
             checkBacklogCleared()
         } else {
             // Bus is saturated: log and drop the message. Subscribers are designed
             // to be fast; a saturated buffer indicates a stalled/blocked subscriber.
-            recordBacklog(e)
+            recordBacklog(published)
         }
     }
 

--- a/src/main/kotlin/github/rikacelery/v3/core/RequestBus.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/RequestBus.kt
@@ -5,6 +5,8 @@ import github.rikacelery.v3.events.CommandEnvelope
 import github.rikacelery.v3.events.ErrorResponse
 import github.rikacelery.v3.events.Request
 import kotlinx.coroutines.*
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
@@ -45,17 +47,34 @@ class RequestBus(
         val id = idGen.incrementAndGet()
         val deferred = CompletableDeferred<Any>(parent = currentCoroutineContext().job)
         pending[id] = deferred
+        val startedAt = System.currentTimeMillis()
 
         eventBus.publish(CommandEnvelope(id, cmd))
 
         return try {
             val result = withTimeout(timeoutMs) { deferred.await() }
-            if (result is ErrorResponse) throw RequestErrorException(cmd, result.message)
+            if (result is ErrorResponse) {
+                monitor(id, cmd, startedAt, "error: ${result.message}")
+                throw RequestErrorException(cmd, result.message)
+            }
+            monitor(id, cmd, startedAt, result)
             result as T
         } catch (e: TimeoutCancellationException) {
             logger.error("Request timeout: cmd=$cmd, timeout=${timeoutMs}ms", e)
             pending.remove(id)?.cancel()
+            monitor(id, cmd, startedAt, "TIMEOUT after ${timeoutMs}ms (no component answered)")
             throw RequestTimeoutException(cmd, timeoutMs)
         }
+    }
+
+    /** Feeds one round trip to the debug stream; a no-op unless a client is watching. */
+    private fun monitor(id: Long, cmd: Request, startedAt: Long, outcome: Any?) {
+        if (!BusMonitor.wants(BusMonitor.REQUEST)) return
+        BusMonitor.record(BusMonitor.REQUEST, buildJsonObject {
+            put("id", id)
+            put("cmd", BusMonitor.shorten(cmd))
+            put("ms", System.currentTimeMillis() - startedAt)
+            put("result", BusMonitor.shorten(outcome))
+        })
     }
 }

--- a/src/main/kotlin/github/rikacelery/v3/data/Config.kt
+++ b/src/main/kotlin/github/rikacelery/v3/data/Config.kt
@@ -13,5 +13,10 @@ data class SystemConfig(
     val listConfPath: String = "list.conf",
     val configPath: String = "xhrec.json",
     val maskSensitiveLogs: Boolean = true,
-    val apiToken: String = ""
+    val apiToken: String = "",
+    /**
+     * Root log level chosen in the dashboard, or `""` to keep whatever `logback.xml` configures.
+     * Applied at startup and whenever the dashboard changes it.
+     */
+    val logLevel: String = ""
 )

--- a/src/main/kotlin/github/rikacelery/v3/data/RuntimeTuning.kt
+++ b/src/main/kotlin/github/rikacelery/v3/data/RuntimeTuning.kt
@@ -15,6 +15,25 @@ data class RuntimeTuning(
     val preconfigProbeTimeout: Duration = 5.seconds,
     val playlistPollInterval: Duration = 3.seconds,
     val playlistFetchTimeout: Duration = 10.seconds,
+    /**
+     * How long a recording session may go without a single new media segment before it is
+     * considered stalled. A playlist that only advertises `#EXT-X-MAP` (init) and no
+     * `#EXT-X-MOUFLON` segments keeps the session in `Recording` while nothing is downloaded, so
+     * without this watchdog the dashboard reports a recording that produces no bytes.
+     */
+    val sessionStallTimeout: Duration = 90.seconds,
+    /**
+     * How long segments may keep being skipped by the resume mark (`lastSegmentId`) before the
+     * session says so once at WARN. Short skips are normal after a cut and must stay silent; a
+     * long one means the stream is behind the resume mark and nothing is being recorded.
+     */
+    val thresholdSkipLogDelay: Duration = 30.seconds,
+    /**
+     * How often the debug stream writes a heartbeat when nothing else is happening. The write is
+     * also how a dropped client is detected: an idle connection is never noticed otherwise, and the
+     * bus taps would stay armed — and keep costing — for the life of the process.
+     */
+    val debugStreamHeartbeat: Duration = 10.seconds,
     val httpRestartDelay: Duration = 500.milliseconds,
     val downloaderRaceDelay: Duration = 8.seconds,
     val downloaderAttemptTimeout: Duration = 25.seconds,

--- a/src/main/kotlin/github/rikacelery/v3/events/Commands.kt
+++ b/src/main/kotlin/github/rikacelery/v3/events/Commands.kt
@@ -93,6 +93,14 @@ object GetHostsConfig : Request {
 data class SetHostsConfig(val hosts: github.rikacelery.v3.data.HostsConfig) : Request {
     override fun toString() = "SetHostsConfig(platformHosts=${hosts.platformHosts}, ws=${hosts.webSocketHosts}, hls=${hosts.hlsHosts})"
 }
+/** Current root log level, for the dashboard's dynamic log-level control. */
+object GetLogLevel : Request {
+    override fun toString() = "GetLogLevel"
+}
+/** Sets the root log level at runtime; the choice is persisted to xhrec.json. */
+data class SetLogLevel(val level: String) : Request {
+    override fun toString() = "SetLogLevel(level=$level)"
+}
 
 // ── Downloader commands (Actor messages, not RequestBus) ──
 

--- a/src/main/kotlin/github/rikacelery/v3/events/Events.kt
+++ b/src/main/kotlin/github/rikacelery/v3/events/Events.kt
@@ -87,6 +87,20 @@ data class SegmentGapDetected(
 ) {
     override fun toString() = "SegmentGapDetected(roomId=$roomId, gap=$gap)"
 }
+/**
+ * How many playlist entries a poll skipped because the resume mark already covered them.
+ *
+ * This is the ordinary steady state, not a fault: the media playlist is a sliding window that
+ * re-lists segments already written, so a healthy poll skips the overlap and enqueues only what is
+ * new. It is reported so the same number is visible in the metrics as in the logs — a rising skip
+ * counter while `downloaded_total` stands still is a stalled room.
+ */
+data class SegmentsSkipped(
+    val roomId: Long,
+    val count: Int
+) {
+    override fun toString() = "SegmentsSkipped(roomId=$roomId, count=$count)"
+}
 data class PlaylistRefreshed(
     val roomId: Long,
     val latencyMs: Long,

--- a/src/main/kotlin/github/rikacelery/v3/fsm/Fsm.kt
+++ b/src/main/kotlin/github/rikacelery/v3/fsm/Fsm.kt
@@ -57,14 +57,20 @@ class StateMachine<S, E, D, C>(
     private val context: C,
     private val maxHistorySize: Int = 10
 ) {
+    @Volatile
     var currentState: S = initialState
         private set
 
     private var driving = false
+    private val historyLock = Any()
     private val _history = ArrayDeque<TransitionRecord<S, E>>(maxHistorySize)
 
+    /**
+     * Snapshot of the recent transitions. Guarded because diagnostics read it from the HTTP
+     * thread while the owning actor keeps driving transitions on its own loop.
+     */
     val history: List<TransitionRecord<S, E>>
-        get() = _history.toList()
+        get() = synchronized(historyLock) { _history.toList() }
 
     private val traceLogger = LoggerFactory.getLogger("v3.Fsm")
 
@@ -121,23 +127,26 @@ class StateMachine<S, E, D, C>(
     }
 
     private fun recordTransition(from: S, event: E, data: Any?, target: Target<S>) {
-        if (_history.size >= maxHistorySize) {
-            _history.removeFirst()
-        }
         val time = LocalDateTime.now().format(DateTimeFormatter.ofPattern("HH:mm:ss.SSS"))
-        _history.addLast(TransitionRecord(time, from, event, data, target))
+        synchronized(historyLock) {
+            if (_history.size >= maxHistorySize) {
+                _history.removeFirst()
+            }
+            _history.addLast(TransitionRecord(time, from, event, data, target))
+        }
     }
 
     private fun dumpHistoryAndThrow(exception: FsmException): Nothing {
+        val snapshot = synchronized(historyLock) { _history.toList() }
         val sb = StringBuilder()
         sb.appendLine("=".repeat(60))
         val title = if (exception is FsmException.ActionFail) "ACTION CRASH" else "FSM ILLEGAL TRANSITION"
         sb.appendLine("$title: ${exception.message}")
-        sb.appendLine("recent ${_history.size} transitions:")
-        if (_history.isEmpty()) {
+        sb.appendLine("recent ${snapshot.size} transitions:")
+        if (snapshot.isEmpty()) {
             sb.appendLine("   (no history, failed at initial state)")
         } else {
-            _history.forEachIndexed { index, record ->
+            snapshot.forEachIndexed { index, record ->
                 sb.appendLine("   ${index + 1}. $record")
             }
         }

--- a/src/main/kotlin/github/rikacelery/v3/utils/LogLevels.kt
+++ b/src/main/kotlin/github/rikacelery/v3/utils/LogLevels.kt
@@ -1,0 +1,60 @@
+package github.rikacelery.v3.utils
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.LoggerContext
+import org.slf4j.Logger.ROOT_LOGGER_NAME
+import org.slf4j.LoggerFactory
+
+/**
+ * Runtime log-level control backing the dashboard's log-level picker.
+ *
+ * The level is applied to the Logback **root** logger, which is what every `github.rikacelery.*`
+ * logger inherits from, so one change covers the whole recorder. The per-logger overrides in
+ * `logback.xml` (netty, ktor, jetty) deliberately keep their own level — they are the noisy
+ * libraries, and raising the root level to TRACE should not flood the log with their internals.
+ *
+ * `logback.xml` is scanned for changes, but Logback only reconfigures when the file's timestamp
+ * actually changes, so a level set here survives until that file is edited or the process restarts.
+ * [ConfigComponent][github.rikacelery.v3.components.ConfigComponent] persists the choice in
+ * `xhrec.json`, so it is also restored on the next start.
+ */
+object LogLevels {
+
+    /** The levels offered to the dashboard, from most to least verbose. */
+    val LEVELS = listOf("TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF")
+
+    /** The default when `logback.xml` does not pin a root level and nothing was persisted. */
+    const val DEFAULT = "DEBUG"
+
+    private fun context(): LoggerContext? = LoggerFactory.getILoggerFactory() as? LoggerContext
+
+    private fun root(): Logger? = context()?.getLogger(ROOT_LOGGER_NAME)
+
+    /** The root level currently in effect, or `null` when the backend is not Logback. */
+    fun current(): String? = root()?.level?.toString()
+
+    /** The level to show when [current] is unavailable. */
+    fun currentOrDefault(): String = current() ?: DEFAULT
+
+    /** Canonical upper-case spelling of [level], or `null` when it is not a known level. */
+    fun normalize(level: String): String? {
+        val canonical = level.trim().uppercase()
+        return canonical.takeIf { it in LEVELS }
+    }
+
+    /**
+     * Applies [level] to the root logger.
+     *
+     * Returns the canonical level that was applied, or `null` when the level is unknown or Logback
+     * is not the active backend (in which case the caller reports the failure instead of pretending
+     * the change took effect).
+     */
+    fun apply(level: String): String? {
+        val logger = root() ?: return null
+        val canonical = normalize(level) ?: return null
+        // Level.valueOf is safe here because normalize() already restricted the input to LEVELS.
+        logger.level = Level.valueOf(canonical)
+        return canonical
+    }
+}

--- a/src/main/resources/vue.html
+++ b/src/main/resources/vue.html
@@ -260,6 +260,10 @@
                         :class="maskEnabled ? 'bg-amber-100 text-amber-700 hover:bg-amber-600 hover:text-white' : 'bg-slate-100 text-slate-400 hover:bg-slate-200 hover:text-slate-600'">
                         <i class="fa-solid" :class="maskEnabled ? 'fa-eye-slash' : 'fa-eye'"></i>
                     </button>
+                    <button @click="openLogLevel()" :title="$t('Log Level — sets how much the server writes to its log at runtime. TRACE/DEBUG help when debugging a room; INFO and above keep the log small.')"
+                        class="h-8 px-2 flex items-center justify-center gap-1.5 rounded bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-700 dark:text-slate-200 text-[10px] font-bold tracking-wide transition-colors">
+                        <i class="fa-solid fa-bug text-xs"></i>{{ logLevel }}
+                    </button>
                     <button @click="toggleLocale()" :title="$t('Switch Language / 切换语言')"
                         class="w-8 h-8 flex items-center justify-center rounded bg-slate-100 text-slate-600 hover:bg-slate-200 hover:text-slate-800 transition-colors">
                         <i class="fa-solid fa-globe text-sm"></i>
@@ -652,6 +656,32 @@
                 </div>
             </div>
         </div>
+    <!-- Log Level Dialog -->
+    <div v-if="logLevelDialog" class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" @click.self="logLevelDialog=false">
+        <div class="bg-white dark:bg-slate-800 rounded-xl shadow-xl max-w-md w-full p-5 border border-slate-200 dark:border-slate-700">
+            <div class="flex items-center justify-between mb-4">
+                <h2 class="text-lg font-bold text-slate-800 dark:text-slate-100">
+                    <i class="fa-solid fa-bug text-indigo-500 mr-2"></i>{{ $t('Log Level') }}
+                </h2>
+                <button @click="logLevelDialog=false" class="w-8 h-8 flex items-center justify-center rounded bg-slate-100 hover:bg-slate-200 dark:bg-slate-700 dark:hover:bg-slate-600 text-slate-600 dark:text-slate-200"><i class="fa-solid fa-xmark"></i></button>
+            </div>
+            <p class="text-xs text-slate-500 dark:text-slate-400 mb-3">{{ $t('Applied immediately and remembered across restarts. Third-party loggers (netty, ktor) keep their own level.') }}</p>
+            <div class="flex flex-col gap-1.5">
+                <button v-for="lvl in logLevelLevels" :key="lvl" @click="setLogLevel(lvl)"
+                    class="flex items-center justify-between px-3 py-2 rounded-lg text-sm border transition-colors"
+                    :class="lvl === logLevel
+                        ? 'bg-indigo-50 border-indigo-400 text-indigo-700 dark:bg-indigo-900/40 dark:border-indigo-500 dark:text-indigo-200 font-semibold'
+                        : 'bg-slate-50 border-slate-200 text-slate-700 hover:bg-slate-100 dark:bg-slate-900 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-700'">
+                    <span>{{ lvl }}</span>
+                    <i class="fa-solid fa-check text-xs" v-if="lvl === logLevel"></i>
+                    <i class="fa-solid fa-bug text-xs opacity-40" v-else-if="lvl === 'TRACE' || lvl === 'DEBUG'"></i>
+                </button>
+            </div>
+            <div class="mt-5 flex justify-end">
+                <button @click="logLevelDialog=false" class="px-4 py-2 rounded bg-slate-100 hover:bg-slate-200 dark:bg-slate-700 dark:hover:bg-slate-600 text-slate-700 dark:text-slate-200 text-sm">{{ $t('Close') }}</button>
+            </div>
+        </div>
+    </div>
     <!-- Model Schedule Dialog -->
     <div v-if="scheduleDialog" class="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
         <div class="bg-white dark:bg-slate-800 rounded-xl shadow-2xl p-6 w-[90vw] max-w-2xl max-h-[80vh] overflow-y-auto">
@@ -945,6 +975,9 @@
                     previewHeight: 40,
                     darkMode: false,
                     maskEnabled: true,
+                    logLevel: 'DEBUG',
+                    logLevelLevels: ['TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'OFF'],
+                    logLevelDialog: false,
                     hostsDialog: false,
                     scheduleDialog: false,
                     modelDetailDialog: false,
@@ -987,6 +1020,10 @@
                             'REC': '录制中', 'FETCH': '获取中', 'ARM': '监听中', 'OFF': '离线',
                             'Recording': '录制中', 'Fetching': '获取中', 'Listening': '监听中', 'Offline': '离线',
                             'Mask ON': '脱敏 开', 'Mask OFF': '脱敏 关', 'Network Error': '网络错误',
+                            'Log Level': '日志等级',
+                            'Log Level — sets how much the server writes to its log at runtime. TRACE/DEBUG help when debugging a room; INFO and above keep the log small.': '日志等级 — 设置服务器在运行时写入日志的详细程度。调试某个直播间时可用 TRACE/DEBUG；INFO 及以上可减小日志体积。',
+                            'Applied immediately and remembered across restarts. Third-party loggers (netty, ktor) keep their own level.': '立即生效并在重启后保留。第三方库日志（netty、ktor）保持各自等级不变。',
+                            'Log level not changed': '日志等级未更改',
                             'Invalid limit value': '无效的限时值', 'Invalid size value': '无效的大小值',
                             'CDN Performance': 'CDN 性能', 'Clear cooldown': '清除冷却', 'Clear': '清除', 'Cooldown cleared': '冷却已清除', 'active': '正常', 'confidence': '置信度',
                             'success': '成功', 'errors': '错误', 'unknown': '未知',
@@ -1156,6 +1193,30 @@
                         this.maskEnabled = text === 'true';
                         this.showToast(this.maskEnabled ? this.$t('Mask ON') : this.$t('Mask OFF'));
                     } catch (e) { this.showToast(this.$t('Network Error'), "error"); }
+                },
+                async openLogLevel() {
+                    await this.fetchLogLevel();
+                    this.logLevelDialog = true;
+                },
+                async fetchLogLevel() {
+                    try {
+                        const r = await fetch(`${HOST}/log/level`);
+                        const j = await r.json();
+                        if (j.level) this.logLevel = j.level;
+                        if (Array.isArray(j.levels) && j.levels.length) this.logLevelLevels = j.levels;
+                    } catch (_) {}
+                },
+                async setLogLevel(level) {
+                    try {
+                        const body = new URLSearchParams({ level });
+                        const r = await fetch(`${HOST}/log/level`, { method: 'POST', body });
+                        if (!r.ok) {
+                            this.showToast(`${this.$t('Log level not changed')}: ${await r.text()}`, 'error');
+                            return;
+                        }
+                        this.logLevel = (await r.text()).trim() || level;
+                        this.showToast(`${this.$t('Log Level')}: ${this.logLevel}`);
+                    } catch (e) { this.showToast(this.$t('Network Error'), 'error'); }
                 },
                 async fetchHostsConfig() {
                     try {
@@ -1574,6 +1635,9 @@
 
                 // Mask status
                 try { const r = await fetch(`${HOST}/mask/status`); this.maskEnabled = (await r.text()) === 'true'; } catch (_) {}
+
+                // Log level
+                await this.fetchLogLevel();
 
                 // Domain hosts config
                 await this.fetchHostsConfig();

--- a/src/test/kotlin/github/rikacelery/v3/components/SchedulerResumeMarkTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/SchedulerResumeMarkTest.kt
@@ -1,0 +1,110 @@
+package github.rikacelery.v3.components
+
+import github.rikacelery.v3.api.ApiClient
+import github.rikacelery.v3.core.DataChannel
+import github.rikacelery.v3.core.EventBus
+import github.rikacelery.v3.core.RequestBus
+import github.rikacelery.v3.data.RoomSettings
+import github.rikacelery.v3.data.RuntimeTuning
+import github.rikacelery.v3.m3u8.M3u8Parser
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.hours
+
+/**
+ * The resume mark (`lastIndex`) exists so a cut inside one continuous stream does not re-download
+ * the segments that were just written. The platform's segment ids restart with each broadcast, so
+ * a mark left over from an earlier broadcast makes the next session skip *every* segment: the
+ * playlist keeps listing them, `computeUnseen` drops them all, and the room reports `Recording`
+ * while downloading nothing at all — until the fresh counter climbs past the stale mark, which can
+ * take as long as the previous broadcast lasted.
+ *
+ * These tests pin the invariant: the mark only survives a restart *inside* one stream, and is
+ * dropped by anything that re-resolves the stream.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SchedulerResumeMarkTest {
+
+    @Test
+    fun `re-preconfiguring clears a resume mark left by a previous broadcast`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val entry = newEntry(backgroundScope)
+            try {
+                entry.lastIndex = 1750L // the previous broadcast of this room got this far
+                entry.fsm.drive(SchedulerEvent.BeginPreconfig)
+                entry.preconfigLoop.cancel()
+
+                assertNull(
+                    entry.lastIndex,
+                    "a mark from an earlier broadcast must not be applied to a re-resolved stream"
+                )
+            } finally {
+                entry.scope.cancel()
+            }
+        }
+
+    @Test
+    fun `returning to armed clears a resume mark`() = runTest(UnconfinedTestDispatcher()) {
+        val entry = newEntry(backgroundScope)
+        try {
+            entry.fsm.drive(SchedulerEvent.BeginPreconfig)
+            entry.preconfigLoop.cancel()
+            entry.lastIndex = 1750L
+
+            entry.fsm.drive(SchedulerEvent.BackToArmed)
+
+            assertNull(entry.lastIndex, "leaving for Armed invalidates the resume mark")
+        } finally {
+            entry.scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a restart inside the same stream keeps the resume mark`() = runTest(UnconfinedTestDispatcher()) {
+        val entry = newEntry(backgroundScope)
+        try {
+            entry.fsm.drive(SchedulerEvent.BeginPreconfig)
+            entry.preconfigLoop.cancel()
+            entry.fsm.drive(
+                SchedulerEvent.PreconfigDone,
+                SchedulerDriveData(playlistUrl = "http://127.0.0.1:1/room/720p.m3u8", quality = "720p", pkey = "room-key")
+            )
+            assertEquals(SchedulerState.Recording, entry.fsm.currentState)
+
+            entry.lastIndex = 1750L
+            entry.fsm.drive(SchedulerEvent.RestartRecording)
+
+            assertEquals(
+                1750L, entry.lastIndex,
+                "a time/size limit cut continues the same stream, so the mark is still valid"
+            )
+        } finally {
+            entry.scope.cancel()
+        }
+    }
+
+    private fun newEntry(scope: CoroutineScope): SchedulerEntry {
+        val eventBus = EventBus()
+        val requestBus = RequestBus(eventBus, scope)
+        val dataChannel = DataChannel()
+        val downloader = DownloaderComponent(dataChannel, eventBus = eventBus, parentScope = scope)
+        val session = SessionComponent(dataChannel, downloader, M3u8Parser, requestBus, eventBus, scope)
+        val scheduler = SchedulerComponent(
+            requestBus,
+            session,
+            // a dead loopback host: no component in this test reaches the network
+            ApiClient(listOf("127.0.0.1:1")),
+            "streamKey",
+            eventBus,
+            scope,
+            runtimeTuning = RuntimeTuning(preconfigRetryInterval = 1.hours)
+        )
+        return SchedulerEntry(7, "model", scheduler).apply { settings = RoomSettings(pkey = "room-key") }
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/components/SessionSegmentAccountingTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/SessionSegmentAccountingTest.kt
@@ -193,6 +193,14 @@ class SessionSegmentAccountingTest {
         }
     }
 
+    @Test
+    fun `a one-element id range renders as a single id, not as a range`() {
+        // `id 1063..1063` in a log reads like a typo and hides that only one entry was skipped
+        assertEquals("1063", formatIdRange(1063L, 1063L))
+        assertEquals("1061..1063", formatIdRange(1061L, 1063L))
+        assertEquals("?", formatIdRange(null, null))
+    }
+
     private fun newEntry(scope: CoroutineScope): SessionEntry {
         val eventBus = EventBus()
         val requestBus = RequestBus(eventBus, scope)

--- a/src/test/kotlin/github/rikacelery/v3/components/SessionSegmentAccountingTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/SessionSegmentAccountingTest.kt
@@ -20,13 +20,21 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
- * The playlist normally overlaps what was already downloaded, so a few segments are skipped on
- * every poll and that is silent by design. When *every* advertised segment sits at or below the
- * resume mark, however, the session is not recording anything while still reporting `Recording` —
- * that has to be visible, but exactly once, with a matching line when it finally catches up.
+ * What a session accounts for in the playlist it polls, in both directions.
+ *
+ * *Skipped* entries are the normal steady state: the playlist is a sliding window that re-lists
+ * what was already downloaded, so a few segments are skipped on every poll and that is silent by
+ * design. When *every* advertised segment sits at or below the resume mark, however, the session is
+ * not recording anything while still reporting `Recording` — that has to be visible, but exactly
+ * once, with a matching line when it finally catches up.
+ *
+ * *Missing* entries are the opposite failure: ids the stream published that the playlist never
+ * showed us, because it advanced past them between two polls or carries a hole. Nothing else in the
+ * pipeline can see those — a segment we never hear about never fails and never reaches the
+ * downloader — so the session counts them itself.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class SessionSkipAccountingTest {
+class SessionSegmentAccountingTest {
 
     @Test
     fun `segments below the resume mark are counted as skipped, not enqueued`() =
@@ -117,6 +125,73 @@ class SessionSkipAccountingTest {
         "https://media.example/room_init_1.mp4",
         urls.map { Segment(it, M3u8Parser.segmentIDFromUrl(it) ?: 0) }
     )
+
+    @Test
+    fun `a jump in segment ids counts the ids that were never advertised`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val entry = newEntry(backgroundScope)
+            try {
+                // first refresh is at id 0 ...
+                entry.computeUnseen(playlist(segUrl("0")))
+                assertEquals(0, entry.lastPollGap, "the first poll only establishes the baseline")
+
+                // ... the second is already at 4, so 1, 2 and 3 were lost
+                entry.computeUnseen(playlist(segUrl("4")))
+                assertEquals(3, entry.lastPollGap, "ids 1,2,3 were never advertised")
+            } finally {
+                entry.scope.cancel()
+            }
+        }
+
+    @Test
+    fun `a hole inside the advertised window is counted too`() = runTest(UnconfinedTestDispatcher()) {
+        val entry = newEntry(backgroundScope)
+        try {
+            entry.computeUnseen(playlist(segUrl("10"), segUrl("11"), segUrl("12")))
+            entry.computeUnseen(playlist(segUrl("11"), segUrl("12"), segUrl("13")))
+            assertEquals(0, entry.lastPollGap, "a normal advance loses nothing")
+
+            // 14 follows the mark directly, but 15..19 are absent and 20 is not 15
+            entry.computeUnseen(playlist(segUrl("13"), segUrl("14"), segUrl("20"), segUrl("21")))
+            assertEquals(5, entry.lastPollGap, "15..19 are missing even though 14 is present")
+        } finally {
+            entry.scope.cancel()
+        }
+    }
+
+    @Test
+    fun `segments published while the playlist stood still are counted as missing`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val entry = newEntry(backgroundScope)
+            try {
+                entry.computeUnseen(playlist(segUrl("5"), segUrl("6"), segUrl("7")))
+                entry.computeUnseen(playlist(segUrl("6"), segUrl("7")))
+                assertEquals(0, entry.lastPollGap, "a stalled window loses nothing by itself")
+
+                entry.computeUnseen(playlist(segUrl("20"), segUrl("21"), segUrl("22")))
+                assertEquals(12, entry.lastPollGap, "8..19 were published while nothing was queued")
+            } finally {
+                entry.scope.cancel()
+            }
+        }
+
+    @Test
+    fun `restarting a session forgets the gap baseline`() = runTest(UnconfinedTestDispatcher()) {
+        val entry = newEntry(backgroundScope)
+        try {
+            entry.previousNewSegmentId = 500L
+            entry.lastPollGap = 7
+
+            entry.fsm.drive(RecordingEvent.StartRecording)
+            entry.playlistLoop.cancel()
+
+            // the seam after a restart (a limit cut, a re-arm) is expected, not lost data
+            assertNull(entry.previousNewSegmentId)
+            assertEquals(0, entry.lastPollGap)
+        } finally {
+            entry.scope.cancel()
+        }
+    }
 
     private fun newEntry(scope: CoroutineScope): SessionEntry {
         val eventBus = EventBus()

--- a/src/test/kotlin/github/rikacelery/v3/components/SessionSkipAccountingTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/SessionSkipAccountingTest.kt
@@ -50,6 +50,7 @@ class SessionSkipAccountingTest {
                 assertEquals(2L, entry.skippedInStreak)
                 assertEquals(100L, entry.skippedMinId)
                 assertEquals(150L, entry.skippedMaxId)
+                assertEquals(2, entry.lastPollSkipped, "the poll's skip count is what reaches the metrics")
                 assertNotNull(entry.skipStreakSince)
             } finally {
                 entry.scope.cancel()

--- a/src/test/kotlin/github/rikacelery/v3/components/SessionSkipAccountingTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/SessionSkipAccountingTest.kt
@@ -1,0 +1,128 @@
+package github.rikacelery.v3.components
+
+import github.rikacelery.v3.core.DataChannel
+import github.rikacelery.v3.core.EventBus
+import github.rikacelery.v3.core.RequestBus
+import github.rikacelery.v3.events.Segment
+import github.rikacelery.v3.m3u8.M3u8Parser
+import github.rikacelery.v3.m3u8.ParsedPlaylist
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The playlist normally overlaps what was already downloaded, so a few segments are skipped on
+ * every poll and that is silent by design. When *every* advertised segment sits at or below the
+ * resume mark, however, the session is not recording anything while still reporting `Recording` —
+ * that has to be visible, but exactly once, with a matching line when it finally catches up.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SessionSkipAccountingTest {
+
+    @Test
+    fun `segments below the resume mark are counted as skipped, not enqueued`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val entry = newEntry(backgroundScope)
+            try {
+                entry.lastSegmentId = 200L
+
+                val unseen = entry.computeUnseen(playlist(segUrl("100"), segUrl("150")))
+
+                assertEquals(
+                    1, unseen.size,
+                    "only the init is enqueued; every advertised media segment is at or below the mark"
+                )
+                assertEquals(-1, unseen.single().index, "the enqueued entry is the init segment")
+                assertFalse(entry.lastPollEnqueuedMedia, "the init alone must not count as media progress")
+                assertEquals(
+                    2, entry.lastPollSegmentCount,
+                    "the playlist did advertise segments — this is what separates a filtered poll from an empty one"
+                )
+                assertEquals(2L, entry.skippedInStreak)
+                assertEquals(100L, entry.skippedMinId)
+                assertEquals(150L, entry.skippedMaxId)
+                assertNotNull(entry.skipStreakSince)
+            } finally {
+                entry.scope.cancel()
+            }
+        }
+
+    @Test
+    fun `a segment past the resume mark resets the streak`() = runTest(UnconfinedTestDispatcher()) {
+        val entry = newEntry(backgroundScope)
+        try {
+            entry.lastSegmentId = 100L
+            entry.computeUnseen(playlist(segUrl("50")))
+            assertFalse(entry.lastPollEnqueuedMedia)
+
+            val unseen = entry.computeUnseen(playlist(segUrl("150")))
+
+            assertEquals(1, unseen.size, "the segment past the mark is downloaded")
+            assertEquals(150, unseen.single().index, "and it is the media segment, not the init")
+            assertTrue(entry.lastPollEnqueuedMedia)
+            assertEquals(150L, entry.lastSegmentId, "the mark advances to the newest segment")
+        } finally {
+            entry.scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a long skip streak is reported once and the catch-up is reported too`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val entry = newEntry(backgroundScope)
+            try {
+                entry.lastSegmentId = 900L
+                entry.computeUnseen(playlist(segUrl("800"), segUrl("850")))
+                entry.noteSkipOutcome(progressed = false)
+
+                // a fresh streak has not lasted long enough to be worth a line
+                assertFalse(entry.skipStreakReported, "a short streak stays silent")
+
+                // age the streak past the reporting delay, the way a real stall would
+                entry.skipStreakSince = Instant.now().minusSeconds(120)
+                entry.noteSkipOutcome(progressed = false)
+                assertTrue(entry.skipStreakReported, "a persistent streak is reported once")
+                assertEquals(2L, entry.skippedInStreak)
+                assertEquals(800L, entry.skippedMinId)
+
+                // repeated polls must not report again
+                entry.noteSkipOutcome(progressed = false)
+                assertTrue(entry.skipStreakReported)
+
+                // catching up ends the streak and clears the accounting
+                entry.noteSkipOutcome(progressed = true)
+                assertNull(entry.skipStreakSince)
+                assertEquals(0L, entry.skippedInStreak)
+                assertFalse(entry.skipStreakReported)
+                assertNull(entry.skippedMaxId)
+            } finally {
+                entry.scope.cancel()
+            }
+        }
+
+    /** `<room>_<segmentId>_<16 alnum>_<10 digits>.mp4` is the shape the id parser expects. */
+    private fun segUrl(id: String) = "https://media.example/$id" + "_${id}_ABCDEFGHIJKLMNOP_1700000000.mp4"
+
+    private fun playlist(vararg urls: String) = ParsedPlaylist(
+        "https://media.example/room_init_1.mp4",
+        urls.map { Segment(it, M3u8Parser.segmentIDFromUrl(it) ?: 0) }
+    )
+
+    private fun newEntry(scope: CoroutineScope): SessionEntry {
+        val eventBus = EventBus()
+        val requestBus = RequestBus(eventBus, scope)
+        val dataChannel = DataChannel()
+        val downloader = DownloaderComponent(dataChannel, eventBus = eventBus, parentScope = scope)
+        val component = SessionComponent(dataChannel, downloader, M3u8Parser, requestBus, eventBus, scope)
+        return SessionEntry(7, "model", component)
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/core/BusMonitorTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/core/BusMonitorTest.kt
@@ -1,0 +1,138 @@
+package github.rikacelery.v3.core
+
+import github.rikacelery.v3.data.DownloadMeta
+import github.rikacelery.v3.data.StreamData
+import github.rikacelery.v3.data.StreamStart
+import github.rikacelery.v3.events.CommandAck
+import github.rikacelery.v3.events.CommandEnvelope
+import github.rikacelery.v3.events.GetMaskStatus
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.onSubscription
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * The debug taps are only armed while a client is watching, so the recorder pays nothing for them
+ * in normal operation. These tests pin both halves of that contract: silent when unwatched, and
+ * actually wired to the request bus and the data channel when watched.
+ *
+ * Emissions are delivered asynchronously through the shared flow, so every assertion waits for its
+ * line instead of assuming the collector already ran.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class BusMonitorTest {
+
+    @Test
+    fun `a category is silent until somebody watches it`() {
+        assertFalse(BusMonitor.wants(BusMonitor.REQUEST))
+        BusMonitor.record(BusMonitor.REQUEST, buildJsonObject { put("ignored", true) })
+        assertFalse(BusMonitor.wants(BusMonitor.REQUEST))
+    }
+
+    @Test
+    fun `watch arms only the requested category and unwatch disarms it`() {
+        try {
+            BusMonitor.watch(listOf(BusMonitor.REQUEST))
+            assertTrue(BusMonitor.wants(BusMonitor.REQUEST))
+            assertFalse(BusMonitor.wants(BusMonitor.DATA), "unrequested categories stay silent")
+        } finally {
+            BusMonitor.unwatch(listOf(BusMonitor.REQUEST))
+        }
+        assertFalse(BusMonitor.wants(BusMonitor.REQUEST))
+    }
+
+    @Test
+    fun `a watched request round trip is tapped with its outcome and latency`() = runTest {
+        val eventBus = EventBus()
+        val requestBus = RequestBus(eventBus, backgroundScope)
+        eventBus.subscribe(backgroundScope, CommandEnvelope::class) { env ->
+            eventBus.publish(CommandAck(env.id, "ok"))
+        }
+        assertTrue(requestBus.awaitSubscribed())
+
+        val lines = collectWatched(backgroundScope, listOf(BusMonitor.REQUEST))
+        try {
+            val result: String = requestBus.request(GetMaskStatus)
+            assertEquals("ok", result)
+
+            val line = lines.await("the tapped request") { it["kind"]?.jsonPrimitive?.content == "request" }
+            assertEquals("GetMaskStatus", line["cmd"]?.jsonPrimitive?.content)
+            assertEquals("ok", line["result"]?.jsonPrimitive?.content)
+            assertTrue((line["ms"]?.jsonPrimitive?.content?.toLong() ?: -1) >= 0, "latency is reported: $line")
+        } finally {
+            BusMonitor.unwatch(listOf(BusMonitor.REQUEST))
+        }
+    }
+
+    @Test
+    fun `a watched data channel message is tapped with its size`() = runTest {
+        val channel = DataChannel()
+        val lines = collectWatched(backgroundScope, listOf(BusMonitor.DATA))
+        try {
+            channel.send(StreamStart(7, "model", Instant.now(), "720p"))
+            channel.send(
+                StreamData(
+                    7, ByteArray(16), 1,
+                    DownloadMeta("https://media.example/seg.mp4", 5, proxied = false, timestamp = Instant.now())
+                )
+            )
+
+            val start = lines.await("StreamStart") { it["msg"]?.jsonPrimitive?.content == "StreamStart" }
+            assertEquals("7", start["room"]?.jsonPrimitive?.content)
+
+            val data = lines.await("StreamData") { it["msg"]?.jsonPrimitive?.content == "StreamData" }
+            assertEquals("16", data["bytes"]?.jsonPrimitive?.content)
+        } finally {
+            BusMonitor.unwatch(listOf(BusMonitor.DATA))
+        }
+    }
+
+    /**
+     * Attaches a collector and waits for the subscription to be live before arming the tap, so the
+     * first emission cannot be missed by a collector that has not attached yet.
+     */
+    private suspend fun collectWatched(scope: CoroutineScope, types: List<String>): CapturedLines {
+        val lines = CapturedLines()
+        val attached = CompletableDeferred<Unit>()
+        scope.launch { BusMonitor.events.onSubscription { attached.complete(Unit) }.collect { lines += it } }
+        attached.await()
+        BusMonitor.watch(types)
+        return lines
+    }
+
+    /** Lines captured from the shared flow, with a bounded wait that yields to the collector. */
+    private class CapturedLines {
+        private val lines = CopyOnWriteArrayList<JsonObject>()
+
+        operator fun plusAssign(line: JsonObject) {
+            lines += line
+        }
+
+        suspend fun await(what: String, predicate: (JsonObject) -> Boolean): JsonObject {
+            val found = withTimeoutOrNull(5.seconds) {
+                var hit: JsonObject? = null
+                while (hit == null) {
+                    hit = lines.firstOrNull(predicate)
+                    if (hit == null) delay(2)
+                }
+                hit
+            }
+            return found ?: error("timed out waiting for $what; captured=${lines.toList()}")
+        }
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/integration/DiagnosticsEndpointTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/DiagnosticsEndpointTest.kt
@@ -107,6 +107,21 @@ class DiagnosticsEndpointTest {
     }
 
     @Test
+    fun `skips behind the resume mark are visible in the metrics too`() = withFixture { fx ->
+        fx.ready()
+        fx.startRecording()
+
+        // A recording re-lists segments it already wrote, so its skip counter must move. Without
+        // this the log and the metrics disagree, which reads as a false alarm.
+        val skipped = fx.await(10.seconds, "the segments-skipped counter to move") {
+            val body = fx.get("/metrics").bodyAsText()
+            Regex("""xhrec_segments_skipped_total\{roomId="1001"\} (\d+)""")
+                .find(body)?.groupValues?.get(1)?.toLong()?.takeIf { it > 0 }
+        }
+        assertTrue(skipped > 0, "skips must be counted, got $skipped")
+    }
+
+    @Test
     fun `an unknown actor is reported as not found`() = withFixture { fx ->
         val response = fx.get("/diagnose?actor=NoSuchComponent")
         assertEquals(HttpStatusCode.NotFound, response.status)

--- a/src/test/kotlin/github/rikacelery/v3/integration/DiagnosticsEndpointTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/DiagnosticsEndpointTest.kt
@@ -1,0 +1,200 @@
+package github.rikacelery.v3.integration
+
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * The introspection surface an operator reaches for when a room looks stuck but the logs are
+ * quiet: which components are alive, what each state machine is doing, and how it got there.
+ */
+class DiagnosticsEndpointTest {
+
+    @Test
+    fun `diagnose lists the live components and their sections`() = withFixture { fx ->
+        val index = fx.get("/diagnose").bodyAsJson().jsonObject
+        val components = index["components"]!!.jsonArray.map { it.jsonObject }
+        val byName = components.associateBy { it["name"]!!.jsonPrimitive.content }
+
+        for (expected in listOf(
+            "SchedulerComponent", "SessionComponent", "DownloaderComponent",
+            "WriterComponent", "RoomComponent", "ConfigComponent"
+        )) {
+            val entry = assertNotNull(byName[expected], "$expected must be registered; got ${byName.keys}")
+            assertTrue(
+                entry["sections"]!!.jsonArray.isNotEmpty(),
+                "$expected must advertise at least one section"
+            )
+        }
+
+        assertTrue(
+            index["monitor"]!!.jsonObject["watched"]!!.jsonArray.isEmpty(),
+            "no debug tap may be armed when nobody is streaming"
+        )
+    }
+
+    @Test
+    fun `every component reports a truthful non-negative mailbox depth`() = withFixture { fx ->
+        val components = fx.get("/diagnose").bodyAsJson().jsonObject["components"]!!.jsonArray
+
+        components.forEach { component ->
+            val summary = fx.get("/diagnose?actor=${component.jsonObject["name"]!!.jsonPrimitive.content}")
+                .bodyAsJson().jsonObject
+            val depth = summary["mailboxDepth"]!!.jsonPrimitive.int
+            assertTrue(depth >= 0, "mailbox depth must never go negative: $summary")
+        }
+    }
+
+    @Test
+    fun `diagnose explains a recording room with its state machine and resume mark`() = withFixture { fx ->
+        fx.ready()
+        fx.startRecording()
+
+        val scheduler = fx.get("/diagnose?actor=SchedulerComponent&section=entries&room=1001")
+            .bodyAsJson().jsonObject
+        val schedulerEntry = scheduler["entries"]!!.jsonArray.single().jsonObject
+        assertEquals(1001L, schedulerEntry["roomId"]!!.jsonPrimitive.content.toLong())
+        assertEquals("Recording", schedulerEntry["fsm"]!!.jsonObject["state"]!!.jsonPrimitive.content)
+
+        val session = fx.get("/diagnose?actor=SessionComponent&section=entries&room=1001")
+            .bodyAsJson().jsonObject
+        val sessionEntry = session["entries"]!!.jsonArray.single().jsonObject
+        assertEquals("Recording", sessionEntry["fsm"]!!.jsonObject["state"]!!.jsonPrimitive.content)
+        assertTrue(
+            sessionEntry["segmentIndex"]!!.jsonPrimitive.int > 0,
+            "a recording session must have queued segments: $sessionEntry"
+        )
+        assertTrue(
+            sessionEntry["playlistLoopRunning"]!!.jsonPrimitive.content.toBoolean(),
+            "the playlist poll loop must be alive while recording"
+        )
+        assertTrue(
+            sessionEntry["noProgressMs"]!!.jsonPrimitive.content.toLong() >= 0,
+            "the no-progress clock is the field that exposes a stalled recording"
+        )
+    }
+
+    @Test
+    fun `diagnose exposes the transition history that led to the current state`() = withFixture { fx ->
+        fx.ready()
+        fx.startRecording()
+
+        val body = fx.get("/diagnose?actor=SchedulerComponent&section=history&room=1001")
+            .bodyAsJson().jsonObject
+        val history = body["history"]!!.jsonObject["1001"]!!.jsonArray.map { it.jsonObject }
+
+        assertTrue(history.isNotEmpty(), "a room that went armed -> preconfig -> recording has history")
+        val eventNames = history.map { it["event"]!!.jsonPrimitive.content }
+        assertTrue(
+            eventNames.contains("PreconfigDone"),
+            "the recording transition must be visible in history: $eventNames"
+        )
+        assertTrue(
+            history.first().containsKey("from") && history.first().containsKey("target"),
+            "each record must carry from/event/target: ${history.first()}"
+        )
+    }
+
+    @Test
+    fun `an unknown actor is reported as not found`() = withFixture { fx ->
+        val response = fx.get("/diagnose?actor=NoSuchComponent")
+        assertEquals(HttpStatusCode.NotFound, response.status)
+        assertTrue(response.bodyAsText().contains("SchedulerComponent"), "the error lists the known actors")
+    }
+
+    @Test
+    fun `diagnose never leaks credentials`() = withFixture { fx ->
+        fx.ready()
+        fx.startRecording()
+
+        val entries = fx.get("/diagnose?actor=SchedulerComponent&section=entries")
+            .bodyAsJson().jsonObject["entries"]!!.jsonArray
+        val playlistPath = entries.first().jsonObject["playlistPath"]!!.jsonPrimitive.content
+
+        assertTrue(playlistPath.isNotEmpty(), "the resolved playlist is reported")
+        assertTrue(
+            !playlistPath.contains("?"),
+            "the playlist URL must be reduced to its path (psch/pkey/aclAuth live in the query): $playlistPath"
+        )
+    }
+}
+
+/** The debug stream's own validation is testable without holding the (infinite) stream open. */
+class DebugStreamRouteTest {
+
+    @Test
+    fun `an unknown stream type is rejected`() = withFixture { fx ->
+        val response = fx.get("/debug/stream?types=nonsense")
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        assertTrue(response.bodyAsText().contains("request"), "the error lists the valid categories")
+    }
+
+    /**
+     * The taps exist to be cheap when nobody watches, which only holds if a client that goes away
+     * actually releases them. An idle connection is invisible to the server, so the heartbeat write
+     * is what discovers the disconnect — without it the taps would stay armed for the life of the
+     * process.
+     */
+    @Test
+    fun `the stream tap is released when the client disconnects`() = withFixture { fx ->
+        val streaming = fx.scope.launch { runCatching { fx.get("/debug/stream?types=request") } }
+        try {
+            fx.await(5.seconds, "the request tap to arm") { armedWatched(fx) }
+        } finally {
+            streaming.cancelAndJoin()
+        }
+
+        val released = fx.await(5.seconds, "the request tap to be released") { releasedWatched(fx) }
+        assertTrue(released.isEmpty(), "every tap must be released once the client is gone: $released")
+    }
+
+    /** Non-null while the tap is armed, so [XhrecIntegrationFixture.await] keeps polling until then. */
+    private suspend fun armedWatched(fx: XhrecIntegrationFixture): List<String>? =
+        watched(fx).takeIf { "request" in it }
+
+    /** Non-null once every tap is released. */
+    private suspend fun releasedWatched(fx: XhrecIntegrationFixture): List<String>? =
+        watched(fx).takeIf { it.isEmpty() }
+
+    private suspend fun watched(fx: XhrecIntegrationFixture): List<String> =
+        fx.get("/diagnose").bodyAsJson().jsonObject["monitor"]!!.jsonObject["watched"]!!
+            .jsonArray.map { it.jsonPrimitive.content }
+}
+
+class LogLevelEndpointTest {
+
+    @Test
+    fun `the log level can be read, changed and rejected`() = withFixture { fx ->
+        val initial = fx.get("/log/level").bodyAsJson().jsonObject
+        val initialLevel = initial["level"]!!.jsonPrimitive.content
+        val levels = initial["levels"]!!.jsonArray.map { it.jsonPrimitive.content }
+        assertTrue(levels.containsAll(listOf("TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF")), "$levels")
+
+        try {
+            val applied = fx.postForm("/log/level", mapOf("level" to "warn")).bodyAsText()
+            assertEquals("WARN", applied, "the level is normalized to its canonical spelling")
+
+            val now = fx.get("/log/level").bodyAsJson().jsonObject["level"]!!.jsonPrimitive.content
+            assertEquals("WARN", now, "the effective level is read back from logback")
+        } finally {
+            fx.postForm("/log/level", mapOf("level" to initialLevel))
+        }
+
+        val rejected = fx.postForm("/log/level", mapOf("level" to "LOUD"))
+        assertEquals(HttpStatusCode.BadRequest, rejected.status)
+    }
+}
+
+private suspend fun io.ktor.client.statement.HttpResponse.bodyAsJson() =
+    Json.parseToJsonElement(bodyAsText())

--- a/src/test/kotlin/github/rikacelery/v3/integration/DiagnosticsEndpointTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/DiagnosticsEndpointTest.kt
@@ -5,6 +5,7 @@ import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -120,6 +121,35 @@ class DiagnosticsEndpointTest {
         }
         assertTrue(skipped > 0, "skips must be counted, got $skipped")
     }
+
+    @Test
+    fun `segments the stream skipped over are counted as missing`() = withFixture { fx ->
+        fx.ready()
+        fx.startRecording()
+
+        // `startRecording` is satisfied by the init download, which the mock serves from an empty
+        // window, so wait until the session has actually queued media segments — otherwise the jump
+        // below only moves the baseline and no discontinuity is ever observable.
+        fx.await(5.seconds, "the session to queue media segments") { baselineSet(fx) }
+
+        // the stream publishes several segments at once, so the next playlist jumps past them
+        fx.mock.skipSegments(1001L, 5)
+
+        val missing = fx.await(10.seconds, "the missing-segment counter to move") {
+            val body = fx.get("/metrics").bodyAsText()
+            Regex("""xhrec_segment_missing_total\{roomId="1001"\} (\d+)""")
+                .find(body)?.groupValues?.get(1)?.toLong()?.takeIf { it > 0 }
+        }
+        assertTrue(missing > 0, "a discontinuity in segment ids must be counted, got $missing")
+    }
+
+    /** Non-null once the session has queued at least one media segment. */
+    private suspend fun baselineSet(fx: XhrecIntegrationFixture): Boolean? =
+        fx.get("/diagnose?actor=SessionComponent&section=entries&room=1001")
+            .bodyAsJson().jsonObject["entries"]!!.jsonArray.firstOrNull()
+            ?.jsonObject?.get("previousNewSegmentId")
+            ?.takeIf { it !is JsonNull }
+            ?.let { true }
 
     @Test
     fun `an unknown actor is reported as not found`() = withFixture { fx ->

--- a/src/test/kotlin/github/rikacelery/v3/integration/MockPlatformServer.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/MockPlatformServer.kt
@@ -204,6 +204,16 @@ class MockPlatformServer(
         }
     }.also { ownedJobs += it }
 
+    /**
+     * Advances the room's newest segment id by [count] at once, leaving a hole in the ids the
+     * playlist advertises. Models a stream that published segments faster than the recorder polled
+     * (or a poll that was delayed), which is what the missing-segment metric counts.
+     */
+    fun skipSegments(id: Long, count: Int) {
+        val room = room(id)
+        room.availableSegments += count
+    }
+
     /** Applies [statuses] in order (first immediately), then loops every [period]. */
     fun rotateStatuses(id: Long, statuses: List<String>, period: Duration): Job {
         require(statuses.isNotEmpty())

--- a/src/test/kotlin/github/rikacelery/v3/integration/XhrecIntegrationFixture.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/XhrecIntegrationFixture.kt
@@ -449,7 +449,9 @@ class XhrecIntegrationFixture(
             downloaderAttemptTimeout = 2.seconds,
             downloaderDeadline = downloaderDeadline,
             downloaderStallTimeout = downloaderStallTimeout,
-            downloaderRetryBackoff = 20.milliseconds
+            downloaderRetryBackoff = 20.milliseconds,
+            // short enough that a dropped stream client is noticed within a test
+            debugStreamHeartbeat = 200.milliseconds
         )
     }
 }


### PR DESCRIPTION
## The bug

A room could sit in `Recording` for the better part of an hour while writing nothing at all — no errors, no `CutPoint`, `running: {}` in the metrics, and only the fMP4 **init** segment (1238 bytes) on disk.

The playlist was healthy the whole time. Probing it directly returned three media segments at `200 OK` (ids 1002–1004). Every one of them was being dropped by `lastSegmentId`, a resume mark left over from the **previous** broadcast:

```kotlin
if (segId != null && lastSegmentId != null && segId <= lastSegmentId) continue
```

`Preconfiguring`'s `BackToArmed` was the only exit that did not clear `lastIndex`, so this path leaked the mark across shows:

```
Stopping --SessionExit(StatusChanged)--> Preconfiguring
         --PreconfigFailed(NoFreeSpy)--> Armed
```

The platform restarts segment ids with each broadcast. The previous show had run 58m31s (counter ≈ 1750); the new one started near 0, so **every** segment compared `<= 1750` and was skipped. The init is exempt from the mark, which is why exactly one download ever happened. The room only recovered once its counter climbed past the stale mark.

Live confirmation: the affected room was still stuck at `total: 1` / 1238 bytes at 22:54, and had recovered to `total: 338` / 46.9 MB by 23:29 — matching the predicted catch-up point.

## The fix

- `lastIndex` is cleared by every `BeginPreconfig` and every `BackToArmed`. Only `RestartRecording` (a time/size cut inside one stream) keeps it, because only then does the mark still describe the same stream.
- A session that makes no progress for `sessionStallTimeout` ends itself, so a genuinely dead playlist cannot masquerade as a recording.
- Segments dropped by the resume mark are reported **once** at WARN for a persistent streak, and once more at INFO when the stream catches up; per-poll ranges go to DEBUG. Short overlaps after a normal cut stay silent.
- `playlistProbe` reports success as an empty string rather than null — `withTimeoutOrNull` also yields null, so a null-able "ok" was indistinguishable from a probe that timed out. (This one would have stopped *all* recording; the integration tests caught it.)

## Introspection added

Debugging this required internal state that nothing exposed, so it is now available:

| Endpoint | What it gives |
| --- | --- |
| `GET /diagnose` | every live component and its sections, plus whether any debug tap is armed |
| `GET /diagnose?actor=&section=&room=` | state machine current state **and bounded transition history**, mailbox backlog, per-component detail |
| `GET /debug/stream?types=request,data,event` | request bus / data channel / event bus taps, one JSON per line |
| `GET/POST /log/level` | root log level at runtime, persisted in `xhrec.json`, with a dashboard picker |

Design notes: `Diagnosable` is implemented by `Actor` itself, so every component answers by default; the bus taps are opt-in and cost nothing while unwatched; a heartbeat write is what detects a dropped stream client, so taps are always released. URLs are reduced to their path and secrets are reported only by presence and length, since `/diagnose` is reachable over HTTP.

Two defects in that new instrumentation were found while verifying it and are fixed here too: the mailbox depth counted only `tell` and drifted negative for bus-delivered messages, and the debug taps were never released because an idle stream never touched the socket.

## Testing

284 tests pass (`0` failures), including new coverage for the resume-mark invariant, skip accounting, the tap lifecycle and every new endpoint.

Also verified against a real local server (isolated config/port, no production state touched): `/diagnose` reports all 10 components with non-negative mailbox depth, `/log/level` round-trips and rejects unknown levels with 400, `/debug/stream` emits valid ndjson, and the tap lifecycle is `[] -> ['request','event'] -> []`.

## Note

Not deployed. `deploy.sh` uploads the jar and rebuilds the image but does not restart the container, so production is still running the old build.
