### PR TITLE
fix: refresh a room whose playlist is rejected, and keep Recording truthful

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,7 +544,15 @@ WARN  v3.SchedulerEntry - Preconfig failed room=…: playlist unusable (HTTP 404
 
 The first is the stall watchdog ending a session that made no progress for `sessionStallTimeout`,
 after which the room re-runs preconfiguration. The second is a preconfig probe that could not use
-the variant playlist — an HTTP status, a probe timeout, or a request failure.
+the variant playlist — an HTTP status, a probe timeout, or a request failure. A 403 or 404
+additionally makes the scheduler ask the RoomComponent to re-read the room: the platform already
+handed out a token, so the CDN refusing the playlist means the show moved on, and the refreshed
+status re-arms a room that stopped being recordable instead of retrying a stream that is gone. A
+session that fails just before preconfig asks for the same room, so a hint does not become a second
+platform request: the first failure reads the room immediately, and the hints that follow inside
+`roomStatusRefreshWindow` collapse into a single catch-up read at the end of that window — debounced,
+but never dropped, so a status that moved just after the first read is still noticed. Activation is
+a command rather than a hint, so it always reads, and it arms the same window for the hints after it.
 
 When the log alone is not enough, `/diagnose` exposes the same state interactively; see
 [Diagnostics & Debug Stream](#diagnostics--debug-stream).

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -172,7 +172,6 @@ cookie_string_here
 | `/debug/stream` | 请求总线 / 数据通道 / 事件总线的实时 NDJSON 推送                      |
 | `/log/level`| 运行时读取（GET）或修改（POST）根日志等级                                |
 | `/metrics`  | Prometheus 指标接口                                 |
-
 | `/mask/toggle` | 切换日志脱敏开关      |
 | `/mask/status` | 获取当前脱敏状态（true/false） |
 
@@ -518,6 +517,12 @@ WARN  v3.SchedulerEntry - Preconfig failed room=…: playlist unusable (HTTP 404
 
 前者是看门狗在会话超过 `sessionStallTimeout` 没有任何进展时主动结束它，之后房间会重新执行 preconfig；
 后者是 preconfig 探测无法使用该清晰度播放列表——可能是 HTTP 状态码、探测超时，或请求失败。
+其中 403/404 还会让调度器请求 RoomComponent 重新读取房间状态：平台已经发放了 token，此时 CDN 拒绝播放列表
+说明直播已经发生变化，刷新后的状态会让已经不可录制的房间重新回到 `Armed`，而不是对着一个已经消失的流反复重试。
+失败往往紧接着前一个失败（会话刚失败、preconfig 又失败），所以一次失败请求不会变成两次平台请求：第一次失败
+立刻读取房间，随后同一房间在 `roomStatusRefreshWindow` 内的失败提示会合并成窗口末尾的一次补读——被 debounce，
+但不会被丢弃，因此第一次读取之后才发生的状态变化仍能被及时看到。手动激活属于命令而非提示，永远会真正读取，
+并为它之后的失败提示开启同一个窗口。
 
 当日志不够用时，`/diagnose` 可以交互式地看到同样的状态，见 [诊断与调试流](#诊断与调试流)。
 

--- a/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
@@ -345,6 +345,7 @@ class HttpServerComponent(
                     val statuses = requestBus.request<Map<Long, Map<String, Any>>>(GetRoomDetailedStatus)
                     val sessions = requestBus.request<List<RoomSession>>(GetSessions)
                     val armedIds = requestBus.request<List<Long>>(GetArmedRoomIds).toSet()
+                    val preconfiguringIds = requestBus.request<List<Long>>(GetPreconfiguringRoomIds).toSet()
                     val metrics = metricComponent.prometheusText()
 
                     val json = Json { encodeDefaults = true }
@@ -361,7 +362,13 @@ class HttpServerComponent(
                             rooms.forEach { r ->
                                 val s = sessions.find { it.roomId == r.id }
                                 val isArmed = r.id in armedIds
-                                val isActive = s?.state == SessionState.Fetching || s?.state == SessionState.Recording
+                                // Preconfiguration is not recording. A session from an earlier
+                                // incarnation can still be closing while the scheduler has already
+                                // moved on — deactivate followed by re-activate — and reporting that
+                                // stale session as Recording would claim a recording that is not
+                                // running. Recording is only ever reported once preconfig succeeded.
+                                val isActive = r.id !in preconfiguringIds &&
+                                    (s?.state == SessionState.Fetching || s?.state == SessionState.Recording)
                                 add(buildJsonObject {
                                     put("session", buildJsonObject {
                                         put("status", when {
@@ -369,7 +376,7 @@ class HttpServerComponent(
                                             isArmed -> "Listening"
                                             else -> s?.state?.name ?: ""
                                         })
-                                        put("active", s?.state == SessionState.Recording)
+                                        put("active", isActive && s.state == SessionState.Recording)
                                         put("quality", s?.quality ?: "")
                                         put("startTime", if (isActive) s.startTime.toEpochMilli() else 0L)
                                     })

--- a/src/main/kotlin/github/rikacelery/v3/components/RoomComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/RoomComponent.kt
@@ -49,6 +49,21 @@ class RoomComponent(
     private var ready = false
     private var saveDebounceJob: Job? = null
     private var refreshDebounceJob: Job? = null
+
+    /**
+     * Rooms whose status was read within the last [RuntimeTuning.roomStatusRefreshWindow], so a
+     * burst of failure-driven refreshes (see [RefreshRoomCmd.coalesce]) cannot become a burst of
+     * platform requests. Each entry is removed once its window job completes.
+     */
+    private val refreshWindows = ConcurrentHashMap<Long, Job>()
+
+    /**
+     * Rooms that saw a coalesced hint during their window. One catch-up read at the window's tail
+     * is enough no matter how many hints landed, and it is what keeps the debounce from *losing* a
+     * status change: the first read happens immediately, the catch-up covers whatever moved after
+     * it, so the room does not have to wait for the next failure or the poll to notice.
+     */
+    private val catchUpRefreshes = ConcurrentHashMap<Long, Boolean>()
     private val saveLock = Mutex()
 
     @Volatile
@@ -233,7 +248,7 @@ class RoomComponent(
             is RefreshRoomCmd -> {
                 val room = rooms[cmd.roomId]
                     ?: throw NoSuchElementException("room ${cmd.roomId} not found")
-                refreshRoomStatus(room)
+                refreshRoomStatus(room, cmd.coalesce)
                 OkResponse
             }
 
@@ -263,7 +278,39 @@ class RoomComponent(
         }
     }
 
-    private suspend fun refreshRoomStatus(room: Room) {
+    /**
+     * Reads one room's status now, unless it was just read.
+     *
+     * A `coalesce` refresh is the failure-driven hint a session or a preconfig probe sends when its
+     * playlist turns 403/404: the two failures usually land within a second of each other for the
+     * same room and mean the same thing, so only the first one reads. The hint is not thrown away,
+     * though — it queues one catch-up read for the tail of [RuntimeTuning.roomStatusRefreshWindow],
+     * so a status that moved just after the first read is still noticed promptly. A forced refresh
+     * (activation) always reads, and it arms the same window for the hints that follow it.
+     */
+    private suspend fun refreshRoomStatus(room: Room, coalesce: Boolean) {
+        if (coalesce && refreshWindows[room.id]?.isActive == true) {
+            if (catchUpRefreshes.putIfAbsent(room.id, true) == null) {
+                logger.debug("refreshRoom: room {} was just read, deferring one catch-up read", room.id)
+            }
+            return
+        }
+        readRoomStatus(room)
+    }
+
+    private suspend fun readRoomStatus(room: Room) {
+        catchUpRefreshes.remove(room.id)
+        // Arm before the request so two hints that arrive back to back cannot both reach the
+        // platform: the second one sees this window even while the first read is in flight.
+        val window = scope.launch {
+            delay(runtimeTuning.roomStatusRefreshWindow)
+            if (catchUpRefreshes.remove(room.id) != null) {
+                logger.debug("refreshRoom: catch-up read for room {} after the debounce window", room.id)
+                readRoomStatus(room)
+            }
+        }
+        refreshWindows[room.id] = window
+        window.invokeOnCompletion { refreshWindows.remove(room.id, window) }
         val status = roomStatusFetcher(room.name)
         val current = rooms[room.id] ?: return
         if (status != current.status) {

--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -964,6 +964,9 @@ class SchedulerComponent(
 
             is GetArmedRoomIds -> entries.keys().toList()
 
+            is GetPreconfiguringRoomIds ->
+                entries.filterValues { it.fsm.currentState == SchedulerState.Preconfiguring }.keys.toList()
+
             is GetRecordingHints -> RecordingHintsResponse(
                 entries.mapNotNull { (roomId, entry) -> entry.hint()?.let { roomId to it } }.toMap()
             )

--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -485,25 +485,69 @@ class SchedulerEntry(
      * segments is a property of the live stream that changes second to second, so rejecting on it
      * here would refuse rooms that are about to be recordable. A stream that stops delivering is
      * caught by the session's own stall watchdog instead.
+     *
+     * A 403/404 is different from every other failure: the token was accepted by the platform, so
+     * the CDN refusing the playlist means the room itself moved on — the show ended, the room went
+     * offline, or the private show was replaced. The room is asked to re-read its status (see
+     * [refreshRoomStatus]) because the stale value in the dashboard and in this entry is exactly
+     * what keeps the loop retrying a stream that no longer exists.
      */
     private suspend fun playlistProbe(url: String): String? {
+        var rejected = false
         // The probe reports success as an *empty string*, not null: `withTimeoutOrNull` also yields
         // null, so a null-able "ok" would be indistinguishable from a probe that ran out of time.
         val reason: String? = try {
             withTimeoutOrNull(component.runtimeTuning.preconfigProbeTimeout) {
                 val client = component.httpClientProvider.proxied("preconfig_$roomId")
                 val response = withRetry(2) { client.get(url) }
-                if (response.status.value in 200..299) "" else "playlist unusable (HTTP ${response.status.value})"
+                if (response.status.value in 200..299) "" else {
+                    rejected = response.status.isRejection()
+                    "playlist unusable (HTTP ${response.status.value})"
+                }
             }
         } catch (e: CancellationException) {
             throw e
+        } catch (e: ClientRequestException) {
+            // the client throws on 4xx, so this is the branch a 403/404 actually takes
+            rejected = e.response.status.isRejection()
+            "playlist unusable (HTTP ${e.response.status.value})"
         } catch (e: Exception) {
             "playlist unusable (${e.message ?: e::class.simpleName})"
         }
+        // Outside the watchdog on purpose: its budget bounds the CDN request, and a refresh that
+        // needs longer than that must not turn the 404 into a "probe timed out".
+        if (rejected) refreshRoomStatus()
         return when {
             reason == null -> "playlist unusable (probe timed out)"
             reason.isEmpty() -> null
             else -> reason
+        }
+    }
+
+    private fun HttpStatusCode.isRejection(): Boolean =
+        this == HttpStatusCode.NotFound || this == HttpStatusCode.Forbidden
+
+    /**
+     * Ask the RoomComponent to re-read this room's status, the same way a session does when a live
+     * playlist turns 403/404. The refresh only publishes [RoomStatusChanged] when the platform
+     * actually reports a different status, and the `Preconfiguring` state re-arms the room on that
+     * event once it is no longer recordable — which also stops this loop.
+     *
+     * The probe's failure is the answer the caller needs, so a refresh that fails is logged and
+     * swallowed: the loop retries on its own interval either way.
+     */
+    private suspend fun refreshRoomStatus() {
+        try {
+            // coalesce: a session whose playlist turned 403/404 just asked for the same room, and
+            // that refresh is still inside the RoomComponent's debounce window
+            component.requestBus.request<OkResponse>(RefreshRoomCmd(roomId, coalesce = true))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            schedulerLogger.warn(
+                "Preconfig playlist rejected and the room status refresh failed roomId={}: {}",
+                roomId, e.message
+            )
         }
     }
 }

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -399,7 +399,9 @@ class SessionEntry(
 
     private suspend fun refreshRoomStatus() {
         try {
-            component.requestBus.request<OkResponse>(RefreshRoomCmd(roomId))
+            // coalesce: the room may fail preconfig right after this session, and that second
+            // failure means the same thing as this one
+            component.requestBus.request<OkResponse>(RefreshRoomCmd(roomId, coalesce = true))
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/src/main/kotlin/github/rikacelery/v3/data/RuntimeTuning.kt
+++ b/src/main/kotlin/github/rikacelery/v3/data/RuntimeTuning.kt
@@ -8,6 +8,14 @@ import kotlin.time.Duration.Companion.seconds
 data class RuntimeTuning(
     val roomPollInterval: Duration = 5.minutes,
     val roomRefreshDebounce: Duration = 1500.milliseconds,
+    /**
+     * How long a room's status read absorbs further failure-driven refreshes: a session playlist
+     * that turned 403/404 and, moments later, a preconfig probe that did the same collapse into one
+     * immediate read plus at most one catch-up read at the end of this window, instead of two
+     * immediate platform requests. Activation ignores the window: that refresh is a command, not a
+     * hint.
+     */
+    val roomStatusRefreshWindow: Duration = 2.seconds,
     val webSocketReconnectInitial: Duration = 1.seconds,
     val webSocketReconnectMax: Duration = 30.seconds,
     val preconfigRetryInterval: Duration = 15.seconds,

--- a/src/main/kotlin/github/rikacelery/v3/events/Commands.kt
+++ b/src/main/kotlin/github/rikacelery/v3/events/Commands.kt
@@ -164,8 +164,17 @@ data class DeductCoins(val userId: Long, val amount: Long) : Request {
 object ShutdownCmd : Request {
     override fun toString() = "ShutdownCmd"
 }
-data class RefreshRoomCmd(val roomId: Long) : Request {
-    override fun toString() = "RefreshRoomCmd(roomId=$roomId)"
+/**
+ * Re-read one room's status from the platform.
+ *
+ * [coalesce] marks a refresh that is a *hint* rather than a command: a session or a preconfig probe
+ * that saw a 403/404 wants a fresh status, but a room whose status was read moments ago (see
+ * `RuntimeTuning.roomStatusRefreshWindow`) is not read again until the tail of that window at the
+ * earliest. Activation leaves it `false`: the user asked for this room, so it always goes to the
+ * platform.
+ */
+data class RefreshRoomCmd(val roomId: Long, val coalesce: Boolean = false) : Request {
+    override fun toString() = "RefreshRoomCmd(roomId=$roomId, coalesce=$coalesce)"
 }
 
 // ── RequestBus responses ──

--- a/src/main/kotlin/github/rikacelery/v3/events/Commands.kt
+++ b/src/main/kotlin/github/rikacelery/v3/events/Commands.kt
@@ -148,6 +148,16 @@ object GetSessions : Request {
 object GetArmedRoomIds : Request {
     override fun toString() = "GetArmedRoomIds"
 }
+/**
+ * Rooms whose scheduler is resolving the stream right now — token, quality and playlist URL.
+ *
+ * Recording only starts once that succeeds, so the dashboard must not report these rooms as
+ * recording: a session from an earlier incarnation can still be closing while the scheduler has
+ * already moved on to preconfiguration, and that stale session would otherwise read as `Recording`.
+ */
+object GetPreconfiguringRoomIds : Request {
+    override fun toString() = "GetPreconfiguringRoomIds"
+}
 object GetRoomDetailedStatus : Request {
     override fun toString() = "GetRoomDetailedStatus"
 }

--- a/src/test/kotlin/github/rikacelery/v3/components/HttpRoutesTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/HttpRoutesTest.kt
@@ -9,8 +9,14 @@ import github.rikacelery.v3.events.AddRoom
 import github.rikacelery.v3.events.CommandAck
 import github.rikacelery.v3.events.CommandEnvelope
 import github.rikacelery.v3.events.DeactivateCmd
+import github.rikacelery.v3.events.GetArmedRoomIds
+import github.rikacelery.v3.events.GetPreconfiguringRoomIds
+import github.rikacelery.v3.events.GetRecordingHints
+import github.rikacelery.v3.events.GetRoomDetailedStatus
 import github.rikacelery.v3.events.GetRooms
+import github.rikacelery.v3.events.GetSessions
 import github.rikacelery.v3.events.OkResponse
+import github.rikacelery.v3.events.RecordingHintsResponse
 import github.rikacelery.v3.events.RoomNameResponse
 import github.rikacelery.v3.hooks.EventHook
 import io.ktor.client.request.get
@@ -21,9 +27,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.serialization.json.*
 import org.junit.jupiter.api.Test
+import java.time.Instant
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -113,6 +123,59 @@ class HttpRoutesTest {
             val html = response.bodyAsText()
             assertTrue(html.contains("Room Settings"), "the dashboard must carry the room settings dialog")
             assertTrue(html.contains("/filter?id="), "the dialog must call the recording filter route")
+        } finally {
+            harness.close()
+        }
+    }
+
+    /**
+     * Recording may only be shown while it is actually happening. A session from an earlier
+     * incarnation can still be closing — and `GetSessions` still reports that as Recording — while
+     * the scheduler has already moved on to preconfiguration (deactivate, then re-activate). The
+     * dashboard must report the room as Listening for that window instead of claiming a recording
+     * that is not running, and it must go back to Recording once preconfig is done.
+     */
+    @Test
+    fun `the dashboard never reports a preconfiguring room as recording`() = testApplication {
+        val harness = RouteHarness()
+        val preconfiguring = AtomicReference(listOf(1001L))
+        try {
+            harness.eventBus.installHook(object : EventHook {
+                override suspend fun intercept(event: Any): Any? {
+                    if (event is CommandEnvelope) {
+                        val answer = when (event.command) {
+                            is GetRooms -> listOf(harness.room)
+                            // the session of the previous incarnation is still closing: it maps to
+                            // Recording, which is exactly what must not leak into the UI here
+                            is GetSessions -> listOf(
+                                RoomSession(1001, "model", "highest", SessionState.Recording, Instant.now())
+                            )
+
+                            is GetArmedRoomIds -> listOf(1001L)
+                            is GetPreconfiguringRoomIds -> preconfiguring.get()
+                            is GetRecordingHints -> RecordingHintsResponse(emptyMap())
+                            is GetRoomDetailedStatus -> emptyMap<Long, Map<String, Any>>()
+                            else -> null
+                        }
+                        if (answer != null) harness.eventBus.publish(CommandAck(event.id, answer))
+                    }
+                    return event
+                }
+            })
+            application { harness.server.installApplication(this, stopEngine = {}) }
+
+            suspend fun session(): JsonObject = Json.parseToJsonElement(client.get("/dashboard").bodyAsText())
+                .jsonObject["listv2"]!!.jsonArray.single().jsonObject["session"]!!.jsonObject
+
+            val duringPreconfig = session()
+            assertEquals("Listening", duringPreconfig["status"]!!.jsonPrimitive.content)
+            assertFalse(duringPreconfig["active"]!!.jsonPrimitive.boolean, "preconfiguration is not a recording")
+            assertEquals(0L, duringPreconfig["startTime"]!!.jsonPrimitive.long)
+
+            preconfiguring.set(emptyList())
+            val recording = session()
+            assertEquals("Recording", recording["status"]!!.jsonPrimitive.content)
+            assertTrue(recording["active"]!!.jsonPrimitive.boolean)
         } finally {
             harness.close()
         }

--- a/src/test/kotlin/github/rikacelery/v3/components/RoomComponentTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/RoomComponentTest.kt
@@ -28,15 +28,18 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 class RoomComponentTest {
 
@@ -92,6 +95,72 @@ class RoomComponentTest {
         )
         component.stop()
         mockServer.close()
+    }
+
+    /**
+     * A session whose playlist turns 403/404 and, a moment later, the preconfig probe that does the
+     * same are two reports of one event. The first reads the room; the second is a hint, so it must
+     * not become a second platform request *and* must not be thrown away either: it queues exactly
+     * one catch-up read for the tail of the window, which is what notices a status that moved after
+     * the first read. Activation is a command, not a hint: it always reads, and it arms the window
+     * that absorbs the hints after it.
+     */
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun `a burst of failure-driven refreshes reads one room once per window`() = runTest(UnconfinedTestDispatcher()) {
+        val reads = AtomicInteger()
+        val eventBus = EventBus()
+        val requestBus = RequestBus(eventBus, backgroundScope)
+        val component = RoomComponent(
+            apiClient = ApiClient(),
+            listConfPath = Files.createTempFile("xhrec-room-coalesce", ".conf").toString(),
+            requestBus = requestBus,
+            eventBus = eventBus,
+            parentScope = backgroundScope,
+            runtimeTuning = RuntimeTuning(
+                roomPollInterval = Duration.INFINITE,
+                roomStatusRefreshWindow = 1.seconds
+            ),
+            roomStatusFetcher = {
+                reads.incrementAndGet()
+                "public"
+            }
+        )
+        component.start()
+        advanceUntilIdle()
+        component.internalAdd(1, "model", RoomSettings())
+
+        suspend fun hint(id: Long) {
+            component.handle(HandleRoomCommand(CommandEnvelope(id, RefreshRoomCmd(1, coalesce = true))))
+        }
+
+        hint(1)
+        hint(2)
+        hint(3)
+        runCurrent()
+        assertEquals(1, reads.get(), "only the first hint reads immediately")
+
+        advanceTimeBy(1001)
+        runCurrent()
+        assertEquals(2, reads.get(), "the hints inside the window still cause one catch-up read")
+
+        advanceTimeBy(1001)
+        runCurrent()
+        assertEquals(2, reads.get(), "a window with no further hint reads nothing more")
+
+        component.handle(HandleRoomCommand(CommandEnvelope(4, RefreshRoomCmd(1))))
+        runCurrent()
+        assertEquals(3, reads.get(), "activation is a command: it reads even inside the window")
+
+        hint(5)
+        runCurrent()
+        assertEquals(3, reads.get(), "a hint right after a forced read is coalesced too")
+
+        advanceTimeBy(1001)
+        runCurrent()
+        assertEquals(4, reads.get(), "and its catch-up read still happens")
+
+        component.stop()
     }
 
     @Test

--- a/src/test/kotlin/github/rikacelery/v3/components/SchedulerPreconfigRefreshTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/SchedulerPreconfigRefreshTest.kt
@@ -1,0 +1,241 @@
+package github.rikacelery.v3.components
+
+import github.rikacelery.v3.api.ApiClient
+import github.rikacelery.v3.core.DataChannel
+import github.rikacelery.v3.core.EventBus
+import github.rikacelery.v3.core.RequestBus
+import github.rikacelery.v3.data.RoomSettings
+import github.rikacelery.v3.data.RuntimeTuning
+import github.rikacelery.v3.events.CommandAck
+import github.rikacelery.v3.events.CommandEnvelope
+import github.rikacelery.v3.events.ConfigResponse
+import github.rikacelery.v3.events.DecryptKeyMatch
+import github.rikacelery.v3.events.GetDecryptKey
+import github.rikacelery.v3.events.GetRoomConfig
+import github.rikacelery.v3.events.MatchDecryptKeys
+import github.rikacelery.v3.events.OkResponse
+import github.rikacelery.v3.events.RefreshRoomCmd
+import github.rikacelery.v3.events.RoomConfigResponse
+import github.rikacelery.v3.events.RoomStatusChanged
+import github.rikacelery.v3.hooks.EventHook
+import github.rikacelery.v3.m3u8.M3u8Parser
+import github.rikacelery.v3.utils.CdnSelector
+import github.rikacelery.v3.utils.HttpClientProvider
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.coroutines.coroutineContext
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * A 403/404 from the variant playlist is the one preconfig failure that is not really about the
+ * network: the platform handed out a token, so the CDN refusing the playlist means the room moved
+ * on (the show ended, the room went offline, the private show was replaced). Left alone, the room
+ * keeps the stale status it was armed with and the preconfig loop retries a stream that no longer
+ * exists, which is exactly what the reported log shows:
+ *
+ * ```
+ * WARN v3.SchedulerEntry - Preconfig failed room=…: playlist unusable (Client request(…403…))
+ * ```
+ *
+ * The fix asks the RoomComponent to re-read the room on 403/404 (the same [RefreshRoomCmd] a live
+ * session sends when its playlist turns 403/404). A status that really changed comes back as
+ * [RoomStatusChanged], and `Preconfiguring` re-arms the room once it is no longer recordable.
+ */
+class SchedulerPreconfigRefreshTest {
+
+    @Test
+    fun `a 404 on the variant playlist asks the room component to refresh it`() = runBlocking {
+        withProbe(HttpStatusCode.NotFound) { h ->
+            assertTrue(
+                awaitUntil { h.refreshes.get() > 0 },
+                "a 404 must ask RoomComponent to re-read the room (state=${h.entry.fsm.currentState})"
+            )
+            assertTrue(
+                awaitUntil { h.entry.lastFailReason == "playlist unusable (HTTP 404)" },
+                "a 404 is reported as an HTTP status, not a raw client message: ${h.entry.lastFailReason}"
+            )
+        }
+    }
+
+    @Test
+    fun `a 403 on the variant playlist asks the room component to refresh it`() = runBlocking {
+        withProbe(HttpStatusCode.Forbidden) { h ->
+            assertTrue(
+                awaitUntil { h.refreshes.get() > 0 },
+                "a 403 must ask RoomComponent to re-read the room (state=${h.entry.fsm.currentState})"
+            )
+            assertTrue(
+                awaitUntil { h.entry.lastFailReason == "playlist unusable (HTTP 403)" },
+                "a 403 is reported as an HTTP status, not a raw client message: ${h.entry.lastFailReason}"
+            )
+        }
+    }
+
+    @Test
+    fun `other playlist failures do not ask for a room refresh`() = runBlocking {
+        for (status in listOf(HttpStatusCode.Unauthorized, HttpStatusCode.InternalServerError)) {
+            withProbe(status) { h ->
+                assertTrue(
+                    awaitUntil { h.entry.lastFailReason?.startsWith("playlist unusable") == true },
+                    "the probe must fail for HTTP ${status.value}"
+                )
+                assertEquals(
+                    0,
+                    h.refreshes.get(),
+                    "HTTP ${status.value} is not a room-state signal, so the room must not be re-read"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `the refreshed status that ends the show re-arms the room and stops the loop`() = runBlocking {
+        withProbe(HttpStatusCode.NotFound) { h ->
+            assertTrue(awaitUntil { h.refreshes.get() > 0 }, "the rejected playlist must trigger the refresh")
+
+            // the RoomComponent answers a refresh by publishing RoomStatusChanged when, and only
+            // when, the platform reports a different status
+            h.eventBus.publish(RoomStatusChanged(7, "public", "off"))
+
+            assertTrue(
+                awaitUntil { h.entry.fsm.currentState == SchedulerState.Armed },
+                "a room that stopped being recordable must leave Preconfiguring (state=${h.entry.fsm.currentState})"
+            )
+            assertTrue(
+                awaitUntil { !h.entry.preconfigLoop.isRunning },
+                "re-arming the room must stop the preconfig loop instead of retrying a dead stream"
+            )
+            assertFalse(h.entry.preconfigLoop.isRunning)
+        }
+    }
+
+    // —— harness ——
+
+    private class Harness(
+        val scheduler: SchedulerComponent,
+        val entry: SchedulerEntry,
+        val eventBus: EventBus,
+        val refreshes: AtomicInteger
+    )
+
+    /**
+     * Runs one preconfig attempt against a mock CDN that answers [playlistStatus] for the selected
+     * variant playlist. Everything else (broadcast info, master playlist, decrypt keys) succeeds,
+     * so the room reaches the probe.
+     */
+    private suspend fun withProbe(playlistStatus: HttpStatusCode, block: suspend (Harness) -> Unit) {
+        val refreshes = AtomicInteger()
+        val cdn = HttpClient(MockEngine { request ->
+            when {
+                request.url.toString().endsWith("/api/front/v1/broadcasts/model") ->
+                    respond("""{"item":{"status":"public"}}""", headers = jsonHeaders)
+
+                request.url.encodedPath.startsWith("/master/") -> respond(masterPlaylist)
+
+                request.url.encodedPath == "/media/model.m3u8" ->
+                    respond("rejected", playlistStatus)
+
+                else -> error("unexpected request ${request.url}")
+            }
+        }) { expectSuccess = true }
+        val provider = object : HttpClientProvider {
+            override fun direct(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient = cdn
+            override fun proxied(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient = cdn
+        }
+        val eventBus = EventBus()
+        val scope = CoroutineScope(coroutineContext + SupervisorJob())
+        val requestBus = RequestBus(eventBus, scope)
+        eventBus.installHook(object : EventHook {
+            override suspend fun intercept(event: Any): Any? {
+                if (event is CommandEnvelope) {
+                    val answer = when (event.command) {
+                        is GetRoomConfig -> RoomConfigResponse(RoomSettings(pkey = "room-key"))
+                        is MatchDecryptKeys -> DecryptKeyMatch("key-id", "decrypt-key")
+                        is GetDecryptKey -> ConfigResponse("decrypt-key")
+                        is RefreshRoomCmd -> {
+                            refreshes.incrementAndGet()
+                            OkResponse
+                        }
+
+                        else -> null
+                    }
+                    if (answer != null) eventBus.publish(CommandAck(event.id, answer))
+                }
+                return event
+            }
+        })
+        val dataChannel = DataChannel()
+        val downloader = DownloaderComponent(dataChannel, eventBus = eventBus, parentScope = scope)
+        val session = SessionComponent(dataChannel, downloader, M3u8Parser, requestBus, eventBus, scope)
+        val scheduler = SchedulerComponent(
+            requestBus = requestBus,
+            sessionComponent = session,
+            apiClient = ApiClient(listOf("ignored.invalid"), provider) { "http://127.0.0.1:18082" },
+            streamAuthKey = "stream-key",
+            eventBus = eventBus,
+            parentScope = scope,
+            httpClientProvider = provider,
+            // one attempt inside the test window; the retry behaviour has its own coverage
+            runtimeTuning = RuntimeTuning(
+                preconfigRetryInterval = 30.seconds,
+                preconfigProbeTimeout = 3.seconds
+            ),
+            masterUrlCandidates = { roomId, pkey, _ ->
+                listOf("http://127.0.0.1:18082/master/$roomId?pkey=$pkey")
+            }
+        )
+        val oldCdnHosts = CdnSelector.hosts
+        CdnSelector.updateHosts(emptyList())
+
+        try {
+            scheduler.start()
+            val entry = scheduler.internalAdd(7, "model", RoomSettings(pkey = "room-key"), isArmed = true)!!
+            scheduler.tell(
+                SchedulerSignal(7, SchedulerEvent.RoomStatusChanged, SchedulerDriveData(roomStatus = "public"))
+            )
+            block(Harness(scheduler, entry, eventBus, refreshes))
+        } finally {
+            scheduler.stop()
+            CdnSelector.updateHosts(oldCdnHosts)
+            scope.cancel()
+            cdn.close()
+        }
+    }
+
+    private suspend fun awaitUntil(
+        timeout: Duration = 5.seconds,
+        predicate: () -> Boolean
+    ): Boolean = withTimeoutOrNull(timeout) {
+        while (!predicate()) delay(20.milliseconds)
+        true
+    } ?: false
+
+    private companion object {
+        val jsonHeaders = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+
+        val masterPlaylist = """
+            #EXTM3U
+            #EXT-X-MOUFLON:PSCH:key-id
+            #EXT-X-STREAM-INF:BANDWIDTH=1000,RESOLUTION=640x360,FRAME-RATE=30
+            http://127.0.0.1:18082/media/model.m3u8
+        """.trimIndent()
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/components/SchedulerPreconfigStatusTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/SchedulerPreconfigStatusTest.kt
@@ -1,0 +1,106 @@
+package github.rikacelery.v3.components
+
+import github.rikacelery.v3.api.ApiClient
+import github.rikacelery.v3.core.DataChannel
+import github.rikacelery.v3.core.EventBus
+import github.rikacelery.v3.core.RequestBus
+import github.rikacelery.v3.data.RoomSettings
+import github.rikacelery.v3.data.RuntimeTuning
+import github.rikacelery.v3.events.CommandAck
+import github.rikacelery.v3.events.CommandEnvelope
+import github.rikacelery.v3.events.GetPreconfiguringRoomIds
+import github.rikacelery.v3.events.GetRoomConfig
+import github.rikacelery.v3.events.RoomConfigResponse
+import github.rikacelery.v3.hooks.EventHook
+import github.rikacelery.v3.m3u8.M3u8Parser
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.hours
+
+/**
+ * The dashboard has to tell "the room is resolving its stream" apart from "the room is recording",
+ * because Recording is only truthful once preconfiguration succeeded — and the session does not
+ * even exist before that. The scheduler is the component that knows, so it is the one that answers
+ * [GetPreconfiguringRoomIds].
+ */
+class SchedulerPreconfigStatusTest {
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun `a room is reported as preconfiguring only while its stream is being resolved`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val settings = RoomSettings(pkey = "streamKey")
+            val eventBus = EventBus()
+            val requestBus = RequestBus(eventBus, backgroundScope)
+            val dataChannel = DataChannel()
+            val downloader = DownloaderComponent(dataChannel, eventBus = eventBus, parentScope = backgroundScope)
+            val session = SessionComponent(dataChannel, downloader, M3u8Parser, requestBus, eventBus, backgroundScope)
+            val scheduler = SchedulerComponent(
+                requestBus,
+                session,
+                // a dead loopback host: the preconfig attempts fail immediately instead of touching the network
+                ApiClient(listOf("127.0.0.1:1")),
+                "streamKey",
+                eventBus,
+                backgroundScope,
+                runtimeTuning = RuntimeTuning(preconfigRetryInterval = 1.hours)
+            )
+            eventBus.installHook(object : EventHook {
+                override suspend fun intercept(event: Any): Any? {
+                    if (event is CommandEnvelope && event.command is GetRoomConfig) {
+                        eventBus.publish(CommandAck(event.id, RoomConfigResponse(settings)))
+                    }
+                    return event
+                }
+            })
+            scheduler.start()
+            advanceUntilIdle()
+
+            try {
+                val entry = scheduler.internalAdd(42, "model", settings, isArmed = true)!!
+                assertEquals(
+                    emptyList<Long>(),
+                    preconfiguring(requestBus),
+                    "an armed room that is still waiting for the show is not preconfiguring"
+                )
+
+                scheduler.tell(SchedulerSignal(42, SchedulerEvent.BeginPreconfig, null))
+                advanceUntilIdle()
+                entry.preconfigLoop.cancel()   // this test drives the state, not the probe
+                assertEquals(SchedulerState.Preconfiguring, entry.fsm.currentState)
+                assertEquals(
+                    listOf(42L),
+                    preconfiguring(requestBus),
+                    "the dashboard must be able to see that the room is still resolving its stream"
+                )
+
+                scheduler.tell(
+                    SchedulerSignal(
+                        42,
+                        SchedulerEvent.PreconfigDone,
+                        SchedulerDriveData(playlistUrl = "http://127.0.0.1:1/playlist.m3u8", quality = "720p")
+                    )
+                )
+                advanceUntilIdle()
+                assertEquals(SchedulerState.Recording, entry.fsm.currentState)
+                assertEquals(
+                    emptyList<Long>(),
+                    preconfiguring(requestBus),
+                    "recording begins only after preconfig succeeded, so the room is no longer preconfiguring"
+                )
+
+                scheduler.tell(SchedulerSignal(42, SchedulerEvent.BackToArmed, null))
+                advanceUntilIdle()
+                assertEquals(emptyList<Long>(), preconfiguring(requestBus))
+            } finally {
+                scheduler.stop()
+            }
+        }
+
+    private suspend fun preconfiguring(requestBus: RequestBus): List<Long> =
+        requestBus.request<List<Long>>(GetPreconfiguringRoomIds)
+}

--- a/src/test/kotlin/github/rikacelery/v3/data/RuntimeTuningTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/data/RuntimeTuningTest.kt
@@ -14,6 +14,7 @@ class RuntimeTuningTest {
 
         assertEquals(5.minutes, tuning.roomPollInterval)
         assertEquals(1500.milliseconds, tuning.roomRefreshDebounce)
+        assertEquals(2.seconds, tuning.roomStatusRefreshWindow)
         assertEquals(1.seconds, tuning.webSocketReconnectInitial)
         assertEquals(30.seconds, tuning.webSocketReconnectMax)
         assertEquals(15.seconds, tuning.preconfigRetryInterval)


### PR DESCRIPTION
## Symptom

When preconfig probes the selected variant playlist, the CDN answers 403/404:

```
WARN v3.SchedulerEntry - Preconfig failed room=197735067: playlist unusable
     (Client request(GET https://media-hls.doppiocdn.net/... 403 . Text: "Forbidden"))
```

The room keeps the status it was armed with and retries a stream that no longer exists every `preconfigRetryInterval`. The dashboard cannot see the room's real status, and it can show `REC` while the room is still being configured.

## Root cause

1. **A 403/404 was treated as just another failure.** `playlistProbe` fell into the generic branch for 4xx and only logged a line. A 403/404 is different: the platform already handed out a token, so the CDN refusing the playlist means the room itself moved on (the show ended, the room went offline, the private show was replaced). With the status frozen at its old value, the loop keeps retrying a dead stream.
2. **Failure hints were not coalesced.** A session whose playlist turns 403/404 already asks for a room refresh; preconfig then fails for the same room a moment later and sends a second platform request for a status that was just read.
3. **The dashboard looked at the session first and only then fell back to armed.** `GetSessions` maps `RecordingState.Closing` to `SessionState.Recording`. After a deactivate and re-activate (or while the previous session is still finalizing), the scheduler is already `Preconfiguring` while that stale session reads as Recording — so the configuring phase showed `REC`.

## Changes

**1. Preconfig 403/404 asks for a room refresh immediately**

- `playlistProbe` catches `ClientRequestException` separately: on 403/404 it sends `RefreshRoomCmd` to have the RoomComponent re-read the room — the same mechanism a session already uses when a live playlist turns 403/404. The failure reason becomes `playlist unusable (HTTP 403/404)`, matching the log sample the README documents.
- The refresh runs *outside* the probe watchdog: that budget bounds the CDN request, and a slow refresh must not turn the 404 into a "probe timed out".
- The RoomComponent publishes `RoomStatusChanged` only when the status actually changed; the scheduler's `Preconfiguring` state re-arms a room that stopped being recordable, which also stops the preconfig loop.

**2. Failure-driven refreshes are debounced per room**

- `RefreshRoomCmd` gains `coalesce`, which tells a failure hint apart from a user activation (a command).
- New `RuntimeTuning.roomStatusRefreshWindow` (2s by default): the first failure reads immediately, and the hints that arrive inside the window collapse into a single catch-up read at the window's tail — debounced, but never dropped, so a status that moved just after the first read is still noticed promptly. Hints after the window read as usual.
- Activation always reads, and it arms the same window for the hints that follow it.
- Both failure hints (session and preconfig) pass `coalesce = true`.

**3. The WebUI never reports a configuring room as Recording**

- New `GetPreconfiguringRoomIds`, answered by the scheduler, which is the only component that knows when recording really begins.
- For those rooms the dashboard no longer reuses the stale session's Recording: `status = Listening`, `active = false`, `startTime = 0`. Once preconfig succeeds the room goes back to `Recording`.

## Tests

- `SchedulerPreconfigRefreshTest` (new): a 403/404 triggers `RefreshRoomCmd`; 401/500 do not; the refreshed `RoomStatusChanged(→off)` takes the room back to `Armed` and stops the loop.
- `RoomComponentTest` (new case): three hints inside the window read once, then exactly one catch-up read at the tail; a window with no hint reads nothing more; activation ignores the window; a hint after an activation is coalesced and still gets its catch-up read.
- `HttpRoutesTest` (new case): with a stale session still reporting Recording and the scheduler preconfiguring, the dashboard must be `Listening` / `active=false` / `startTime=0`; after preconfig it goes back to `Recording` / `active=true`.
- `SchedulerPreconfigStatusTest` (new): `GetPreconfiguringRoomIds` contains the room only while it is `Preconfiguring`.
- `RuntimeTuningTest`: the new tuning default.

Full suite: `./gradlew test` → **298 passing**; `.github/scripts/check_compile_warnings.py` → **0 new warnings**.

## Commits

- `b8c39f7` fix(rooms): debounce failure-driven room status refreshes
- `98d70bd` fix(scheduler): refresh the room when preconfig rejects the playlist
- `30fc5f5` fix(webui): never report a preconfiguring room as recording

Ordered by dependency: debounce the existing failure-refresh path first (`coalesce` + window + catch-up read), then wire preconfig's 403/404 into the same mechanism, then the independent dashboard fix.
