### PR TITLE
fix(http): make a dead playlist connection recoverable instead of giving up reuse

### DIFF
--- a/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
@@ -431,6 +431,9 @@ class HttpServerComponent(
                                     put("totalSuccesses", stat.totalSuccesses)
                                     put("failures", stat.failures)
                                     put("coolingDown", stat.cooldownUntil > now)
+                                    put("playlistFailures", stat.playlistFailures)
+                                    put("playlistErrors", stat.playlistErrors)
+                                    put("playlistCoolingDown", stat.playlistCooldownUntil > now)
                                     run {
                                         val ps = CdnSelector.probeSnapshot(host)
                                         put("probeSamples", JsonPrimitive(ps?.samples ?: 0))

--- a/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
@@ -4,6 +4,7 @@ import github.rikacelery.v3.core.Actor
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.events.*
 import github.rikacelery.v3.utils.CdnSelector
+import github.rikacelery.v3.utils.HttpConnectionStats
 import github.rikacelery.v3.utils.ModelSchedule
 import kotlinx.coroutines.CoroutineScope
 import java.util.concurrent.ConcurrentHashMap
@@ -248,6 +249,7 @@ class MetricComponent(
             sb.appendLine("xhrec_segment_downloaded_current{roomId=\"$roomId\"} ${m.segmentDownloaded.get()}")
         }
         // CDN host duration metrics
+        val now = System.currentTimeMillis()
         val cdnStats = CdnSelector.snapshot()
         cdnStats.forEach { (host, stat) ->
             val durLabel = if (stat.estimatedDurationMs.isNaN()) "-1" else stat.estimatedDurationMs.toLong().toString()
@@ -263,6 +265,48 @@ class MetricComponent(
             sb.appendLine("# HELP xhrec_cdn_total_errors CDN host total errors")
             sb.appendLine("# TYPE xhrec_cdn_total_errors counter")
             sb.appendLine("xhrec_cdn_total_errors{host=\"$host\"} ${stat.totalErrors}")
+            sb.appendLine("# HELP xhrec_cdn_playlist_failures CDN host consecutive playlist fetch failures")
+            sb.appendLine("# TYPE xhrec_cdn_playlist_failures gauge")
+            sb.appendLine("xhrec_cdn_playlist_failures{host=\"$host\"} ${stat.playlistFailures}")
+            sb.appendLine("# HELP xhrec_cdn_playlist_cooldown CDN host cooling down for playlists (1) or not (0)")
+            sb.appendLine("# TYPE xhrec_cdn_playlist_cooldown gauge")
+            sb.appendLine("xhrec_cdn_playlist_cooldown{host=\"$host\"} ${if (stat.playlistCooldownUntil > now) 1 else 0}")
+        }
+
+        // Connection-level telemetry for the human-paced clients (playlist / master / preconfig),
+        // which is what separates the two causes of a playlist timeout:
+        //   reused climbing and waitHeadersAvg ≈ the per-attempt timeout -> dead pooled connection
+        //   newConnections climbing and connectAvg high                 -> host/edge is slow to dial
+        // The first is answered by the client eviction, the second by rotating the host.
+        val connStats = HttpConnectionStats.snapshot()
+        if (connStats.isNotEmpty()) {
+            sb.appendLine("# HELP xhrec_http_requests_total Requests observed on a human-paced HTTP client")
+            sb.appendLine("# TYPE xhrec_http_requests_total counter")
+            sb.appendLine("# HELP xhrec_http_new_connections_total Connections dialed for those requests")
+            sb.appendLine("# TYPE xhrec_http_new_connections_total counter")
+            sb.appendLine("# HELP xhrec_http_reused_connections_total Requests served from a pooled connection")
+            sb.appendLine("# TYPE xhrec_http_reused_connections_total counter")
+            sb.appendLine("# HELP xhrec_http_connect_seconds_total Time spent dialing those connections")
+            sb.appendLine("# TYPE xhrec_http_connect_seconds_total counter")
+            sb.appendLine("# HELP xhrec_http_wait_headers_seconds_total Time from request headers to response headers")
+            sb.appendLine("# TYPE xhrec_http_wait_headers_seconds_total counter")
+            sb.appendLine("# HELP xhrec_http_failures_total Failed calls, by failure phase")
+            sb.appendLine("# TYPE xhrec_http_failures_total counter")
+            sb.appendLine("# HELP xhrec_http_timeouts_total Failed calls that were timeouts")
+            sb.appendLine("# TYPE xhrec_http_timeouts_total counter")
+            sb.appendLine("# HELP xhrec_http_cancelled_total Calls cancelled before completion")
+            sb.appendLine("# TYPE xhrec_http_cancelled_total counter")
+            connStats.forEach { s ->
+                val labels = "role=\"${s.role}\",host=\"${s.host}\""
+                sb.appendLine("xhrec_http_requests_total{$labels} ${s.requests}")
+                sb.appendLine("xhrec_http_new_connections_total{$labels} ${s.newConnections}")
+                sb.appendLine("xhrec_http_reused_connections_total{$labels} ${s.reusedConnections}")
+                sb.appendLine("xhrec_http_connect_seconds_total{$labels} ${s.connectMsTotal / 1000.0}")
+                sb.appendLine("xhrec_http_wait_headers_seconds_total{$labels} ${s.waitHeadersMsTotal / 1000.0}")
+                sb.appendLine("xhrec_http_failures_total{$labels} ${s.failures}")
+                sb.appendLine("xhrec_http_timeouts_total{$labels} ${s.timeouts}")
+                sb.appendLine("xhrec_http_cancelled_total{$labels} ${s.cancelled}")
+            }
         }
 
         return sb.toString()

--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -39,6 +39,7 @@ import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.plugins.timeout
 import io.ktor.client.request.*
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.*
@@ -468,7 +469,7 @@ class SchedulerEntry(
             parameters["pkey"] = keyName
             token?.takeIf { it.isNotEmpty() }?.let { parameters["aclAuth"] = it }
         }.toString()
-        return CdnSelector.resolve(url)
+        return CdnSelector.resolvePlaylist(url)
     }
 
     /**
@@ -486,20 +487,37 @@ class SchedulerEntry(
      * here would refuse rooms that are about to be recordable. A stream that stops delivering is
      * caught by the session's own stall watchdog instead.
      *
+     * The outcome is fed back to [CdnSelector] as a *playlist* result: a failing host gets a
+     * playlist-specific cooldown (segment successes from other rooms cannot clear it) and its
+     * pooled client is dropped, so the next preconfig attempt neither reuses the connection that
+     * just failed nor re-picks the host by default.
+     *
      * A 403/404 is different from every other failure: the token was accepted by the platform, so
      * the CDN refusing the playlist means the room itself moved on — the show ended, the room went
      * offline, or the private show was replaced. The room is asked to re-read its status (see
      * [refreshRoomStatus]) because the stale value in the dashboard and in this entry is exactly
-     * what keeps the loop retrying a stream that no longer exists.
+     * what keeps the loop retrying a stream that no longer exists. A rejection carries no host
+     * penalty either.
      */
     private suspend fun playlistProbe(url: String): String? {
+        val host = CdnSelector.hostOf(url)
+        val attemptMs = component.runtimeTuning.playlistAttemptTimeout.inWholeMilliseconds
         var rejected = false
         // The probe reports success as an *empty string*, not null: `withTimeoutOrNull` also yields
         // null, so a null-able "ok" would be indistinguishable from a probe that ran out of time.
         val reason: String? = try {
             withTimeoutOrNull(component.runtimeTuning.preconfigProbeTimeout) {
                 val client = component.httpClientProvider.proxied("preconfig_$roomId")
-                val response = withRetry(2) { client.get(url) }
+                val response = withRetry(2) {
+                    client.get(url) {
+                        timeout {
+                            // Abort a dead pooled connection in the engine (which drops it) rather
+                            // than letting the watchdog cancel the whole probe on it.
+                            socketTimeoutMillis = attemptMs
+                            connectTimeoutMillis = attemptMs
+                        }
+                    }
+                }
                 if (response.status.value in 200..299) "" else {
                     rejected = response.status.isRejection()
                     "playlist unusable (HTTP ${response.status.value})"
@@ -513,6 +531,16 @@ class SchedulerEntry(
             "playlist unusable (HTTP ${e.response.status.value})"
         } catch (e: Exception) {
             "playlist unusable (${e.message ?: e::class.simpleName})"
+        }
+        // A host that did not serve the playlist is dropped and reported as a *playlist* failure, so
+        // the next attempt neither reuses the connection that just failed nor re-picks the host by
+        // default. A rejection is excluded: the room moved on, the host is fine.
+        val served = reason != null && reason.isEmpty()
+        if (served) {
+            CdnSelector.recordPlaylistSuccess(host)
+        } else if (!rejected) {
+            component.httpClientProvider.evict("preconfig_$roomId")
+            CdnSelector.recordPlaylistFailure(host)
         }
         // Outside the watchdog on purpose: its budget bounds the CDN request, and a refresh that
         // needs longer than that must not turn the 404 into a "probe timed out".
@@ -871,12 +899,14 @@ class SchedulerComponent(
             is WriterFatal -> {
                 logger.error("Writer fatal room {}: {}", event.roomId, event.error)
                 entries.remove(event.roomId)?.scope?.cancel()
+                evictRoomClients(event.roomId)
             }
             // A room removed from the list while armed/recording must be disarmed and its
             // recording stopped, otherwise the session keeps writing and the UI shows a
             // ghost row (see issue #141). Mirrors the DeactivateCmd branch.
             is RoomRemoved -> {
                 entries.remove(event.roomId)?.scope?.cancel()
+                evictRoomClients(event.roomId)
                 sessionComponent.tell(StopRecording(event.roomId, EndReason.UserStop))
                 logger.info("Room {} removed: disarmed and recording stopped", event.roomId)
             }
@@ -903,6 +933,17 @@ class SchedulerComponent(
     private suspend fun driveFsm(roomId: Long, event: SchedulerEvent, data: SchedulerDriveData?) {
         val e = entries[roomId] ?: return
         e.fsm.driveCatch(event, data)?.let { logger.error("Scheduler FSM drive failed", it) }
+    }
+
+    /**
+     * A room that stops being tracked releases every client its recording created. A pool that went
+     * bad must die with the room instead of being inherited by a future recording of the same id,
+     * and an unarmed room has no reason to keep sockets open.
+     */
+    private fun evictRoomClients(roomId: Long) {
+        httpClientProvider.evict("master_$roomId")
+        httpClientProvider.evict("preconfig_$roomId")
+        httpClientProvider.evict("m3u8_$roomId")
     }
 
     /** Arms a room loaded from list.conf and returns its entry, or null when it is not armed. */
@@ -952,6 +993,7 @@ class SchedulerComponent(
 
             is DeactivateCmd -> {
                 entries.remove(cmd.roomId)?.scope?.cancel()
+                evictRoomClients(cmd.roomId)
                 sessionComponent.tell(StopRecording(cmd.roomId, EndReason.UserStop))
                 logger.info("Room {} deactivated", cmd.roomId)
                 OkResponse
@@ -976,6 +1018,7 @@ class SchedulerComponent(
                 entries.forEach { (id, e) ->
                     sessionComponent.tell(StopRecording(id, EndReason.UserStop))
                     e.scope.cancel()
+                    evictRoomClients(id)
                 }
                 entries.clear()
                 OkResponse

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -15,10 +15,12 @@ import github.rikacelery.v3.fsm.StateMachine
 import github.rikacelery.v3.fsm.buildFsm
 import github.rikacelery.v3.m3u8.M3u8Parser
 import github.rikacelery.v3.m3u8.ParsedPlaylist
+import github.rikacelery.v3.utils.CdnSelector
 import github.rikacelery.v3.utils.DefaultHttpClientProvider
 import github.rikacelery.v3.utils.HttpClientProvider
 import github.rikacelery.v3.utils.withRetry
 import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.plugins.timeout
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.HttpStatusCode
@@ -198,6 +200,20 @@ class SessionEntry(
     var lastPollGap: Int = 0
     val circleCache = CircleCache(100)
 
+    /**
+     * CDN hosts this session already fetched the playlist from.
+     *
+     * The playlist URL is resolved exactly once, by the scheduler, before the session starts
+     * (`SchedulerEntry.resolveVariantUrl`); nothing downstream re-resolves it. A host that stops
+     * answering therefore keeps being polled until the session gives up on the whole recording and
+     * the scheduler preconfigures again — which picks the same host, because a failed playlist
+     * fetch never told [CdnSelector] anything. This set is what lets the session walk to the next
+     * host instead. It is deliberately session-local rather than a global host penalty: the same
+     * CDN serves other rooms' segments fine, so any host-level failure count would be reset by
+     * their next success long before it cooled the host down.
+     */
+    val playlistHostsTried = LinkedHashSet<String>()
+
     // —— scope / loop timer ——
     val scope = CoroutineScope(
         component.ioScope.coroutineContext + SupervisorJob(component.ioScope.coroutineContext[Job])
@@ -222,6 +238,12 @@ class SessionEntry(
 
     internal fun cutFile(reason: EndReason) {
         playlistLoop.cancel()
+        // A session that ends for good releases its playlist client: a pool that went bad must not
+        // be inherited by the next session of this room, and an idle room should not hold sockets.
+        // A time/size limit restarts on the *same* stream seconds later, so that one keeps it.
+        if (reason != EndReason.TimeLimit && reason != EndReason.SizeLimit) {
+            component.httpClientProvider.evict("m3u8_$roomId")
+        }
         launch {
             component.downloader.tell(
                 DoCutPoint(CutPoint(roomId, segmentIndex - 1, roomName, Instant.now(), reason, quality, generation))
@@ -371,7 +393,20 @@ class SessionEntry(
         return try {
             withTimeout(component.runtimeTuning.playlistFetchTimeout) {
                 val client = component.httpClientProvider.proxied("m3u8_$roomId")
-                val response = withRetry(3) { client.get(playlistUrl) }
+                val attemptMs = component.runtimeTuning.playlistAttemptTimeout.inWholeMilliseconds
+                val response = withRetry(3) {
+                    client.get(playlistUrl) {
+                        timeout {
+                            // Engine-level timeouts, deliberately below playlistFetchTimeout: a
+                            // pooled connection that stopped answering is aborted here, so OkHttp
+                            // drops it and HttpRequestRetry can dial a fresh one. Without this the
+                            // whole fetch budget is spent on one dead connection as a coroutine
+                            // cancellation, which no retry layer can observe.
+                            socketTimeoutMillis = attemptMs
+                            connectTimeoutMillis = attemptMs
+                        }
+                    }
+                }
                 val text = response.bodyAsText()
                 val key = (component.requestBus.request<ConfigResponse>(GetDecryptKey(pkey)).value as? String)
                     ?: return@withTimeout SessionSignal(
@@ -379,22 +414,59 @@ class SessionEntry(
                         RecordingDriveData(failReason = "no decrypt key")
                     )
                 val parsed = component.m3u8Parser.parse(text, key)
+                CdnSelector.recordPlaylistSuccess(CdnSelector.hostOf(playlistUrl))
                 SessionSignal(roomId, RecordingEvent.PlaylistFetched, RecordingDriveData(playlist = parsed))
             }
         } catch (e: TimeoutCancellationException) {
+            failOverPlaylistHost()
             SessionSignal(roomId, RecordingEvent.PlaylistFetchFailed, RecordingDriveData(failReason = "timeout"))
         } catch (e: ClientRequestException) {
             if (e.response.status == HttpStatusCode.NotFound || e.response.status == HttpStatusCode.Forbidden) {
                 refreshRoomStatus()
                 SessionSignal(roomId, RecordingEvent.PlaylistUnusable, RecordingDriveData(failReason = e.response.status.toString()))
             } else {
+                failOverPlaylistHost()
                 SessionSignal(roomId, RecordingEvent.PlaylistFetchFailed, RecordingDriveData(failReason = e.message))
             }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
+            failOverPlaylistHost()
             SessionSignal(roomId, RecordingEvent.PlaylistFetchFailed, RecordingDriveData(failReason = e.message))
         }
+    }
+
+    /**
+     * Move this session's playlist request to the next-best CDN host after a transport failure, and
+     * report the failure to [CdnSelector] so the host is penalized for the *next* preconfig too.
+     *
+     * Two levels, in this order:
+     *  1. drop this room's playlist client, so the retry cannot be handed the same pooled
+     *     connection that just failed;
+     *  2. move to a host outside [playlistHostsTried]. A plain `CdnSelector.resolve` would hand back
+     *     the same host, because its segment score is still the best one and playlist penalties live
+     *     apart from it. The session therefore keeps its own tried set — the same shape the segment
+     *     downloader uses — with a second pass over all hosts once every host has been tried
+     *     (playlist cooldowns are short, and the only remaining host may still be the working one).
+     *
+     * Returns true when the playlist actually moved to a different host.
+     */
+    internal fun failOverPlaylistHost(): Boolean {
+        val failed = CdnSelector.hostOf(playlistUrl)
+        if (failed.isEmpty()) return false
+        component.httpClientProvider.evict("m3u8_$roomId")
+        CdnSelector.recordPlaylistFailure(failed)
+        playlistHostsTried += failed
+        val next = CdnSelector.rankedPlaylistHosts(exclude = playlistHostsTried).firstOrNull()
+            ?: CdnSelector.rankedPlaylistHosts(includeCooling = true).firstOrNull()
+            ?: return false
+        if (next == failed) return false
+        playlistUrl = CdnSelector.rewriteHost(playlistUrl, next)
+        sessionLogger.warn(
+            "roomId={} playlist fetch failed on {}; switching the playlist to {}",
+            roomId, failed, next
+        )
+        return true
     }
 
     private suspend fun refreshRoomStatus() {
@@ -430,6 +502,8 @@ private fun buildSessionFsm(ctx: SessionEntry) =
                 previousNewSegmentId = null
                 lastPollGap = 0
                 circleCache.clear()   // a new file must re-download the init; media segments are skipped via the lastSegmentId threshold
+                // the playlist host is re-resolved by the scheduler for every new session
+                playlistHostsTried.clear()
                 launch { component.dataChannel.send(StreamStart(roomId, roomName, startTime, quality)) }
                 // LiveEventSource expands the WebSocket channel set and metrics start counting on this
                 launch { component.publish(RecordingStarted(roomId, quality)) }
@@ -717,6 +791,9 @@ internal fun SessionEntry.diagnoseJson(): JsonObject = buildJsonObject {
     put("totalBytes", totalBytes)
     put("retryCount", retryCount)
     put("playlistLoopRunning", playlistLoop.isRunning)
+    // Which hosts the playlist was already moved off in this session: the answer to "the playlist
+    // keeps timing out, why is it still on the same CDN?".
+    put("playlistHostsTried", buildJsonArray { playlistHostsTried.forEach { add(JsonPrimitive(it)) } })
     put("lastPollSegmentCount", lastPollSegmentCount)
     put("lastPollSkipped", lastPollSkipped)
     put("lastPollGap", lastPollGap)

--- a/src/main/kotlin/github/rikacelery/v3/data/RuntimeTuning.kt
+++ b/src/main/kotlin/github/rikacelery/v3/data/RuntimeTuning.kt
@@ -24,6 +24,16 @@ data class RuntimeTuning(
     val playlistPollInterval: Duration = 3.seconds,
     val playlistFetchTimeout: Duration = 10.seconds,
     /**
+     * Per-attempt read/connect timeout for a playlist request, applied as an HTTP-engine timeout.
+     *
+     * Deliberately smaller than [playlistFetchTimeout]: a pooled connection that stopped answering
+     * must be aborted by the engine (which drops it and lets the retry dial a fresh one) instead of
+     * consuming the whole fetch budget as one coroutine cancellation that no retry can observe.
+     * Size it against the real warm latency (a reused connection answers in well under a second) —
+     * too small turns a merely slow CDN into a host rotation.
+     */
+    val playlistAttemptTimeout: Duration = 4.seconds,
+    /**
      * How long a recording session may go without a single new media segment before it is
      * considered stalled. A playlist that only advertises `#EXT-X-MAP` (init) and no
      * `#EXT-X-MOUFLON` segments keeps the session in `Recording` while nothing is downloaded, so

--- a/src/main/kotlin/github/rikacelery/v3/utils/CdnSelector.kt
+++ b/src/main/kotlin/github/rikacelery/v3/utils/CdnSelector.kt
@@ -103,6 +103,15 @@ object CdnSelector {
         @Volatile var cooldownUntil: Long = 0L,
         @Volatile var lastDurationMs: Long = 0L,
 
+        /**
+         * Playlist-specific failure state, kept out of [failures]/[cooldownUntil] on purpose:
+         * [record] clears those on *any* success, and the bulk segment traffic of the other rooms
+         * would wipe a playlist penalty within milliseconds. Only a playlist success clears these.
+         */
+        @Volatile var playlistFailures: Int = 0,
+        @Volatile var playlistErrors: Int = 0,
+        @Volatile var playlistCooldownUntil: Long = 0L,
+
         /** Recent samples for anomaly detection (ring buffer, last 20). */
         @Volatile var recentDurations: LongArray = LongArray(20),
         @Volatile var recentIdx: Int = 0,
@@ -262,6 +271,45 @@ object CdnSelector {
         }
         try { PredictionEngine.onCdnFailure(host, now) } catch (_: Exception) { }
     }
+
+    /**
+     * Record a failed *playlist* fetch (variant or master playlist: transport error, timeout).
+     *
+     * Counted apart from [recordFailure] because a playlist and a segment exercise a host
+     * differently, and because the segment successes of every other room would otherwise clear the
+     * playlist penalty before it could ever trigger. Only [recordPlaylistSuccess] clears it.
+     *
+     * Business rejections (403/404: the room moved on) must NOT come through here — those say
+     * nothing about the host.
+     */
+    fun recordPlaylistFailure(host: String, now: Long = System.currentTimeMillis()) {
+        val stat = stats.computeIfAbsent(host) { HostStat() }
+        synchronized(stat) {
+            stat.playlistFailures++
+            stat.playlistErrors++
+            if (stat.playlistFailures >= CONSECUTIVE_FAILURE_THRESHOLD) {
+                val excess = stat.playlistFailures - CONSECUTIVE_FAILURE_THRESHOLD
+                val backoff = (BASE_COOLDOWN_MS * 2.0.pow(excess.coerceAtMost(5))).toLong()
+                    .coerceAtMost(MAX_COOLDOWN_MS)
+                stat.playlistCooldownUntil = now + backoff
+            }
+        }
+    }
+
+    /** A playlist was served: this host is healthy for playlists again. */
+    fun recordPlaylistSuccess(host: String) {
+        stats[host]?.let { stat ->
+            synchronized(stat) {
+                stat.playlistFailures = 0
+                stat.playlistCooldownUntil = 0L
+            }
+        }
+    }
+
+    /** Hosts not cooling down for *playlist* fetches. */
+    fun playlistAvailableHosts(now: Long = System.currentTimeMillis()): List<String> =
+        hosts.filter { host -> (stats[host]?.playlistCooldownUntil ?: 0L) <= now }
+
     /**
      * Record a probe result (independent measurement, not a main download).
      * Probes keep other hosts' stats fresh without consuming main-download traffic.
@@ -308,8 +356,16 @@ object CdnSelector {
     }
 
 
-    fun select(now: Long = System.currentTimeMillis()): String {
-        val avail = availableHosts(now)
+    fun select(now: Long = System.currentTimeMillis()): String = selectFrom(availableHosts(now), now)
+
+    /**
+     * Like [select], but skips hosts that are cooling down for *playlist* fetches. Used to resolve
+     * a variant playlist URL: a host that serves segments fine can still be the one that stopped
+     * answering playlists, and [record] would never keep that penalty alive.
+     */
+    fun selectPlaylist(now: Long = System.currentTimeMillis()): String = selectFrom(playlistAvailableHosts(now), now)
+
+    private fun selectFrom(avail: List<String>, now: Long): String {
         if (avail.isEmpty()) return hosts.firstOrNull() ?: ""
         if (avail.size == 1) return avail[0]
 
@@ -354,8 +410,17 @@ object CdnSelector {
         now: Long = System.currentTimeMillis(),
         includeCooling: Boolean = false,
         exclude: Set<String> = emptySet()
-    ): List<String> {
-        val pool = (if (includeCooling) hosts else availableHosts(now)).filter { it !in exclude }
+    ): List<String> = rankedFrom(if (includeCooling) hosts else availableHosts(now), now, exclude)
+
+    /** [rankedHosts] restricted to hosts that are not cooling down for playlist fetches. */
+    fun rankedPlaylistHosts(
+        now: Long = System.currentTimeMillis(),
+        includeCooling: Boolean = false,
+        exclude: Set<String> = emptySet()
+    ): List<String> = rankedFrom(if (includeCooling) hosts else playlistAvailableHosts(now), now, exclude)
+
+    private fun rankedFrom(candidates: List<String>, now: Long, exclude: Set<String>): List<String> {
+        val pool = candidates.filter { it !in exclude }
         if (pool.size <= 1) return pool
         val scores = scoredHosts(pool, now)
         val ranked = scores.sortedBy { it.second }.map { it.first }
@@ -365,6 +430,13 @@ object CdnSelector {
 
     fun resolve(url: String, now: Long = System.currentTimeMillis()): String {
         val host = select(now)
+        if (host.isEmpty()) return url
+        return rewriteHost(url, host)
+    }
+
+    /** [resolve] for a playlist URL: hosts cooling down for playlists are left out. */
+    fun resolvePlaylist(url: String, now: Long = System.currentTimeMillis()): String {
+        val host = selectPlaylist(now)
         if (host.isEmpty()) return url
         return rewriteHost(url, host)
     }
@@ -398,6 +470,10 @@ object CdnSelector {
         val totalSuccesses: Int,
         val cooldownUntil: Long,
         val lastDurationMs: Long,
+        /** Playlist-only failure state, tracked apart from [failures]/[cooldownUntil]. */
+        val playlistFailures: Int,
+        val playlistErrors: Int,
+        val playlistCooldownUntil: Long,
         /** Per-hour EWMA (ignoring day) for visualization. */
         val hourEwma: DoubleArray,
         val hourSamples: IntArray
@@ -428,6 +504,9 @@ object CdnSelector {
                     totalSuccesses = stat.totalSuccesses,
                     cooldownUntil = stat.cooldownUntil,
                     lastDurationMs = stat.lastDurationMs,
+                    playlistFailures = stat.playlistFailures,
+                    playlistErrors = stat.playlistErrors,
+                    playlistCooldownUntil = stat.playlistCooldownUntil,
                     hourEwma = stat.hourEwma.copyOf(),
                     hourSamples = stat.hourSamples.copyOf()
                 )
@@ -456,11 +535,15 @@ object CdnSelector {
             stats.forEach { it.value.run {
                 failures = 0
                 cooldownUntil = 0L
+                playlistFailures = 0
+                playlistCooldownUntil = 0L
             } }
         } else {
             stats[host]?.run {
                 failures = 0
                 cooldownUntil = 0L
+                playlistFailures = 0
+                playlistCooldownUntil = 0L
             }
         }
     }
@@ -491,6 +574,9 @@ object CdnSelector {
                         put("totalSuccesses", JsonPrimitive(stat.totalSuccesses))
                         put("cooldownUntil", JsonPrimitive(stat.cooldownUntil))
                         put("lastDurationMs", JsonPrimitive(stat.lastDurationMs))
+                        put("playlistFailures", JsonPrimitive(stat.playlistFailures))
+                        put("playlistErrors", JsonPrimitive(stat.playlistErrors))
+                        put("playlistCooldownUntil", JsonPrimitive(stat.playlistCooldownUntil))
                         put("recentDurations", buildJsonArray { stat.recentDurations.forEach { add(JsonPrimitive(it)) } })
                         put("recentIdx", JsonPrimitive(stat.recentIdx))
                         put("recentCount", JsonPrimitive(stat.recentCount))
@@ -546,6 +632,9 @@ object CdnSelector {
                     stat.totalSuccesses = obj["totalSuccesses"]?.jsonPrimitive?.content?.toIntOrNull() ?: 0
                     stat.cooldownUntil = obj["cooldownUntil"]?.jsonPrimitive?.content?.toLongOrNull() ?: 0L
                     stat.lastDurationMs = obj["lastDurationMs"]?.jsonPrimitive?.content?.toLongOrNull() ?: 0L
+                    stat.playlistFailures = obj["playlistFailures"]?.jsonPrimitive?.content?.toIntOrNull() ?: 0
+                    stat.playlistErrors = obj["playlistErrors"]?.jsonPrimitive?.content?.toIntOrNull() ?: 0
+                    stat.playlistCooldownUntil = obj["playlistCooldownUntil"]?.jsonPrimitive?.content?.toLongOrNull() ?: 0L
                     stat.recentDurations = obj["recentDurations"]?.jsonArray?.map { it.jsonPrimitive.content.toLong() }?.toLongArray()
                         ?: stat.recentDurations
                     stat.recentIdx = obj["recentIdx"]?.jsonPrimitive?.content?.toIntOrNull() ?: 0

--- a/src/main/kotlin/github/rikacelery/v3/utils/ClientManager.kt
+++ b/src/main/kotlin/github/rikacelery/v3/utils/ClientManager.kt
@@ -19,12 +19,47 @@ object ClientManager {
     private val logger = LoggerFactory.getLogger(ClientManager::class.java)
 
     /**
+     * The human-paced clients: a playlist, master or preconfig request every few seconds. They are
+     * the ones where a pooled connection can sit idle long enough for the peer (or a proxy) to drop
+     * it silently, so they get a shorter idle policy, HTTP/2 keep-alive pings and connection
+     * telemetry. The bulk segment clients (`dl_`/`px_`) keep the default pool and stay untouched:
+     * an [okhttp3.EventListener] and a ping timer on a path doing hundreds of requests per second
+     * is pure overhead, and their own stall watchdog already abandons dead connections.
+     */
+    private fun isStreamKey(key: String): Boolean =
+        key.startsWith("m3u8_") || key.startsWith("master_") || key.startsWith("preconfig_")
+
+    /** Role label for [HttpConnectionStats]; keep the set small, it labels metrics. */
+    private fun roleOf(key: String): String = when {
+        key.startsWith("m3u8_") -> "playlist"
+        key.startsWith("master_") -> "master"
+        key.startsWith("preconfig_") -> "preconfig"
+        key.startsWith("dl_") -> "download"
+        key.startsWith("px_") -> "proxy"
+        else -> "other"
+    }
+
+    /**
+     * A stream client polls every few seconds, so a connection idle for more than 30s is not doing
+     * useful work — but it can still be a socket the peer quietly dropped, and handing that to the
+     * next poll costs a full timeout. Dropping it early costs one handshake that would have to
+     * happen anyway. Bulk clients keep the default 5 minutes.
+     */
+    private fun newPool(stream: Boolean): ConnectionPool =
+        if (stream) ConnectionPool(4, 30, TimeUnit.SECONDS)
+        else ConnectionPool(16, 5, TimeUnit.MINUTES)
+
+    /**
      * http1=true forces HTTP/1.1 — required for the stripchat.com WAF: its HTTP/2
      * fingerprint check rejects OkHttp (non-browser h2), while HTTP/1.1 + browser
      * navigation headers passes. CDN clients (doppiocdn.org) keep HTTP/2.
      */
     private fun clientDirect(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient {
-        val pool = ConnectionPool(16, 5, TimeUnit.MINUTES)
+        val stream = isStreamKey(key)
+        // Created once and captured: Ktor derives a separate OkHttpClient per request-timeout
+        // profile, and they must share this pool or connection reuse would be lost per profile.
+        val pool = newPool(stream)
+        val listener = if (stream) ConnectionStatsListener(roleOf(key)) else null
         logger.debug("create direct client key={} http1={} expectSuccess={}", key, http1, expectSuccess)
         return HttpClient(OkHttp) {
             configureClient()
@@ -35,13 +70,21 @@ object ClientManager {
                     followSslRedirects(true)
                     followRedirects(true)
                     if (http1) protocols(listOf(Protocol.HTTP_1_1))
+                    if (listener != null) {
+                        // PINGs notice a connection the peer dropped without a GOAWAY/RST; ignored
+                        // on HTTP/1.1.
+                        pingInterval(20, TimeUnit.SECONDS)
+                        eventListener(listener)
+                    }
                 }
             }
         }
     }
 
     private fun clientProxied(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient {
-        val pool = ConnectionPool(16, 5, TimeUnit.MINUTES)
+        val stream = isStreamKey(key)
+        val pool = newPool(stream)
+        val listener = if (stream) ConnectionStatsListener(roleOf(key)) else null
         val proxyEnv = System.getenv("http_proxy") ?: System.getenv("HTTP_PROXY")
         logger.info("create proxied client key={} proxy={} http1={} expectSuccess={}", key, proxyEnv, http1, expectSuccess)
         return HttpClient(OkHttp) {
@@ -64,6 +107,10 @@ object ClientManager {
                     followSslRedirects(true)
                     followRedirects(true)
                     if (http1) protocols(listOf(Protocol.HTTP_1_1))
+                    if (listener != null) {
+                        pingInterval(20, TimeUnit.SECONDS)
+                        eventListener(listener)
+                    }
                 }
             }
         }
@@ -136,15 +183,30 @@ object ClientManager {
         }
     }
 
-    /** Close and remove the per-room clients created for a recording session. */
-    fun removeRoomClients(roomId: Long) {
+    /**
+     * Close and forget a client, so its pooled connections die with it and the next request dials
+     * fresh. Called when a request failed on a connection that may itself be the problem, and when
+     * a room's streams end: a client kept across sessions would keep handing the same dead pooled
+     * connection to every retry.
+     */
+    fun removeClient(key: String) {
         synchronized(lock) {
-            listOf("m3u8_$roomId", "master_$roomId").forEach { key ->
-                clientsProxied.remove(key)?.let { client ->
-                    runCatching { client.close() }
-                    logger.info("Closed per-room client {}", key)
-                }
+            clientsProxied.remove(key)?.let { client ->
+                runCatching { client.close() }
+                logger.debug("Evicted proxied client {}", key)
             }
+            clientsDirect.remove(key)?.let { client ->
+                runCatching { client.close() }
+                logger.debug("Evicted direct client {}", key)
+            }
+        }
+    }
+
+    /** Close and remove every client a room's recording may have created. */
+    fun removeRoomClients(roomId: Long) {
+        listOf("m3u8_$roomId", "master_$roomId", "preconfig_$roomId").forEach { key ->
+            synchronized(lock) { if (clientsProxied.containsKey(key)) logger.info("Closed per-room client {}", key) }
+            removeClient(key)
         }
     }
 

--- a/src/main/kotlin/github/rikacelery/v3/utils/HttpClientProvider.kt
+++ b/src/main/kotlin/github/rikacelery/v3/utils/HttpClientProvider.kt
@@ -5,6 +5,13 @@ import io.ktor.client.HttpClient
 interface HttpClientProvider {
     fun direct(key: String, http1: Boolean = false, expectSuccess: Boolean = true): HttpClient
     fun proxied(key: String, http1: Boolean = false, expectSuccess: Boolean = true): HttpClient
+
+    /**
+     * Drop [key]'s pooled connections so the next request dials fresh. Used after a request failed
+     * in a way that may implicate the connection itself (a timeout on a pooled connection) and
+     * when a room's streams end. Default no-op so test providers need no change.
+     */
+    fun evict(key: String) {}
 }
 
 object DefaultHttpClientProvider : HttpClientProvider {
@@ -13,4 +20,6 @@ object DefaultHttpClientProvider : HttpClientProvider {
 
     override fun proxied(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient =
         ClientManager.getProxiedClient(key, http1, expectSuccess)
+
+    override fun evict(key: String) = ClientManager.removeClient(key)
 }

--- a/src/main/kotlin/github/rikacelery/v3/utils/HttpConnectionStats.kt
+++ b/src/main/kotlin/github/rikacelery/v3/utils/HttpConnectionStats.kt
@@ -1,0 +1,213 @@
+package github.rikacelery.v3.utils
+
+import okhttp3.Call
+import okhttp3.Connection
+import okhttp3.EventListener
+import okhttp3.Request
+import java.io.IOException
+import java.io.InterruptedIOException
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.net.SocketTimeoutException
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.LongAdder
+
+/**
+ * Connection-level telemetry for the human-paced HTTP clients (playlist / master / preconfig).
+ *
+ * This answers a question the aggregate CDN stats cannot: when a request times out, was it a
+ * *fresh* connection that was slow, or a *pooled* one that had stopped answering? The two have
+ * opposite remedies — the first is a network/edge problem (rotate the host), the second is a
+ * connection-liveness problem (drop the connection and dial again) — and only the HTTP engine can
+ * tell them apart. An [okhttp3.EventListener] therefore feeds this object, attached to those
+ * clients only; the bulk segment clients keep their hot path free of instrumentation.
+ *
+ * Reading it:
+ *  - `reused > 0` and `waitHeadersAvg` close to the per-attempt timeout → the pool handed out a
+ *    dead connection (the case the eviction in [ClientManager.removeClient] exists for);
+ *  - `newConnections` high and `connectMsAvg` high → connecting itself is slow (edge/DNS), so host
+ *    rotation is the fix, not connection recycling;
+ *  - `failures` with `phase=connect` → the dial failed before any request was written.
+ *
+ * The counters are cumulative and cheap (LongAdder); [MetricComponent] renders them as Prometheus
+ * text and `/config/hosts` exposes the per-host averages.
+ */
+object HttpConnectionStats {
+
+    /** One (role, host) pair. Roles come from the client key, see `ClientManager.roleOf`. */
+    data class Snapshot(
+        val role: String,
+        val host: String,
+        val requests: Long,
+        val newConnections: Long,
+        val reusedConnections: Long,
+        val connectMsTotal: Long,
+        val waitHeadersSamples: Long,
+        val waitHeadersMsTotal: Long,
+        val failures: Long,
+        val timeouts: Long,
+        val cancelled: Long,
+        val lastFailure: String?
+    ) {
+        val connectMsAvg: Long get() = if (newConnections > 0) connectMsTotal / newConnections else 0
+        val waitHeadersMsAvg: Long get() = if (waitHeadersSamples > 0) waitHeadersMsTotal / waitHeadersSamples else 0
+    }
+
+    private class Counters {
+        val requests = LongAdder()
+        val newConnections = LongAdder()
+        val reusedConnections = LongAdder()
+        val connectMsTotal = LongAdder()
+        val waitHeadersSamples = LongAdder()
+        val waitHeadersMsTotal = LongAdder()
+        val failures = LongAdder()
+        val timeouts = LongAdder()
+        val cancelled = LongAdder()
+
+        @Volatile
+        var lastFailure: String? = null
+    }
+
+    private val counters = ConcurrentHashMap<String, Counters>()
+
+    private fun countersFor(role: String, host: String): Counters =
+        counters.computeIfAbsent("$role|${host.ifEmpty { "?" }}") { Counters() }
+
+    fun recordRequest(role: String, host: String) {
+        countersFor(role, host).requests.increment()
+    }
+
+    /** A connection was acquired: [reused] is false when it had to be dialed (and then [connectMs] is its dial time). */
+    fun recordConnection(role: String, host: String, reused: Boolean, connectMs: Long) {
+        val c = countersFor(role, host)
+        if (reused) {
+            c.reusedConnections.increment()
+        } else {
+            c.newConnections.increment()
+            c.connectMsTotal.add(connectMs.coerceAtLeast(0))
+        }
+    }
+
+    /** Time from finishing the request headers to the first response header: the phase a stalled connection stalls in. */
+    fun recordWaitHeaders(role: String, host: String, waitMs: Long) {
+        val c = countersFor(role, host)
+        c.waitHeadersSamples.increment()
+        c.waitHeadersMsTotal.add(waitMs.coerceAtLeast(0))
+    }
+
+    fun recordFailure(role: String, host: String, phase: String, reason: String?, timeout: Boolean, cancelled: Boolean) {
+        val c = countersFor(role, host)
+        c.failures.increment()
+        if (timeout) c.timeouts.increment()
+        if (cancelled) c.cancelled.increment()
+        c.lastFailure = "$phase: ${reason ?: "?"}"
+    }
+
+    fun snapshot(): List<Snapshot> = counters.entries
+        .map { (key, c) ->
+            val split = key.split('|', limit = 2)
+            Snapshot(
+                role = split.getOrElse(0) { "?" },
+                host = split.getOrElse(1) { "?" },
+                requests = c.requests.sum(),
+                newConnections = c.newConnections.sum(),
+                reusedConnections = c.reusedConnections.sum(),
+                connectMsTotal = c.connectMsTotal.sum(),
+                waitHeadersSamples = c.waitHeadersSamples.sum(),
+                waitHeadersMsTotal = c.waitHeadersMsTotal.sum(),
+                failures = c.failures.sum(),
+                timeouts = c.timeouts.sum(),
+                cancelled = c.cancelled.sum(),
+                lastFailure = c.lastFailure
+            )
+        }
+        .sortedWith(compareBy({ it.role }, { it.host }))
+
+    fun reset() = counters.clear()
+}
+
+/**
+ * Feeds [HttpConnectionStats] from OkHttp's call lifecycle. Attached only to the human-paced
+ * clients: an [EventListener] is invoked for every connection and header event, which is noise on
+ * the bulk segment path and exactly what is wanted for a request every few seconds.
+ *
+ * Call state is keyed by [Call] because OkHttp may report connection events from a different thread
+ * than the request events. A listener that throws would fail the call it observes, so the callbacks
+ * only touch in-memory counters.
+ */
+internal class ConnectionStatsListener(private val role: String) : EventListener() {
+
+    private class CallState {
+        @Volatile
+        var connectStartedNs: Long = 0L
+
+        @Volatile
+        var requestHeadersEndNs: Long = 0L
+
+        @Volatile
+        var phase: String = "connect"
+    }
+
+    private val states = ConcurrentHashMap<Call, CallState>()
+
+    private fun host(call: Call): String = call.request().url.host
+
+    override fun callStart(call: Call) {
+        states[call] = CallState()
+        HttpConnectionStats.recordRequest(role, host(call))
+    }
+
+    override fun connectStart(call: Call, inetSocketAddress: InetSocketAddress, proxy: Proxy) {
+        val state = states[call] ?: return
+        state.connectStartedNs = System.nanoTime()
+        state.phase = "connect"
+    }
+
+    override fun connectionAcquired(call: Call, connection: Connection) {
+        val state = states[call] ?: return
+        // connectStart only fires when the connection had to be dialed, so its absence marks reuse.
+        val started = state.connectStartedNs
+        val reused = started == 0L
+        val connectMs = if (reused) 0L else (System.nanoTime() - started) / 1_000_000
+        HttpConnectionStats.recordConnection(role, host(call), reused, connectMs)
+        state.phase = "request"
+    }
+
+    override fun requestHeadersEnd(call: Call, request: Request) {
+        val state = states[call] ?: return
+        state.requestHeadersEndNs = System.nanoTime()
+        state.phase = "response"
+    }
+
+    override fun responseHeadersStart(call: Call) {
+        val state = states[call] ?: return
+        val started = state.requestHeadersEndNs
+        if (started > 0) {
+            HttpConnectionStats.recordWaitHeaders(role, host(call), (System.nanoTime() - started) / 1_000_000)
+        }
+    }
+
+    override fun callEnd(call: Call) {
+        states.remove(call)
+    }
+
+    override fun callFailed(call: Call, ioe: IOException) {
+        finish(
+            call,
+            ioe.message ?: ioe::class.simpleName ?: "failed",
+            timeout = ioe is SocketTimeoutException || ioe is InterruptedIOException,
+            cancelled = false
+        )
+    }
+
+    override fun canceled(call: Call) {
+        // OkHttp reports a cancellation both here and (for a failed call) through callFailed; the
+        // first of the two wins so one attempt is never counted twice.
+        finish(call, "cancelled", timeout = false, cancelled = true)
+    }
+
+    private fun finish(call: Call, reason: String, timeout: Boolean, cancelled: Boolean) {
+        val state = states.remove(call) ?: return
+        HttpConnectionStats.recordFailure(role, host(call), state.phase, reason, timeout, cancelled)
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/components/RuntimeInjectionTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/RuntimeInjectionTest.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import java.io.IOException
 import java.nio.file.Files
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.test.assertEquals
@@ -295,6 +296,12 @@ class RuntimeInjectionTest {
             pkey = "key-id"
             quality = "360p"
         }
+        // No CDN candidates: this test pins the poll timing, and MockEngine answers on a real
+        // dispatcher, so its fetches time out under virtual time. With candidates configured the
+        // session would walk the playlist to another host after that failure (see the failover test
+        // below) and the URL assertion would no longer hold.
+        val oldCdnHosts = CdnSelector.hosts
+        CdnSelector.updateHosts(emptyList())
 
         try {
             entry.fsm.drive(RecordingEvent.StartRecording)
@@ -312,6 +319,70 @@ class RuntimeInjectionTest {
             assertTrue(requests.all { it == "http://127.0.0.1:18083/live.m3u8" })
         } finally {
             entry.scope.cancel()
+            CdnSelector.updateHosts(oldCdnHosts)
+            client.close()
+        }
+    }
+
+    // Real time on purpose: the fetch is bounded by withTimeout, and MockEngine's dispatcher is not
+    // the test scheduler, so virtual time would race ahead and time out a request that answered on
+    // the next real millisecond (the same reason checkSchedulerMaster below uses runBlocking).
+    @Test
+    fun `session playlist fails over to the next CDN host when one stops answering`() = runBlocking {
+        val testScope = CoroutineScope(coroutineContext + SupervisorJob())
+        val requests = CopyOnWriteArrayList<String>()
+        val client = HttpClient(MockEngine { request ->
+            requests += request.url.toString()
+            if (request.url.host == "127.0.0.1") throw IOException("connection reset by peer")
+            respond("#EXTM3U\n#EXT-X-MAP:URI=\"http://127.0.0.2:18084/init.mp4\"")
+        })
+        val provider = RecordingProvider(client, client)
+        val eventBus = EventBus()
+        installRequestAnswers(eventBus)
+        val requestBus = RequestBus(eventBus, testScope)
+        val dataChannel = DataChannel()
+        val downloader = DownloaderComponent(dataChannel, eventBus = eventBus, parentScope = testScope)
+        val session = SessionComponent(
+            dataChannel,
+            downloader,
+            M3u8Parser,
+            requestBus,
+            eventBus,
+            testScope,
+            httpClientProvider = provider
+        )
+        val entry = SessionEntry(9, "model", session).apply {
+            playlistUrl = "http://127.0.0.1:18084/live.m3u8"
+            pkey = "key-id"
+            quality = "720p"
+        }
+        val oldCdnHosts = CdnSelector.hosts
+        val errorsBefore = CdnSelector.snapshot()["127.0.0.1"]?.playlistErrors ?: 0
+        CdnSelector.updateHosts(listOf("127.0.0.1", "127.0.0.2"))
+
+        try {
+            val failed = assertIs<SessionSignal>(entry.fetchPlaylistSignal())
+            assertEquals(RecordingEvent.PlaylistFetchFailed, failed.event)
+            // the dead host is remembered by this session, and the playlist walked to the other one
+            assertEquals(listOf("127.0.0.1"), entry.playlistHostsTried.toList())
+            assertEquals("http://127.0.0.2:18084/live.m3u8", entry.playlistUrl)
+            // the pooled client is dropped, so the retry cannot be handed the connection that failed
+            assertEquals(listOf("m3u8_9"), provider.evicted)
+            // and the failure reaches the selector as a *playlist* failure, so the next preconfig
+            // avoids the host too
+            assertEquals(errorsBefore + 1, CdnSelector.snapshot().getValue("127.0.0.1").playlistErrors)
+
+            val fetched = assertIs<SessionSignal>(entry.fetchPlaylistSignal())
+            assertEquals(RecordingEvent.PlaylistFetched, fetched.event, "failReason=${fetched.data?.failReason}")
+            assertTrue(requests.any { it == "http://127.0.0.2:18084/live.m3u8" })
+            // a served playlist clears the playlist penalty of the host that served it, and only
+            // that host's: the failed one keeps its streak for the next preconfig
+            assertEquals(0, CdnSelector.snapshot()["127.0.0.2"]?.playlistFailures ?: 0)
+            assertEquals(1, CdnSelector.snapshot().getValue("127.0.0.1").playlistFailures)
+        } finally {
+            entry.scope.cancel()
+            testScope.cancel()
+            CdnSelector.updateHosts(oldCdnHosts)
             client.close()
         }
     }
@@ -397,6 +468,7 @@ class RuntimeInjectionTest {
     ) : HttpClientProvider {
         val directCalls = CopyOnWriteArrayList<ClientCall>()
         val proxiedCalls = CopyOnWriteArrayList<ClientCall>()
+        val evicted = CopyOnWriteArrayList<String>()
 
         override fun direct(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient {
             directCalls += ClientCall(key, http1, expectSuccess)
@@ -406,6 +478,10 @@ class RuntimeInjectionTest {
         override fun proxied(key: String, http1: Boolean, expectSuccess: Boolean): HttpClient {
             proxiedCalls += ClientCall(key, http1, expectSuccess)
             return proxiedClient
+        }
+
+        override fun evict(key: String) {
+            evicted += key
         }
     }
 

--- a/src/test/kotlin/github/rikacelery/v3/data/RuntimeTuningTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/data/RuntimeTuningTest.kt
@@ -20,6 +20,8 @@ class RuntimeTuningTest {
         assertEquals(15.seconds, tuning.preconfigRetryInterval)
         assertEquals(3.seconds, tuning.playlistPollInterval)
         assertEquals(10.seconds, tuning.playlistFetchTimeout)
+        // per-attempt engine timeout must stay below the whole-fetch watchdog
+        assertEquals(4.seconds, tuning.playlistAttemptTimeout)
         assertEquals(500.milliseconds, tuning.httpRestartDelay)
         assertEquals(8.seconds, tuning.downloaderRaceDelay)
         assertEquals(25.seconds, tuning.downloaderAttemptTimeout)

--- a/src/test/kotlin/github/rikacelery/v3/utils/CdnPlaylistCooldownTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/utils/CdnPlaylistCooldownTest.kt
@@ -1,0 +1,112 @@
+package github.rikacelery.v3.utils
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Playlist failures are tracked apart from segment failures: a host can serve segments perfectly
+ * while its playlist requests time out, and the segment successes of the other rooms would clear a
+ * shared counter before it could ever cool the host down.
+ */
+class CdnPlaylistCooldownTest {
+
+    private val zone = ZoneId.systemDefault()
+    private val now = ZonedDateTime.of(2024, 1, 15, 10, 30, 0, 0, zone).toInstant().toEpochMilli()
+
+    @BeforeEach
+    fun setUp() {
+        CdnSelector.reset()
+        CdnSelector.updateHosts(listOf("cdn-a.com", "cdn-b.com"))
+        CdnSelector.exploreProbability = 0.0
+        CdnSelector.spreadTolerance = 0.0
+        CdnSelector.spreadAbsMs = 0.0
+    }
+
+    @Test
+    fun `three playlist failures cool the host down for playlists only`() {
+        CdnSelector.recordPlaylistFailure("cdn-a.com", now)
+        CdnSelector.recordPlaylistFailure("cdn-a.com", now)
+        assertEquals(0L, CdnSelector.snapshot(now)["cdn-a.com"]!!.playlistCooldownUntil)
+
+        CdnSelector.recordPlaylistFailure("cdn-a.com", now)
+        val snap = CdnSelector.snapshot(now)["cdn-a.com"]!!
+        assertEquals(3, snap.playlistFailures)
+        assertTrue(snap.playlistCooldownUntil > now, "3 consecutive playlist failures should cool down")
+        // the segment view of the host is untouched: it is still selectable for downloads
+        assertEquals(0L, snap.cooldownUntil)
+        assertTrue(CdnSelector.rankedHosts(now).contains("cdn-a.com"))
+        assertFalse(CdnSelector.rankedPlaylistHosts(now).contains("cdn-a.com"))
+    }
+
+    @Test
+    fun `segment success neither clears nor triggers the playlist penalty`() {
+        CdnSelector.recordPlaylistFailure("cdn-a.com", now)
+        CdnSelector.recordPlaylistFailure("cdn-a.com", now)
+        // A segment served by another room is not evidence about playlists.
+        CdnSelector.record("cdn-a.com", 150, now)
+        val afterSuccess = CdnSelector.snapshot(now)["cdn-a.com"]!!
+        assertEquals(2, afterSuccess.playlistFailures, "a segment success must not clear playlist failures")
+        assertEquals(0, afterSuccess.failures)
+
+        CdnSelector.recordPlaylistFailure("cdn-a.com", now)
+        assertTrue(CdnSelector.snapshot(now)["cdn-a.com"]!!.playlistCooldownUntil > now)
+
+        // …and once cooled down, more segment successes must not release it.
+        CdnSelector.record("cdn-a.com", 150, now)
+        assertTrue(CdnSelector.snapshot(now)["cdn-a.com"]!!.playlistCooldownUntil > now)
+
+        CdnSelector.recordPlaylistSuccess("cdn-a.com")
+        val cleared = CdnSelector.snapshot(now)["cdn-a.com"]!!
+        assertEquals(0, cleared.playlistFailures)
+        assertEquals(0L, cleared.playlistCooldownUntil)
+    }
+
+    @Test
+    fun `playlist selection skips a playlist-cooled host that is still best for segments`() {
+        // cdn-a is the better download host, so the segment selector keeps choosing it…
+        repeat(5) {
+            CdnSelector.record("cdn-a.com", 100, now)
+            CdnSelector.record("cdn-b.com", 300, now)
+        }
+        repeat(3) { CdnSelector.recordPlaylistFailure("cdn-a.com", now) }
+
+        assertEquals("cdn-a.com", CdnSelector.select(now), "segments should still prefer cdn-a")
+        assertEquals("cdn-b.com", CdnSelector.selectPlaylist(now), "playlists should avoid cdn-a")
+
+        val url = "https://cdn-a.com/b-hls-22/123/123_720p.m3u8?psch=v2&pkey=k1"
+        assertTrue(CdnSelector.resolvePlaylist(url, now).startsWith("https://cdn-b.com/"))
+        assertTrue(CdnSelector.resolve(url, now).startsWith("https://cdn-a.com/"))
+        assertEquals(listOf("cdn-b.com"), CdnSelector.rankedPlaylistHosts(now))
+    }
+
+    @Test
+    fun `playlist penalty survives a persistence round trip`() {
+        repeat(3) { CdnSelector.recordPlaylistFailure("cdn-a.com", now) }
+        val exported = CdnSelector.exportState()
+
+        CdnSelector.reset()
+        CdnSelector.importState(exported)
+
+        val restored = CdnSelector.snapshot(now)["cdn-a.com"]!!
+        assertEquals(3, restored.playlistFailures)
+        assertTrue(restored.playlistCooldownUntil > now)
+        assertFalse(CdnSelector.playlistAvailableHosts(now).contains("cdn-a.com"))
+    }
+
+    @Test
+    fun `clearCooldown releases the playlist penalty too`() {
+        repeat(3) { CdnSelector.recordPlaylistFailure("cdn-a.com", now) }
+        assertTrue(CdnSelector.snapshot(now)["cdn-a.com"]!!.playlistCooldownUntil > now)
+
+        CdnSelector.clearCooldown("cdn-a.com")
+        val cleared = CdnSelector.snapshot(now)["cdn-a.com"]!!
+        assertEquals(0, cleared.playlistFailures)
+        assertEquals(0L, cleared.playlistCooldownUntil)
+        assertTrue(CdnSelector.playlistAvailableHosts(now).contains("cdn-a.com"))
+    }
+}

--- a/src/test/kotlin/github/rikacelery/v3/utils/HttpConnectionProfileTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/utils/HttpConnectionProfileTest.kt
@@ -1,0 +1,203 @@
+package github.rikacelery.v3.utils
+
+import com.sun.net.httpserver.HttpServer
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.*
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import kotlinx.coroutines.runBlocking
+import okhttp3.ConnectionPool
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import java.net.InetSocketAddress
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Guards the connection policy of the human-paced clients: the whole point of the pool, the pings
+ * and the telemetry is to keep the *warm* path warm. If a change makes a stream client dial per
+ * request, or adds per-request overhead to it, this fails.
+ *
+ * The comparison against the pre-change profile is deliberate: the same loopback workload run on
+ * the old pool/timeout configuration must not be measurably faster, otherwise the new keep-alive
+ * and [HttpConnectionStats] listener are costing more than they return.
+ */
+class HttpConnectionProfileTest {
+
+    private val body = "#EXTM3U\n#EXT-X-MAP:URI=\"http://127.0.0.1:1/init.mp4\""
+
+    private class Server(body: String) {
+        val connections = ConcurrentHashMap.newKeySet<String>()
+        val server: HttpServer = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+
+        init {
+            server.createContext("/live.m3u8") { exchange ->
+                connections += exchange.remoteAddress.toString()
+                val bytes = body.toByteArray()
+                exchange.responseHeaders.add("Content-Type", "application/vnd.apple.mpegurl")
+                exchange.sendResponseHeaders(200, bytes.size.toLong())
+                exchange.responseBody.use { it.write(bytes) }
+            }
+            server.executor = Executors.newFixedThreadPool(4)
+            server.start()
+        }
+
+        val url: String get() = "http://127.0.0.1:${server.address.port}/live.m3u8"
+
+        fun stop() = server.stop(0)
+    }
+
+    /** The profile as it was before the connection policy change: 16 idle / 5 minutes, no pings. */
+    private fun baselineClient(): HttpClient = HttpClient(OkHttp) {
+        expectSuccess = true
+        install(HttpTimeout) {
+            requestTimeoutMillis = 60_000
+            connectTimeoutMillis = 10_000
+            socketTimeoutMillis = 30_000
+        }
+        install(HttpRequestRetry) {
+            retryOnExceptionIf(maxRetries = 3) { _, cause -> cause !is ResponseException }
+            constantDelay(300)
+        }
+        engine { config { connectionPool(ConnectionPool(16, 5, TimeUnit.MINUTES)) } }
+    }
+
+    private fun timeRequests(client: HttpClient, url: String, count: Int): LongArray = runBlocking {
+        // warm up: the first request always dials
+        client.get(url).bodyAsText()
+        LongArray(count) {
+            val start = System.nanoTime()
+            client.get(url).bodyAsText()
+            (System.nanoTime() - start) / 1_000_000
+        }
+    }
+
+    private fun percentile(samples: LongArray, p: Double): Double {
+        val sorted = samples.sortedArray()
+        val idx = ((sorted.size - 1) * p).toInt().coerceIn(0, sorted.size - 1)
+        return sorted[idx].toDouble()
+    }
+
+    @Test
+    fun `stream client keeps one pooled connection and records engine telemetry`() {
+        assumeTrue(System.getenv("http_proxy") == null && System.getenv("HTTP_PROXY") == null) {
+            "a configured proxy would bypass the loopback server"
+        }
+        val server = Server(body)
+        HttpConnectionStats.reset()
+        val oldHosts = CdnSelector.hosts
+        CdnSelector.updateHosts(emptyList())
+        val key = "m3u8_profile_${System.nanoTime()}"
+        val client = ClientManager.getProxiedClient(key)
+
+        try {
+            val samples = timeRequests(client, server.url, 20)
+            assertEquals(20, samples.size)
+
+            val stats = HttpConnectionStats.snapshot()
+                .firstOrNull { it.role == "playlist" && it.host == "127.0.0.1" }
+            assertTrue(stats != null, "the playlist client must feed connection telemetry")
+            assertEquals(21L, stats.requests, "warm-up plus the measured requests")
+            assertTrue(stats.reusedConnections >= 18, "keep-alive must serve nearly every request: $stats")
+            assertEquals(1, server.connections.size, "exactly one pooled connection expected")
+        } finally {
+            ClientManager.removeClient(key)
+            CdnSelector.updateHosts(oldHosts)
+            server.stop()
+        }
+    }
+
+    @Test
+    fun `stream client is not slower than the previous pool profile`() {
+        assumeTrue(System.getenv("http_proxy") == null && System.getenv("HTTP_PROXY") == null) {
+            "a configured proxy would bypass the loopback server"
+        }
+        val server = Server(body)
+        val oldHosts = CdnSelector.hosts
+        CdnSelector.updateHosts(emptyList())
+        val key = "m3u8_profile_ab_${System.nanoTime()}"
+        val baseline = baselineClient()
+        val current = ClientManager.getProxiedClient(key)
+        val count = 200
+
+        try {
+            // Alternate to spread any process-wide drift (GC, scheduler) over both arms.
+            val baselineWarm = timeRequests(baseline, server.url, 20)
+            val currentWarm = timeRequests(current, server.url, 20)
+            val baselineSamples = baselineWarm + timeRequests(baseline, server.url, count)
+            val currentSamples = currentWarm + timeRequests(current, server.url, count)
+
+            val baselineP50 = percentile(baselineSamples, 0.50)
+            val currentP50 = percentile(currentSamples, 0.50)
+            val baselineP95 = percentile(baselineSamples, 0.95)
+            val currentP95 = percentile(currentSamples, 0.95)
+            println(
+                "stream profile latency (loopback, ms): baseline p50=$baselineP50 p95=$baselineP95 " +
+                    "current p50=$currentP50 p95=$currentP95"
+            )
+            // Generous on purpose: the point is to catch a structural regression (dialing per
+            // request, per-request listener work), not to police sub-millisecond jitter.
+            assertTrue(
+                currentP50 <= baselineP50 * 1.5 + 5.0,
+                "new profile regressed: baseline p50=$baselineP50 current p50=$currentP50"
+            )
+        } finally {
+            ClientManager.removeClient(key)
+            baseline.close()
+            CdnSelector.updateHosts(oldHosts)
+            server.stop()
+        }
+    }
+
+    @Test
+    fun `bulk download clients stay free of connection telemetry`() {
+        assumeTrue(System.getenv("http_proxy") == null && System.getenv("HTTP_PROXY") == null) {
+            "a configured proxy would bypass the loopback server"
+        }
+        val server = Server(body)
+        HttpConnectionStats.reset()
+        val key = "dl_profile_${System.nanoTime()}"
+        val client = ClientManager.getClient(key)
+
+        try {
+            runBlocking {
+                repeat(5) { client.get(server.url).bodyAsText() }
+            }
+            assertTrue(server.connections.isNotEmpty(), "the requests must have reached the server")
+            assertTrue(
+                HttpConnectionStats.snapshot().none { it.role == "download" },
+                "the bulk path must not carry the EventListener: $server"
+            )
+        } finally {
+            ClientManager.removeClient(key)
+            server.stop()
+        }
+    }
+
+    @Test
+    fun `removing a client forces the next request onto a fresh client`() {
+        val key = "m3u8_evict_${System.nanoTime()}"
+        val first = ClientManager.getProxiedClient(key)
+        ClientManager.removeClient(key)
+        val second = ClientManager.getProxiedClient(key)
+        try {
+            assertTrue(first !== second, "removeClient must drop the cached client")
+        } finally {
+            ClientManager.removeClient(key)
+        }
+
+        val directKey = "dl_evict_${System.nanoTime()}"
+        val directFirst = ClientManager.getClient(directKey)
+        ClientManager.removeClient(directKey)
+        val directSecond = ClientManager.getClient(directKey)
+        try {
+            assertTrue(directFirst !== directSecond, "removeClient must cover direct clients too")
+        } finally {
+            ClientManager.removeClient(directKey)
+        }
+    }
+}


### PR DESCRIPTION
## Symptom

A room's playlist fetches time out on one CDN host while that host is still perfectly healthy for
every other room, and the room never leaves it:

```
10:55:50  PlaylistFetchFailed(timeout) -> KEEP
   ...      x5, every 13s (10s watchdog + 3s poll)
10:56:42  PlaylistRetryExhausted -> Closing            (exit StreamEnd)
10:56:43  PreconfigDone  -> Recording
          playlistUrl=https://media-hls.doppiocdn.net/...   <- same host again
```

Room 121249934 repeated that cycle three times in a row (11:07, 11:08, 11:10) on
`media-hls.doppiocdn.net`, while `/config/hosts` reported that host with `failures=0`,
`coolingDown=false` and the best estimated duration — so `CdnSelector` handed the same host to the
next preconfig as well.

## Root cause

1. **Playlist outcomes never reached `CdnSelector`.** `SessionEntry.fetchPlaylistSignal` only drove
   the FSM: no `record` on success, no `recordFailure` on failure. The whole `SessionComponent` did
   not import `CdnSelector`.
2. **A playlist penalty would not have survived anyway.** `CdnSelector.record()` clears
   `failures` and `cooldownUntil` on *any* success from *any* room, and the other rooms keep
   downloading segments from the same host — a shared counter is wiped within milliseconds. This is
   why the live stats showed `failures=0` next to tens of thousands of `totalErrors`.
3. **The session had no host failover and its playlist URL was frozen.** `PlaylistFetchFailed` only
   incremented `retryCount`; after `MAX_PLAYLIST_RETRY` the session cut and the scheduler
   re-preconfigured onto the same host. Segment downloads have had `rankedHosts`/`recordFailure`
   failover all along; the playlist path had nothing.
4. **A stalled pooled connection had no bounded detection.** The fetch budget (10s) equalled
   `connectTimeoutMillis` (10s) and sat below `socketTimeoutMillis` (30s), so one dead connection
   consumed the whole budget as a coroutine cancellation, and `HttpRequestRetry` never got a chance
   to dial a fresh one. The old comments here deliberately traded this off against a long connection
   pool, but the trade was never made recoverable.

## Changes

**1. Per-attempt engine timeout below the fetch watchdog**

`RuntimeTuning.playlistAttemptTimeout` (4s) is applied per playlist request as
`socketTimeoutMillis`/`connectTimeoutMillis`. That is an *engine* timeout, so OkHttp aborts the
stalled connection, drops it, and the retry dials fresh — all inside the existing 10s
`playlistFetchTimeout`. The same is applied to the preconfig probe.

**2. Drop the connection, then move the host**

New `HttpClientProvider.evict` / `ClientManager.removeClient`. On a transport failure the session
drops `m3u8_<roomId>` first (so the retry cannot be handed the connection that just failed), then
moves the playlist to the next host outside its per-session tried set
(`rankedPlaylistHosts`). 403/404 still closes the session without a host penalty.

**3. Client lifecycle**

A session that ends for good releases its `m3u8_<roomId>` client; a time/size-limit cut keeps it
because it restarts on the same stream seconds later. `RoomRemoved`, `DeactivateCmd`, `WriterFatal`
and `ShutdownCmd` release `master_`/`preconfig_`/`m3u8_`. This also wires up `removeRoomClients`,
which was dead code (and never covered `preconfig_`).

**4. Keep-alive by role**

`m3u8_`/`master_`/`preconfig_` get `ConnectionPool(4, 30s)` and h2 `pingInterval(20s)`; the bulk
`dl_`/`px_` clients keep the default 5-minute pool and are not instrumented. The pool is created
once per `HttpClient` and shared across the per-request-timeout `OkHttpClient` instances Ktor
derives, so adding the engine timeout does not cost connection reuse.

**5. Playlist failures counted apart**

`HostStat` gains `playlistFailures`/`playlistErrors`/`playlistCooldownUntil`, cleared only by a
playlist success; new `selectPlaylist`/`resolvePlaylist`/`rankedPlaylistHosts` are used by
`resolveVariantUrl`, the preconfig probe and the session failover. The state is persisted with the
rest of the CDN statistics and exposed by `/config/hosts`.

**6. Observability**

`HttpConnectionStats` plus an OkHttp `EventListener` on the stream clients records reused/new
connections, dial time, wait-for-headers time, failure phase, timeouts and cancellations.
`/metrics` exposes `xhrec_http_*{role,host}` and `xhrec_cdn_playlist_*`. The intended reading is
documented on `HttpConnectionStats`: `reused` climbing with `waitHeadersAvg` close to the
per-attempt timeout means a dead pooled connection (eviction is the fix), while
`newConnections`/`connectMsAvg` climbing means a slow host (host rotation is the fix).

## Performance

The point of the change is to keep long connections, so it was measured both before and after:

| measurement | previous profile | this change |
|---|---|---|
| loopback A/B, 220 requests, p50 / p95 | 42 ms / 43 ms | 42 ms / 43 ms |
| real CDN warm p50 / p95 | 279 ms / 535 ms | 250 ms / 498 ms (within noise) |
| real CDN first (cold) request | 1643 ms | 1202 ms |
| connections used by 21 real-CDN requests | — | 1 new, 20 reused |

Also verified: a 31 s idle gap forces a new connection (the 30 s stream pool bound really applies),
and the bulk segment path produces no telemetry at all (it is not instrumented), so its hot path is
untouched by construction and by test.

## Tests

- `CdnPlaylistCooldownTest` (new): the playlist cooldown is independent of segment successes; a
  playlist-cooled host is still selectable for segments but skipped for playlists; the state
  survives a persistence round trip.
- `HttpConnectionProfileTest` (new): one pooled connection serves 20/21 stream requests with
  telemetry recorded; the new profile is not slower than the previous one; bulk clients carry no
  telemetry; `removeClient` forces a fresh client for proxied and direct keys.
- `RuntimeInjectionTest` (updated): the failover case also asserts the client eviction, the
  playlist-specific accounting in `CdnSelector`, and that only the serving host's penalty is
  cleared.
- `RuntimeTuningTest`: the per-attempt timeout default stays below the whole-fetch watchdog.

`./gradlew test` — 308 tests, 0 failures. The `compile-warnings` gate passes locally.
