### PR TITLE
fix(session): only report a resume mark left ahead of the playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,30 +280,31 @@ curl -sk "https://localhost:8090/diagnose?actor=SessionComponent&section=entries
       "lastPollSkipped": 2,
       "lastPollEnqueuedMedia": false,
       "playlistLoopRunning": true,
-      "skipStreak": { "skipped": 987, "minId": 1002, "maxId": 1004, "reported": true },
+      "resumeMarkAhead": { "ahead": 746, "reported": true, "since": "2026-09-11T22:21:50.492Z" },
       "fsm": { "state": "Recording", "history": [ "…" ] }
     }
   ]
 }
 ```
 
-**How to read a stuck room.** The three fields below tell the two failure modes apart, which is
-otherwise invisible:
+**How to read a stuck room.** These fields tell the failure modes apart, which is otherwise
+invisible:
 
 | Field | Meaning |
 | --- | --- |
 | `lastPollSegmentCount` | media segments the last playlist actually advertised |
 | `lastPollEnqueuedMedia` | whether any of them was queued for download |
-| `lastPollSkipped` | how many were skipped as already covered by the resume mark (normal) |
+| `lastPollSkipped` | how many were already covered by the resume mark (normal overlap) |
+| `resumeMarkAhead.ahead` | how far the mark leads the newest advertised id; > 0 beyond the threshold is a backlog |
 | `lastPollGap` | how many ids the playlist jumped over this poll and never showed us (lost) |
 | `previousNewSegmentId` | the highest id this session has queued; the baseline for the gap check |
-| `lastSegmentId` | the resume mark; segments with an id at or below it are skipped |
+| `lastSegmentId` | the resume mark |
 | `noProgressMs` | how long since the session last queued or received anything |
 
-`lastPollSegmentCount > 0` with `lastPollEnqueuedMedia: false` means the playlist is healthy but
-every segment sits behind the resume mark — the stream has not caught up yet. `lastPollSegmentCount
-= 0` means the playlist itself is empty. A growing `mailboxDepth` on a component means its actor is
-falling behind rather than idle.
+`resumeMarkAhead.reported: true` is the stall: the mark leads the playlist, so every advertised
+segment is already recorded and nothing can be downloaded. `lastPollSegmentCount = 0` instead means
+the playlist itself is empty. A growing `mailboxDepth` on a component means its actor is falling
+behind rather than idle.
 
 `section=history` shows how a room reached its current state, which is usually where the answer is:
 
@@ -493,11 +494,23 @@ level regardless.
 
 ### Diagnosing a stalled recording
 
-**Skipping is the normal steady state, not a fault.** The media playlist is a sliding window that
-re-lists segments already written, so every healthy poll skips the overlap and enqueues only what is
-new. Those skips are counted in `xhrec_segments_skipped_total{roomId=…}`, which therefore rises
-steadily for *any* room that is recording. The signal to watch is that counter climbing while
-`xhrec_downloaded_total` stands still.
+**An overlap with the resume mark is normal, not a fault.** The media playlist is a sliding window
+that re-lists segments already written, so the window and the mark "join up": a healthy poll queues
+only what is new and silently ignores the rest. That is why `xhrec_segments_skipped_total{roomId=…}`
+does **not** move for a healthy room — counting the ordinary overlap would make it grow forever
+without ever meaning anything.
+
+What is worth reporting is the mark running *ahead* of the playlist, because then every advertised
+segment is already recorded and nothing can be downloaded until the stream catches up. The session
+reports that once per episode at `WARN`, and only that report moves the counter:
+
+```
+WARN v3.SessionEntry - roomId=206236901 the resume mark is 746 segment id(s) ahead of the playlist (mark=1750, newest advertised=1004); everything advertised is already recorded, so nothing can be recorded until the stream catches up
+INFO v3.SessionEntry - roomId=206236901 the stream caught up with the resume mark after 2154s (it was 746 id(s) ahead)
+```
+
+The cutoff is `resumeMarkAheadThreshold` (10 by default): a lead of a few ids is ordinary jitter,
+while a mark far ahead is what a resume mark left over from an earlier broadcast looks like.
 
 The opposite failure is `xhrec_segment_missing_total{roomId=…}`: ids the stream published that the
 playlist never showed us. If one refresh ends at id 3 and the next already starts at 7, then 4, 5
@@ -514,8 +527,8 @@ session has no earlier observation to compare against, so restarting the compari
 flag every ordinary cut as lost data.
 
 Per-poll detail is at `TRACE` — opt-in from the WebUI toolbar or `POST /log/level` — so it does not
-clutter the log at the default (`INFO`) level. Read it as "N of the M ids this playlist advertised were already
-covered, and the mark then moved from A to B":
+clutter the default log. Read it as "N of the M ids this playlist advertised were already covered,
+and the mark then moved from A to B":
 
 ```
 TRACE v3.SessionEntry - roomId=152807806 skipped 1 of 3 advertised segment(s): id 1063 already at or below the resume mark (mark 1063 -> 1065)
@@ -526,17 +539,7 @@ window — and the mark is printed as a transition because by then it has alread
 poll's newest id. So the line above means the window was `1063..1065`, the mark stood at `1063`, so
 1063 was already written and skipped while 1064 and 1065 were queued and moved the mark to 1065.
 
-When nothing new has arrived for `thresholdSkipLogDelay`, the session says so **once**, and says what
-actually happened rather than a count of skip events (the same ids repeat on every poll, so a running
-total would overstate it badly):
-
-```
-WARN  v3.SessionEntry - roomId=170139817 no new segments for 32s: the playlist still advertises only id 1025..1027, all already covered by the resume mark (1027)
-INFO  v3.SessionEntry - roomId=206236901 caught up with the resume mark after 2154s; 1102 skip event(s) (id 1002..1789), recording resumed
-```
-
-Short overlaps after an ordinary cut stay silent; only a *persistent* streak is reported. Two further
-lines are worth recognising:
+Two further lines are worth recognising:
 
 ```
 WARN  v3.SessionEntry - Recording stalled roomId=…: no segment for 90s (playlist carries 0 media segment(s));

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -271,28 +271,29 @@ curl -sk "https://localhost:8090/diagnose?actor=SessionComponent&section=entries
       "lastPollSkipped": 2,
       "lastPollEnqueuedMedia": false,
       "playlistLoopRunning": true,
-      "skipStreak": { "skipped": 987, "minId": 1002, "maxId": 1004, "reported": true },
+      "resumeMarkAhead": { "ahead": 746, "reported": true, "since": "2026-09-11T22:21:50.492Z" },
       "fsm": { "state": "Recording", "history": [ "…" ] }
     }
   ]
 }
 ```
 
-**怎么判断卡住的房间。** 下面几个字段能区分两种本来无法分辨的故障：
+**怎么判断卡住的房间。** 下面这些字段能区分几种本来无法分辨的故障：
 
 | 字段 | 含义 |
 | --- | --- |
 | `lastPollSegmentCount` | 最近一次播放列表实际提供了多少个媒体分片 |
 | `lastPollEnqueuedMedia` | 其中是否有分片被真正排入下载队列 |
-| `lastPollSkipped` | 其中有多少因已被续传标记覆盖而跳过（正常现象） |
+| `lastPollSkipped` | 其中有多少已被续传标记覆盖（正常重叠） |
+| `resumeMarkAhead.ahead` | 标记比最新分片超前多少；超过阈值即为积压 |
 | `lastPollGap` | 本次轮询播放列表跨过了多少个 id、从未展示给我们（已丢失） |
 | `previousNewSegmentId` | 本会话已排队的最大 id，也是缺失检测的基线 |
-| `lastSegmentId` | 续传标记；id 小于等于它的分片会被跳过 |
+| `lastSegmentId` | 续传标记 |
 | `noProgressMs` | 距离上一次排入或收到数据已经过了多久 |
 
-`lastPollSegmentCount > 0` 而 `lastPollEnqueuedMedia` 为 `false`，说明播放列表是正常的，但所有分片都落在
-续传标记之后——直播流还没追上标记。`lastPollSegmentCount = 0` 则说明播放列表本身就是空的。某个组件的
-`mailboxDepth` 持续增长，说明它的 actor 正在积压，而不是空闲。
+`resumeMarkAhead.reported: true` 就是卡住的情形：标记超前于播放列表，列表里的分片全都已录过，什么都下不了。
+`lastPollSegmentCount = 0` 则说明播放列表本身就是空的。某个组件的 `mailboxDepth` 持续增长，说明它的 actor
+正在积压，而不是空闲。
 
 `section=history` 展示房间是如何走到当前状态的，答案通常就在这里：
 
@@ -473,9 +474,21 @@ curl -k https://localhost:8090/mask/status     # 查看当前状态
 
 ### 排查卡住的录制
 
-**跳过（skipped）是正常稳态，不是故障。** 播放列表是滑动窗口，每次轮询都会重复列出刚写过的分片，所以任何
-健康录制都会跳过重叠部分、只下载新增的。这些跳过次数计入 `xhrec_segments_skipped_total{roomId=…}`，因此对
-**任何正在录制的房间**它都会持续增长。真正要看的信号是：这个计数器在涨、而 `xhrec_downloaded_total` 不动。
+**与续传标记重叠是正常现象，不是故障。** 播放列表是滑动窗口，每次轮询都会重复列出刚写过的分片，也就是窗口和
+标记"接上"了：健康的一轮只把新增的分片入队，其余静默忽略。这就是为什么
+`xhrec_segments_skipped_total{roomId=…}` 对健康房间**不会增长**——把这种正常重叠也计入，只会让它永远涨、
+却从不说明任何问题。
+
+真正值得报告的是**标记反过来超前于播放列表**：此时列表里的每个分片都已经录过，在流追上之前什么都下不了。
+会话每次这种情况只报告一次（`WARN`），也只有这一次会让计数器增长：
+
+```
+WARN v3.SessionEntry - roomId=206236901 the resume mark is 746 segment id(s) ahead of the playlist (mark=1750, newest advertised=1004); everything advertised is already recorded, so nothing can be recorded until the stream catches up
+INFO v3.SessionEntry - roomId=206236901 the stream caught up with the resume mark after 2154s (it was 746 id(s) ahead)
+```
+
+判据是 `resumeMarkAheadThreshold`（默认 10）：领先几个 id 属于正常抖动，而远远领先正是"上一场直播遗留的
+续传标记"的样子。
 
 相反方向的故障是 `xhrec_segment_missing_total{roomId=…}`：**流确实发布过、但播放列表从未告诉我们的 id**。
 比如上一次刷新停在 id 3，下一次直接是 7，那么 4、5、6 就丢了——播放列表跨过了它们。管线里其他环节都发现不了
@@ -488,7 +501,7 @@ DEBUG v3.SessionEntry - roomId=206236901 playlist went from segment id 1023 to 1
 **会话接缝处不计入缺失**：时限切分、`Break`、重新激活之后，会话没有更早的观测可以对比；若把重启当作基线重置之外
 还去比较，就会把每一次正常的切分都误报成丢数据。
 
-每次轮询的明细在 `TRACE`（可在 WebUI 工具栏或 `POST /log/level` 打开），所以不会污染默认级别（`INFO`）的日志。
+每次轮询的明细在 `TRACE`（可在 WebUI 工具栏或 `POST /log/level` 打开），所以不会污染默认级别的日志。
 读法是"播放列表提供的 M 个 id 中有 N 个已被覆盖，随后标记从 A 推进到 B"：
 
 ```
@@ -499,15 +512,7 @@ TRACE v3.SessionEntry - roomId=152807806 skipped 1 of 3 advertised segment(s): i
 到这里它已经被本轮最新的 id 推进过了。所以上面这行表示：窗口是 `1063..1065`，进入本轮时标记是 `1063`，因此
 1063 已经写过被跳过，而 1064、1065 是新入队的并把标记推进到了 1065。
 
-当超过 `thresholdSkipLogDelay` 一直没有新分片时，会话会**报告一次**，并且说的是真正发生的事，而不是累计的
-跳过事件数（同一批 id 每次轮询都会被重复计数，累计值会严重夸大）：
-
-```
-WARN  v3.SessionEntry - roomId=170139817 no new segments for 32s: the playlist still advertises only id 1025..1027, all already covered by the resume mark (1027)
-INFO  v3.SessionEntry - roomId=206236901 caught up with the resume mark after 2154s; 1102 skip event(s) (id 1002..1789), recording resumed
-```
-
-普通切分后的短暂重叠是静默的，只有**持续**无新分片才会报告。另外两类值得留意的日志：
+另外两类值得留意的日志：
 
 ```
 WARN  v3.SessionEntry - Recording stalled roomId=…: no segment for 90s (playlist carries 0 media segment(s));

--- a/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
@@ -205,7 +205,7 @@ class MetricComponent(
         family("xhrec_success_proxied_total", "Proxied success count", "counter")
         family("xhrec_avg_latency_ms", "Average download latency ms", "gauge")
         family("xhrec_segment_missing_total", "Segments the playlist never advertised (a jump in segment ids)", "counter")
-        family("xhrec_segments_skipped_total", "Playlist entries already covered by the resume mark", "counter")
+        family("xhrec_segments_skipped_total", "Segment ids the resume mark was ahead of the playlist by, when a backlog was reported", "counter")
         family("xhrec_files_total", "Files produced", "counter")
         family("xhrec_refresh_latency_ms", "Playlist refresh latency ms", "gauge")
         family("xhrec_segment_id_current", "Current segment ID", "gauge")

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -171,16 +171,16 @@ class SessionEntry(
     var lastProgressAt: Instant = Instant.now()
     var retryCount: Int = 0
 
-    // —— Resume-mark skip accounting ——
-    // The playlist normally lists a window that overlaps what was already downloaded, so some
-    // segments are skipped on every poll. That is silent by design. A *persistent* skip streak
-    // means every advertised segment is at or below the resume mark — the stream has not caught
-    // up and nothing is being recorded — which is worth one log line, not one per poll.
-    var skipStreakSince: Instant? = null
-    var skippedInStreak: Long = 0L
-    var skippedMinId: Long? = null
-    var skippedMaxId: Long? = null
-    var skipStreakReported: Boolean = false
+    // —— Resume-mark backlog accounting ——
+    // A healthy playlist *overlaps* the resume mark by a segment or two — the mark and the window
+    // join up — and the few entries that fall below the mark are simply already written. That is
+    // normal and silent. What is worth reporting is the mark running far *ahead* of the playlist:
+    // then every advertised segment is already recorded and nothing can be downloaded until the
+    // stream catches up, which is what a mark left from an earlier broadcast looks like.
+    var lastPollMarkAhead: Long = 0L
+    var lastPollMarkAheadJustReported: Boolean = false
+    var markAheadReported: Boolean = false
+    var markAheadSince: Instant? = null
 
     /**
      * Whether the most recent poll enqueued at least one *media* segment. The init segment is
@@ -311,9 +311,11 @@ class SessionEntry(
         var skipped = 0L
         var skippedMin = Long.MAX_VALUE
         var skippedMax = Long.MIN_VALUE
+        var advertisedMax = Long.MIN_VALUE
         val newIds = mutableListOf<Long>()
         for (seg in parsed.segments) {
             val segId = component.m3u8Parser.segmentIDFromUrl(seg.url)?.toLong()
+            if (segId != null && segId > advertisedMax) advertisedMax = segId
             if (segId != null) {
                 val threshold = lastSegmentId
                 if (threshold != null && segId <= threshold) {
@@ -331,16 +333,13 @@ class SessionEntry(
         }
         if (newIds.isNotEmpty()) lastSegmentId = newIds.max()
         noteSegmentGap(newIds)
+        noteMarkAhead(markBefore, advertisedMax.takeIf { it != Long.MIN_VALUE })
         lastPollSkipped = skipped.toInt()
         if (skipped > 0) {
-            if (skipStreakSince == null) skipStreakSince = Instant.now()
-            skippedInStreak += skipped
-            if (skippedMinId == null || skippedMin < skippedMinId!!) skippedMinId = skippedMin
-            if (skippedMaxId == null || skippedMax > skippedMaxId!!) skippedMaxId = skippedMax
-            // Which entries were dropped: one aggregated line per poll, never per segment. This is
-            // TRACE, not DEBUG, because skipping is the *steady state* of a healthy recording — the
-            // playlist is a sliding window that re-lists what was just written — so at DEBUG (the
-            // default root level) it would be unconditional noise on every poll of every room.
+            // Which entries fell below the mark: one aggregated line per poll, never per segment.
+            // This is TRACE, not DEBUG, because an overlap is the *steady state* of a healthy
+            // recording, so at DEBUG (the default root level) it would be unconditional noise on
+            // every poll of every room.
             //
             // Both numbers matter and neither is the window: `id` is the skipped set's own range
             // (a single id when one entry was skipped), and the mark is printed as a transition
@@ -354,39 +353,45 @@ class SessionEntry(
     }
 
     /**
-     * Called once per poll after the unseen set is known. Reports a skip streak that has lasted
-     * long enough to mean "this room is not recording", and the moment it catches up.
+     * Called once per poll. Reports a resume mark that has run far ahead of the playlist, and the
+     * moment the stream passes it again.
+     *
+     * The mark normally sits at (or just behind) the newest advertised id — the two "join up" — so
+     * a small lead means nothing and is not reported. Only a lead beyond
+     * [RuntimeTuning.resumeMarkAheadThreshold] is a backlog: everything advertised is already
+     * recorded and nothing can be downloaded until the stream advances.
      */
-    internal fun noteSkipOutcome(progressed: Boolean) {
-        val since = skipStreakSince ?: return
-        val waitedMs = JavaDuration.between(since, Instant.now()).toMillis()
-        if (progressed) {
-            if (skipStreakReported || waitedMs >= component.runtimeTuning.thresholdSkipLogDelay.inWholeMilliseconds) {
+    private fun noteMarkAhead(mark: Long?, advertisedMax: Long?) {
+        lastPollMarkAheadJustReported = false
+        val ahead = if (mark == null || advertisedMax == null) 0L else mark - advertisedMax
+        if (ahead <= component.runtimeTuning.resumeMarkAheadThreshold) {
+            if (markAheadReported) {
+                val waitedMs = markAheadSince?.let { JavaDuration.between(it, Instant.now()).toMillis() } ?: 0L
                 sessionLogger.info(
-                    "roomId={} caught up with the resume mark after {}s; {} skip event(s) (id {}), recording resumed",
-                    roomId, waitedMs / 1000, skippedInStreak, formatIdRange(skippedMinId, skippedMaxId)
+                    "roomId={} the stream caught up with the resume mark after {}s (it was {} id(s) ahead)",
+                    roomId, waitedMs / 1000, lastPollMarkAhead
                 )
             }
-            resetSkipStreak()
+            resetMarkAhead()
             return
         }
-        if (!skipStreakReported && waitedMs >= component.runtimeTuning.thresholdSkipLogDelay.inWholeMilliseconds) {
-            skipStreakReported = true
-            // Report what actually happened — the playlist stopped advancing — rather than a count of
-            // skip events, which repeats the same ids on every poll and greatly overstates the total.
-            sessionLogger.warn(
-                "roomId={} no new segments for {}s: the playlist still advertises only id {}, all already covered by the resume mark ({})",
-                roomId, waitedMs / 1000, formatIdRange(skippedMinId, skippedMaxId), lastSegmentId
-            )
-        }
+        lastPollMarkAhead = ahead
+        if (markAheadReported) return
+        markAheadReported = true
+        markAheadSince = Instant.now()
+        lastPollMarkAheadJustReported = true
+        sessionLogger.warn(
+            "roomId={} the resume mark is {} segment id(s) ahead of the playlist (mark={}, newest advertised={}); " +
+                "everything advertised is already recorded, so nothing can be recorded until the stream catches up",
+            roomId, ahead, mark, advertisedMax
+        )
     }
 
-    internal fun resetSkipStreak() {
-        skipStreakSince = null
-        skippedInStreak = 0L
-        skippedMinId = null
-        skippedMaxId = null
-        skipStreakReported = false
+    internal fun resetMarkAhead() {
+        lastPollMarkAhead = 0L
+        lastPollMarkAheadJustReported = false
+        markAheadReported = false
+        markAheadSince = null
     }
 
     /**
@@ -534,7 +539,7 @@ private fun buildSessionFsm(ctx: SessionEntry) =
                 segmentIndex = 0
                 totalBytes = 0L
                 retryCount = 0
-                resetSkipStreak()
+                resetMarkAhead()
                 previousNewSegmentId = null
                 lastPollGap = 0
                 circleCache.clear()   // a new file must re-download the init; media segments are skipped via the lastSegmentId threshold
@@ -567,11 +572,15 @@ private fun buildSessionFsm(ctx: SessionEntry) =
                     lastProgressAt = Instant.now()
                     launch { component.downloader.tell(DoDownload(Download(roomId, unseen, segmentIndex, generation))) }
                 }
-                noteSkipOutcome(progressed = lastPollEnqueuedMedia)
-                // Mirror the skip to the metrics so the number in the log is verifiable there, and so
-                // "skips climbing while downloads stand still" is an alertable stall signal.
-                if (lastPollSkipped > 0) {
-                    launch { component.publish(SegmentsSkipped(roomId, lastPollSkipped)) }
+                // Report a resume mark that has run far ahead of the playlist. Only this reported
+                // case reaches the metric: the ordinary overlap of the window with the mark happens
+                // on every poll of every healthy room, so counting it would make the counter grow
+                // forever without ever meaning anything.
+                if (lastPollMarkAheadJustReported) {
+                    launch {
+                        component.publish(SegmentsSkipped(roomId, lastPollMarkAhead.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()))
+                    }
+                    lastPollMarkAheadJustReported = false
                 }
                 // A discontinuity is real data loss and nothing downstream can observe it: a segment
                 // that was never advertised never fails and never reaches the downloader.
@@ -850,12 +859,10 @@ internal fun SessionEntry.diagnoseJson(): JsonObject = buildJsonObject {
     put("lastPollGap", lastPollGap)
     put("previousNewSegmentId", previousNewSegmentId?.let { JsonPrimitive(it) } ?: JsonNull)
     put("lastPollEnqueuedMedia", lastPollEnqueuedMedia)
-    put("skipStreak", buildJsonObject {
-        put("since", skipStreakSince?.toString()?.let { JsonPrimitive(it) } ?: JsonNull)
-        put("skipped", skippedInStreak)
-        put("minId", skippedMinId?.let { JsonPrimitive(it) } ?: JsonNull)
-        put("maxId", skippedMaxId?.let { JsonPrimitive(it) } ?: JsonNull)
-        put("reported", skipStreakReported)
+    put("resumeMarkAhead", buildJsonObject {
+        put("ahead", lastPollMarkAhead)
+        put("reported", markAheadReported)
+        put("since", markAheadSince?.toString()?.let { JsonPrimitive(it) } ?: JsonNull)
     })
     put("fsm", fsm.diagnose())
 }

--- a/src/main/kotlin/github/rikacelery/v3/data/RuntimeTuning.kt
+++ b/src/main/kotlin/github/rikacelery/v3/data/RuntimeTuning.kt
@@ -47,11 +47,15 @@ data class RuntimeTuning(
      */
     val sessionCutTimeout: Duration = 3.minutes,
     /**
-     * How long segments may keep being skipped by the resume mark (`lastSegmentId`) before the
-     * session says so once at WARN. Short skips are normal after a cut and must stay silent; a
-     * long one means the stream is behind the resume mark and nothing is being recorded.
+     * How far the resume mark may sit *ahead* of the newest advertised segment id before the
+     * session reports a backlog.
+     *
+     * A healthy playlist overlaps the mark by a segment or two — the mark and the window "join up"
+     * — so a small lead is normal and must stay silent. A mark far ahead means every advertised
+     * segment is already recorded and nothing can be downloaded until the stream catches up, which
+     * is exactly what a resume mark left over from an earlier broadcast looks like.
      */
-    val thresholdSkipLogDelay: Duration = 30.seconds,
+    val resumeMarkAheadThreshold: Int = 10,
     /**
      * How often the debug stream writes a heartbeat when nothing else is happening. The write is
      * also how a dropped client is detected: an idle connection is never noticed otherwise, and the

--- a/src/test/kotlin/github/rikacelery/v3/components/SessionSegmentAccountingTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/SessionSegmentAccountingTest.kt
@@ -12,21 +12,19 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import java.time.Instant
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
  * What a session accounts for in the playlist it polls, in both directions.
  *
- * *Skipped* entries are the normal steady state: the playlist is a sliding window that re-lists
- * what was already downloaded, so a few segments are skipped on every poll and that is silent by
- * design. When *every* advertised segment sits at or below the resume mark, however, the session is
- * not recording anything while still reporting `Recording` — that has to be visible, but exactly
- * once, with a matching line when it finally catches up.
+ * *Skipping* is the normal steady state: the playlist is a sliding window that overlaps the resume
+ * mark, so a few entries are already written and are simply not queued again. That must never be
+ * reported, and must never reach the metrics — it happens on every poll of every healthy room. What
+ * is worth reporting is the mark running far *ahead* of the playlist, because then nothing can be
+ * recorded at all until the stream catches up.
  *
  * *Missing* entries are the opposite failure: ids the stream published that the playlist never
  * showed us, because it advanced past them between two polls or carries a hole. Nothing else in the
@@ -37,7 +35,7 @@ import kotlin.test.assertTrue
 class SessionSegmentAccountingTest {
 
     @Test
-    fun `segments below the resume mark are counted as skipped, not enqueued`() =
+    fun `entries below the resume mark are skipped, not enqueued`() =
         runTest(UnconfinedTestDispatcher()) {
             val entry = newEntry(backgroundScope)
             try {
@@ -55,18 +53,14 @@ class SessionSegmentAccountingTest {
                     2, entry.lastPollSegmentCount,
                     "the playlist did advertise segments — this is what separates a filtered poll from an empty one"
                 )
-                assertEquals(2L, entry.skippedInStreak)
-                assertEquals(100L, entry.skippedMinId)
-                assertEquals(150L, entry.skippedMaxId)
-                assertEquals(2, entry.lastPollSkipped, "the poll's skip count is what reaches the metrics")
-                assertNotNull(entry.skipStreakSince)
+                assertEquals(2, entry.lastPollSkipped, "the poll reports how many entries it did not queue")
             } finally {
                 entry.scope.cancel()
             }
         }
 
     @Test
-    fun `a segment past the resume mark resets the streak`() = runTest(UnconfinedTestDispatcher()) {
+    fun `a segment past the resume mark advances the mark`() = runTest(UnconfinedTestDispatcher()) {
         val entry = newEntry(backgroundScope)
         try {
             entry.lastSegmentId = 100L
@@ -85,38 +79,76 @@ class SessionSegmentAccountingTest {
     }
 
     @Test
-    fun `a long skip streak is reported once and the catch-up is reported too`() =
+    fun `an overlap with the resume mark is normal and stays silent`() = runTest(UnconfinedTestDispatcher()) {
+        val entry = newEntry(backgroundScope)
+        try {
+            // the everyday case: the window and the mark join up, so the mark never leads
+            entry.computeUnseen(playlist(segUrl("1061"), segUrl("1062"), segUrl("1063")))
+            entry.computeUnseen(playlist(segUrl("1063"), segUrl("1064"), segUrl("1065")))
+
+            assertEquals(0L, entry.lastPollMarkAhead, "the mark and the window join up")
+            assertFalse(entry.markAheadReported, "an ordinary overlap must never be reported")
+            assertFalse(entry.lastPollMarkAheadJustReported, "and must never reach the metrics")
+        } finally {
+            entry.scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a resume mark far ahead of the playlist is reported once per episode`() =
         runTest(UnconfinedTestDispatcher()) {
             val entry = newEntry(backgroundScope)
             try {
-                entry.lastSegmentId = 900L
-                entry.computeUnseen(playlist(segUrl("800"), segUrl("850")))
-                entry.noteSkipOutcome(progressed = false)
+                entry.lastSegmentId = 1750L
 
-                // a fresh streak has not lasted long enough to be worth a line
-                assertFalse(entry.skipStreakReported, "a short streak stays silent")
+                entry.computeUnseen(playlist(segUrl("1002"), segUrl("1003"), segUrl("1004")))
 
-                // age the streak past the reporting delay, the way a real stall would
-                entry.skipStreakSince = Instant.now().minusSeconds(120)
-                entry.noteSkipOutcome(progressed = false)
-                assertTrue(entry.skipStreakReported, "a persistent streak is reported once")
-                assertEquals(2L, entry.skippedInStreak)
-                assertEquals(800L, entry.skippedMinId)
+                assertEquals(746L, entry.lastPollMarkAhead, "the mark is 746 ids ahead of the newest advertised")
+                assertTrue(entry.markAheadReported)
+                assertTrue(entry.lastPollMarkAheadJustReported, "the first poll of the episode publishes it")
 
-                // repeated polls must not report again
-                entry.noteSkipOutcome(progressed = false)
-                assertTrue(entry.skipStreakReported)
-
-                // catching up ends the streak and clears the accounting
-                entry.noteSkipOutcome(progressed = true)
-                assertNull(entry.skipStreakSince)
-                assertEquals(0L, entry.skippedInStreak)
-                assertFalse(entry.skipStreakReported)
-                assertNull(entry.skippedMaxId)
+                // still stuck on the next poll, but the episode was already reported
+                entry.computeUnseen(playlist(segUrl("1002"), segUrl("1003"), segUrl("1004")))
+                assertEquals(746L, entry.lastPollMarkAhead)
+                assertFalse(entry.lastPollMarkAheadJustReported, "a reported backlog is not repeated")
             } finally {
                 entry.scope.cancel()
             }
         }
+
+    @Test
+    fun `a lead within the threshold is not a backlog`() = runTest(UnconfinedTestDispatcher()) {
+        val entry = newEntry(backgroundScope)
+        try {
+            entry.lastSegmentId = 1070L
+            entry.computeUnseen(playlist(segUrl("1050"), segUrl("1060")))
+            assertFalse(entry.markAheadReported, "a lead of exactly the threshold is still normal")
+
+            entry.lastSegmentId = 1071L
+            entry.computeUnseen(playlist(segUrl("1050"), segUrl("1060")))
+            assertTrue(entry.markAheadReported, "one id past the threshold is reported")
+        } finally {
+            entry.scope.cancel()
+        }
+    }
+
+    @Test
+    fun `the stream catching up clears the backlog`() = runTest(UnconfinedTestDispatcher()) {
+        val entry = newEntry(backgroundScope)
+        try {
+            entry.lastSegmentId = 1750L
+            entry.computeUnseen(playlist(segUrl("1002"), segUrl("1003")))
+            assertTrue(entry.markAheadReported)
+
+            entry.computeUnseen(playlist(segUrl("1748"), segUrl("1749"), segUrl("1751")))
+
+            assertEquals(0L, entry.lastPollMarkAhead)
+            assertFalse(entry.markAheadReported, "the episode is over")
+            assertNull(entry.markAheadSince)
+        } finally {
+            entry.scope.cancel()
+        }
+    }
 
     /** `<room>_<segmentId>_<16 alnum>_<10 digits>.mp4` is the shape the id parser expects. */
     private fun segUrl(id: String) = "https://media.example/$id" + "_${id}_ABCDEFGHIJKLMNOP_1700000000.mp4"

--- a/src/test/kotlin/github/rikacelery/v3/integration/DiagnosticsEndpointTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/DiagnosticsEndpointTest.kt
@@ -3,6 +3,7 @@ package github.rikacelery.v3.integration
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
@@ -115,18 +116,42 @@ class DiagnosticsEndpointTest {
     }
 
     @Test
-    fun `skips behind the resume mark are visible in the metrics too`() = withFixture { fx ->
+    fun `the ordinary playlist overlap is not counted as skipped`() = withFixture { fx ->
         fx.ready()
         fx.startRecording()
 
-        // A recording re-lists segments it already wrote, so its skip counter must move. Without
-        // this the log and the metrics disagree, which reads as a false alarm.
-        val skipped = fx.await(10.seconds, "the segments-skipped counter to move") {
+        // The window overlaps the resume mark on every poll of a healthy room. Counting that made
+        // the metric grow forever without ever meaning anything, so it must stay at zero.
+        fx.await(5.seconds, "the session to queue media segments") { baselineSet(fx) }
+        delay(600)
+
+        val skipped = Regex("""xhrec_segments_skipped_total\{roomId="1001"\} (\d+)""")
+            .find(fx.get("/metrics").bodyAsText())?.groupValues?.get(1)?.toLong()
+        assertEquals(0L, skipped, "a healthy recording must not report a resume-mark backlog")
+    }
+
+    @Test
+    fun `a resume mark left ahead of the playlist is reported in the metrics`() = withFixture { fx ->
+        fx.ready()
+        fx.startRecording()
+
+        // Let the session get far enough ahead that rewinding the stream leaves the mark well
+        // beyond the threshold, rather than a segment or two.
+        fx.await(10.seconds, "the session to get ahead of the rewind point") {
+            previousNewSegmentId(fx)?.takeIf { it >= 1030 }
+        }
+
+        // The platform restarts its segment counter while the recorder still holds a mark from
+        // before, so every advertised segment is already recorded. This is the stall the accounting
+        // exists to catch, and the only case that may move the counter.
+        fx.mock.rewindSegments(1001L, 2)
+
+        val skipped = fx.await(10.seconds, "the resume-mark backlog to be reported") {
             val body = fx.get("/metrics").bodyAsText()
             Regex("""xhrec_segments_skipped_total\{roomId="1001"\} (\d+)""")
                 .find(body)?.groupValues?.get(1)?.toLong()?.takeIf { it > 0 }
         }
-        assertTrue(skipped > 0, "skips must be counted, got $skipped")
+        assertTrue(skipped > 0, "a mark far ahead of the playlist must be reported, got $skipped")
     }
 
     @Test
@@ -152,11 +177,15 @@ class DiagnosticsEndpointTest {
 
     /** Non-null once the session has queued at least one media segment. */
     private suspend fun baselineSet(fx: XhrecIntegrationFixture): Boolean? =
+        previousNewSegmentId(fx)?.let { true }
+
+    /** The highest segment id the session has queued, straight from `/diagnose`. */
+    private suspend fun previousNewSegmentId(fx: XhrecIntegrationFixture): Long? =
         fx.get("/diagnose?actor=SessionComponent&section=entries&room=1001")
             .bodyAsJson().jsonObject["entries"]!!.jsonArray.firstOrNull()
             ?.jsonObject?.get("previousNewSegmentId")
             ?.takeIf { it !is JsonNull }
-            ?.let { true }
+            ?.jsonPrimitive?.content?.toLongOrNull()
 
     @Test
     fun `an unknown actor is reported as not found`() = withFixture { fx ->

--- a/src/test/kotlin/github/rikacelery/v3/integration/MockPlatformServer.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/MockPlatformServer.kt
@@ -214,6 +214,16 @@ class MockPlatformServer(
         room.availableSegments += count
     }
 
+    /**
+     * Moves the room's newest segment id back to [to], so the playlist advertises ids *below* the
+     * ids the recorder has already seen. Models what a broadcast restart looks like from inside a
+     * session: the platform restarts its counter while the recorder still holds a resume mark from
+     * the previous show, so every advertised segment is already covered.
+     */
+    fun rewindSegments(id: Long, to: Int) {
+        room(id).availableSegments = to
+    }
+
     /** Applies [statuses] in order (first immediately), then loops every [period]. */
     fun rotateStatuses(id: Long, statuses: List<String>, period: Duration): Job {
         require(statuses.isNotEmpty())


### PR DESCRIPTION
Follow-up to #161, which is already merged.

## What was wrong with #161

It counted **every** entry the resume mark covered and published `SegmentsSkipped` on every poll. That was a mistake: the media playlist is a sliding window that overlaps the mark on *every* poll of *every* healthy room, so `xhrec_segments_skipped_total` grew forever without ever distinguishing a working room from a stuck one. Observing it live showed 46k `skipped` lines in nine hours against rooms that were downloading perfectly (`attempted == downloaded`, hundreds of MB each), while the one genuine event was buried.

The `no new segments for 30s` warning it fed had the same problem: it fired on ordinary idle stretches.

## The condition actually worth reporting

The inverse: the resume mark running **ahead** of the playlist.

```
mark 1750   newest advertised 1004   ->  ahead = 746
```

Every advertised segment is already recorded, so nothing can be downloaded until the stream catches up. That is exactly what the production stall looked like — a mark left over from an earlier broadcast, where the platform restarts its segment ids while the recorder still holds the previous show's mark. A healthy playlist instead *overlaps* the mark by a segment or two; the two "join up", so the lead is zero or negative.

## Changes

- The session compares the mark with the newest advertised id each poll. A lead beyond `resumeMarkAheadThreshold` (**10**) is a backlog: reported **once per episode** at `WARN`, and cleared with an `INFO` when the stream passes it.
- Only that report publishes `SegmentsSkipped`, so `xhrec_segments_skipped_total` now moves for exactly the rooms that are stuck, and stays at `0` for healthy ones.
- `thresholdSkipLogDelay` and the idle-based warning it drove are removed — that was the noisy signal.
- The per-poll `TRACE` line stays: it records which entries were covered, is opt-in, and read as "N of the M advertised ids were already covered; the mark moved A -> B".
- `/diagnose` exposes `resumeMarkAhead: {ahead, reported, since}` in place of `skipStreak`.

## Tests

329 pass, `0` failures; the compile-warnings gate is clean (`0`).

Both directions are pinned:

| Case | Expectation |
| --- | --- |
| window overlaps the mark | never reported, counter untouched |
| lead of exactly the threshold | not a backlog |
| one id past the threshold | reported |
| still stuck on the next poll | not reported or published again |
| stream passes the mark | episode cleared |
| healthy recording, end to end | `xhrec_segments_skipped_total` stays `0` |
| mock stream rewound under a live mark, end to end | counter moves |

The last two use a new `MockPlatformServer.rewindSegments` helper, which reproduces the production failure shape: the platform restarts its counter while the recorder holds a mark from before.

## Docs

Both READMEs now state that an overlap is normal and that the counter only moves for a mark left ahead of the playlist, with the new `WARN`/`INFO` lines, the threshold, and the updated `/diagnose` fields.

## Deployment

`deploy.sh` was run: the jar is uploaded and the `rec:latest` image is rebuilt. The script does not restart the container, so the running process is still on the previous build until it is restarted.
