### PR TITLE
fix(metrics): feed the refresh-latency gauge and expose recording liveness

### DIFF
--- a/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
@@ -49,6 +49,17 @@ class MetricComponent(
 
     private val metrics = ConcurrentHashMap<Long, RoomMetrics>()
 
+    /**
+     * Rooms with a session running right now.
+     *
+     * Every other per-room series survives the session it describes — `metrics` entries are dropped
+     * only when the room itself is removed — so a flat `xhrec_downloaded_total` says "not
+     * downloading" without saying whether the room was supposed to be. This gauge separates the
+     * two, which is what makes "recording but not downloading" alertable instead of something that
+     * also fires for every offline room.
+     */
+    private val recording = ConcurrentHashMap.newKeySet<Long>()
+
     override suspend fun onStart(scope: CoroutineScope) {
         // One collector preserves ordering across event types, including immediate
         // failures and file rotations. wrapEvent filters out unrelated events.
@@ -162,16 +173,21 @@ class MetricComponent(
 
                 is RecordingStarted -> {
                     metrics.getOrPut(e.roomId) { RoomMetrics() }.quality = e.quality
+                    recording.add(e.roomId)
                 }
 
                 is RecordingStopped -> {
-                    // Deliberately keep the counters. RecordingStopped fires per session (a limit
-                    // cut restarts the room), so removing here reset every lifetime counter on each
-                    // cut and erased the series before anyone could read it post-mortem. The entry is
-                    // dropped only when the room itself is removed.
+                    // The session is over, so the room is not downloading because it is not
+                    // recording — the distinction `xhrec_recording` exists to make. The counters
+                    // stay: RecordingStopped fires per session (a limit cut restarts the room), so
+                    // resetting here erased every lifetime counter on each cut.
+                    recording.remove(e.roomId)
                 }
 
-                is RoomRemoved -> metrics.remove(e.roomId)
+                is RoomRemoved -> {
+                    metrics.remove(e.roomId)
+                    recording.remove(e.roomId)
+                }
 
                 is RoomStatusChanged -> {
                     // Record model schedule when room goes live (not offline)
@@ -211,6 +227,7 @@ class MetricComponent(
         family("xhrec_segment_id_current", "Current segment ID", "gauge")
         family("xhrec_downloading_current", "Currently downloading segments", "gauge")
         family("xhrec_quality", "Recording quality", "gauge")
+        family("xhrec_recording", "A recording session is running for this room (1) or not (0)", "gauge")
         family("xhrec_segment_downloaded_current", "Downloaded in current segment", "gauge")
         family("xhrec_cdn_estimated_duration_ms", "CDN host estimated duration at current time", "gauge")
         family("xhrec_cdn_confidence", "CDN host prediction confidence (0-1)", "gauge")
@@ -245,6 +262,7 @@ class MetricComponent(
             sb.appendLine("xhrec_segment_id_current{roomId=\"$roomId\"} ${m.currentSegmentId.get()}")
             sb.appendLine("xhrec_downloading_current{roomId=\"$roomId\"} ${m.runningUrls.size}")
             sb.appendLine("xhrec_quality{roomId=\"$roomId\",quality=\"${m.quality}\"} 1")
+            sb.appendLine("xhrec_recording{roomId=\"$roomId\"} ${if (roomId in recording) 1 else 0}")
             sb.appendLine("xhrec_segment_downloaded_current{roomId=\"$roomId\"} ${m.segmentDownloaded.get()}")
         }
 

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -427,6 +427,7 @@ class SessionEntry(
             withTimeout(component.runtimeTuning.playlistFetchTimeout) {
                 val client = component.httpClientProvider.proxied("m3u8_$roomId")
                 val attemptMs = component.runtimeTuning.playlistAttemptTimeout.inWholeMilliseconds
+                val startedAt = System.currentTimeMillis()
                 val response = withRetry(3) {
                     client.get(playlistUrl) {
                         timeout {
@@ -441,6 +442,7 @@ class SessionEntry(
                     }
                 }
                 val text = response.bodyAsText()
+                val latencyMs = System.currentTimeMillis() - startedAt
                 val key = decryptKey ?: run {
                     val fetched = component.requestBus.request<ConfigResponse>(GetDecryptKey(pkey)).value as? String
                     if (fetched != null) decryptKey = fetched
@@ -451,6 +453,13 @@ class SessionEntry(
                 )
                 val parsed = component.m3u8Parser.parse(text, key)
                 CdnSelector.recordPlaylistSuccess(CdnSelector.hostOf(playlistUrl))
+                // The only producer of this event: without it `xhrec_refresh_latency_ms` and
+                // `xhrec_segment_id_current` are declared, consumed and scraped, but stay at 0
+                // forever. The latency covers the whole fetch including retries and the body read,
+                // which is what "how long did this refresh take" means to an operator.
+                component.publish(
+                    PlaylistRefreshed(roomId, latencyMs, parsed.segments.maxOfOrNull { it.index } ?: 0)
+                )
                 SessionSignal(roomId, RecordingEvent.PlaylistFetched, RecordingDriveData(playlist = parsed))
             }
         } catch (e: TimeoutCancellationException) {

--- a/src/test/kotlin/github/rikacelery/v3/integration/MetricsPipelineIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/MetricsPipelineIntegrationTest.kt
@@ -1,0 +1,61 @@
+package github.rikacelery.v3.integration
+
+import github.rikacelery.v3.events.PlaylistRefreshed
+import io.ktor.client.statement.bodyAsText
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * The exported gauges have to be fed by something. Two of them were not:
+ *
+ *  - nothing published [PlaylistRefreshed], so `xhrec_refresh_latency_ms` and
+ *    `xhrec_segment_id_current` were declared, consumed and scraped while staying at 0 forever;
+ *  - nothing distinguished "not downloading because the room is offline" from "not downloading
+ *    while a session is running", because every per-room series outlives the session it describes.
+ */
+class MetricsPipelineIntegrationTest {
+
+    @Test
+    fun `each playlist poll reports its latency and newest segment id`() = withFixture { fx ->
+        fx.ready()
+        fx.startRecording()
+
+        // The window is legitimately empty before the stream publishes anything, so the first
+        // refresh or two carry no media ids; wait for one that does.
+        val refreshed = fx.awaitEvent<PlaylistRefreshed>(10.seconds) {
+            it.roomId == 1001L && it.maxSegmentId > 0
+        }
+        assertTrue(refreshed.latencyMs >= 0, "the fetch latency is measured: $refreshed")
+        assertTrue(refreshed.maxSegmentId > 0, "the newest advertised id, not the init placeholder: $refreshed")
+
+        val metrics = fx.get("/metrics").bodyAsText()
+        assertTrue(
+            Regex("""xhrec_refresh_latency_ms\{roomId="1001"\} [\d.]+""").containsMatchIn(metrics),
+            "the refresh gauge must be exported for a recording room"
+        )
+        val currentId = Regex("""xhrec_segment_id_current\{roomId="1001"\} (\d+)""")
+            .find(metrics)?.groupValues?.get(1)?.toLong()
+        assertTrue((currentId ?: 0) > 0, "the current-segment gauge must carry the advertised id, got $currentId")
+    }
+
+    @Test
+    fun `the recording gauge tracks whether a session is running`() = withFixture { fx ->
+        fx.ready()
+        fx.startRecording()
+        assertEquals(1L, recordingGauge(fx), "a room with a running session must report recording=1")
+
+        fx.get("/deactivate?id=1001")
+
+        val off = fx.await(10.seconds, "the recording gauge to drop back to 0") {
+            recordingGauge(fx).takeIf { it == 0L }
+        }
+        assertEquals(0L, off, "an offline room must report recording=0, or a stalled-room alert would fire on it")
+    }
+
+    /** Reads `xhrec_recording` for room 1001, or null when the room is not exported yet. */
+    private suspend fun recordingGauge(fx: XhrecIntegrationFixture): Long? =
+        Regex("""xhrec_recording\{roomId="1001"\} (\d+)""")
+            .find(fx.get("/metrics").bodyAsText())?.groupValues?.get(1)?.toLong()
+}


### PR DESCRIPTION
While rebuilding the Grafana dashboard against the current metric set, three series turned out to be declared, consumed, scraped — and never produced. This fixes two of them and adds the liveness signal the dashboard needs.

## `PlaylistRefreshed` had no publisher

`xhrec_refresh_latency_ms` and `xhrec_segment_id_current` are both driven by `PlaylistRefreshed`. The event class existed, `MetricComponent.wrapEvent` had a branch for it, the handler filled `refreshLatencySamples` and `currentSegmentId` — and **nothing in the codebase ever published it**. Both gauges were permanently `0`, so any panel built on them (including the "Refresh Latency" panel in the existing dashboard) was empty.

The session now publishes it once per playlist poll:

- `latencyMs` covers the whole fetch — retries and the body read included — which is what "how long did this refresh take" means to an operator;
- `maxSegmentId` is the newest **advertised** id, so the gauge shows where the stream actually is (useful next to the resume mark when diagnosing a stall).

## There was no way to tell a stalled room from an offline one

Every per-room series outlives the session it describes: `metrics` entries are dropped only on `RoomRemoved`, and `RecordingStopped` deliberately keeps the counters so a post-mortem is possible. A flat `xhrec_downloaded_total` therefore means "not downloading" without saying whether the room was *supposed* to be — and any alert built on that fires for every room that simply went offline.

`xhrec_recording{roomId}` is `1` while a session is running, `0` otherwise (exported for every room already tracked, so an offline room reads `0` rather than disappearing). That is what makes the stall alertable:

```promql
(changes(xhrec_downloaded_total{job="xhrec_native"}[10m]) == 0)
and (xhrec_recording{job="xhrec_native"} == 1)
and (xhrec_downloaded_total{job="xhrec_native"} offset 10m)
```

The `offset` term excludes a room that started recording less than ten minutes ago, so a fresh session does not trip it while it is still warming up.

## Tests

327 pass, `0` failures; the compile-warnings gate is clean.

- one test waits for a `PlaylistRefreshed` that carries a real segment id (the first refresh or two legitimately carry none, because the window is empty until the stream publishes) and asserts both gauges are exported with a value;
- another drives a room through `/deactivate` and asserts `xhrec_recording` returns to `0`.

`RuntimeInjectionTest`'s downloader race-timing test failed once during a full run and passed on two immediate re-runs; it is timing-sensitive and untouched by this change.

## Dashboard

A rebuilt dashboard accompanies this (24 panels, delivered separately, not committed since `*.json` is ignored): Failed and Missing now show cumulative **counts** rather than rates, Refresh Latency is back now that its metric is fed, and there are new panels for the resume-mark backlog and for "recording but not downloading".
