### PR TITLE
feat(metrics): pipeline, CDN attribution and per-room state for Prometheus

### DIFF
--- a/src/main/kotlin/github/rikacelery/v3/components/DownloaderComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/DownloaderComponent.kt
@@ -5,6 +5,7 @@ import github.rikacelery.v3.core.DataChannel
 import github.rikacelery.v3.core.Diagnosable
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.OrderedEmitter
+import github.rikacelery.v3.core.PipelineMetrics
 import github.rikacelery.v3.data.DownloadMeta
 import github.rikacelery.v3.data.DownloadResult
 import github.rikacelery.v3.data.RuntimeTuning
@@ -301,6 +302,11 @@ class DownloaderComponent(
             when {
                 result is DownloadResult.Success -> {
                     CdnSelector.record(host, result.meta.fetchDurationMs)
+                    // `host` is the one whose rewritten URL served the bytes — after any failover,
+                    // not the selector's first pick. Counted here rather than through
+                    // `CdnSelector.record` because that one also counts master playlist fetches and
+                    // skips sub-millisecond downloads.
+                    PipelineMetrics.recordCdnServed(host)
                     return result
                 }
                 result is DownloadResult.Failed && result.statusCode == 404 -> {
@@ -314,7 +320,10 @@ class DownloaderComponent(
                     return result
                 }
                 result is DownloadResult.Failed -> {
-                    if (result.transportError) CdnSelector.recordFailure(host)
+                    if (result.transportError) {
+                        CdnSelector.recordFailure(host)
+                        PipelineMetrics.recordCdnServeFailure(host)
+                    }
                     logger.trace("Segment #{} attempt {} failed on {}: {}", idx, attempts, host, result.reason)
                     lastFail = result
                 }

--- a/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
@@ -2,6 +2,7 @@ package github.rikacelery.v3.components
 
 import github.rikacelery.v3.core.Actor
 import github.rikacelery.v3.core.EventBus
+import github.rikacelery.v3.core.PipelineMetrics
 import github.rikacelery.v3.events.*
 import github.rikacelery.v3.utils.CdnSelector
 import github.rikacelery.v3.utils.HttpConnectionStats
@@ -212,6 +213,8 @@ class MetricComponent(
         family("xhrec_downloading_current", "Currently downloading segments", "gauge")
         family("xhrec_quality", "Recording quality", "gauge")
         family("xhrec_segment_downloaded_current", "Downloaded in current segment", "gauge")
+        family("xhrec_room_download_bytes_total", "Total bytes downloaded for a room", "counter")
+        family("xhrec_cdn_cooldown", "CDN host cooling down for segment downloads (1) or not (0)", "gauge")
         family("xhrec_cdn_estimated_duration_ms", "CDN host estimated duration at current time", "gauge")
         family("xhrec_cdn_confidence", "CDN host prediction confidence (0-1)", "gauge")
         family("xhrec_cdn_total_successes", "CDN host total successful downloads", "counter")
@@ -246,6 +249,7 @@ class MetricComponent(
             sb.appendLine("xhrec_downloading_current{roomId=\"$roomId\"} ${m.runningUrls.size}")
             sb.appendLine("xhrec_quality{roomId=\"$roomId\",quality=\"${m.quality}\"} 1")
             sb.appendLine("xhrec_segment_downloaded_current{roomId=\"$roomId\"} ${m.segmentDownloaded.get()}")
+            sb.appendLine("xhrec_room_download_bytes_total{roomId=\"$roomId\"} ${m.lifetimeBytes.get()}")
         }
 
         // CDN host duration metrics
@@ -259,6 +263,7 @@ class MetricComponent(
             sb.appendLine("xhrec_cdn_total_errors{host=\"$host\"} ${stat.totalErrors}")
             sb.appendLine("xhrec_cdn_playlist_failures{host=\"$host\"} ${stat.playlistFailures}")
             sb.appendLine("xhrec_cdn_playlist_cooldown{host=\"$host\"} ${if (stat.playlistCooldownUntil > now) 1 else 0}")
+            sb.appendLine("xhrec_cdn_cooldown{host=\"$host\"} ${if (stat.cooldownUntil > now) 1 else 0}")
         }
 
         // Connection-level telemetry for the human-paced clients (playlist / master / preconfig),
@@ -296,6 +301,10 @@ class MetricComponent(
                 sb.appendLine("xhrec_http_cancelled_total{$labels} ${s.cancelled}")
             }
         }
+
+        // Bus, data channel and actor counters are process-wide and live in the objects that own
+        // them; they are pulled here rather than pushed as events (see PipelineMetrics).
+        PipelineMetrics.appendMetrics(sb)
 
         return sb.toString()
     }

--- a/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
@@ -41,6 +41,9 @@ data class RoomMetrics(
     val segmentMissing: AtomicLong = AtomicLong(0),
     /** Playlist entries skipped because the resume mark already covered them (never reset). */
     val segmentsSkipped: AtomicLong = AtomicLong(0),
+    /** Cut and session-exit reasons, so "why did this recording end" is a label. */
+    val cutReasons: ConcurrentHashMap<String, AtomicLong> = ConcurrentHashMap(),
+    val stopReasons: ConcurrentHashMap<String, AtomicLong> = ConcurrentHashMap(),
     val runningUrls: ConcurrentHashMap<String, RunningUrlInfo> = ConcurrentHashMap()
 )
 
@@ -63,6 +66,10 @@ class MetricComponent(
         is DownloadStarted -> OnMetricEvent(event)
         is SegmentGapDetected -> OnMetricEvent(event)
         is SegmentsSkipped -> OnMetricEvent(event)
+        is CutPointDone -> OnMetricEvent(event)
+        is SessionExit -> OnMetricEvent(event)
+        is WsReconnected -> OnMetricEvent(event)
+        is WsDisconnected -> OnMetricEvent(event)
         is FileReady -> OnMetricEvent(event)
         is FileProcessed -> OnMetricEvent(event)
         is PlaylistRefreshed -> OnMetricEvent(event)
@@ -142,6 +149,19 @@ class MetricComponent(
                     metrics.getOrPut(e.roomId) { RoomMetrics() }.segmentsSkipped.addAndGet(e.count.toLong())
                 }
 
+                is CutPointDone -> {
+                    metrics.getOrPut(e.roomId) { RoomMetrics() }
+                        .cutReasons.computeIfAbsent(e.reason.name) { AtomicLong() }.incrementAndGet()
+                }
+
+                is SessionExit -> {
+                    metrics.getOrPut(e.roomId) { RoomMetrics() }
+                        .stopReasons.computeIfAbsent(e.reason.name) { AtomicLong() }.incrementAndGet()
+                }
+
+                is WsReconnected -> PipelineMetrics.recordWsConnected()
+                is WsDisconnected -> PipelineMetrics.recordWsDisconnected()
+
                 is FileReady -> {
                     val m = metrics[e.roomId] ?: return
                     m.fileCount.incrementAndGet()
@@ -216,6 +236,8 @@ class MetricComponent(
         family("xhrec_segment_downloaded_current", "Downloaded in current segment", "gauge")
         family("xhrec_room_download_bytes_total", "Total bytes downloaded for a room", "counter")
         family("xhrec_cdn_cooldown", "CDN host cooling down for segment downloads (1) or not (0)", "gauge")
+        family("xhrec_room_cut_total", "File cuts, by reason", "counter")
+        family("xhrec_room_recordings_stopped_total", "Recording sessions that ended, by reason", "counter")
         family("xhrec_cdn_estimated_duration_ms", "CDN host estimated duration at current time", "gauge")
         family("xhrec_cdn_confidence", "CDN host prediction confidence (0-1)", "gauge")
         family("xhrec_cdn_total_successes", "CDN host total successful downloads", "counter")
@@ -251,6 +273,12 @@ class MetricComponent(
             sb.appendLine("xhrec_quality{roomId=\"$roomId\",quality=\"${m.quality}\"} 1")
             sb.appendLine("xhrec_segment_downloaded_current{roomId=\"$roomId\"} ${m.segmentDownloaded.get()}")
             sb.appendLine("xhrec_room_download_bytes_total{roomId=\"$roomId\"} ${m.lifetimeBytes.get()}")
+            m.cutReasons.forEach { (reason, count) ->
+                sb.appendLine("xhrec_room_cut_total{roomId=\"$roomId\",reason=\"$reason\"} ${count.get()}")
+            }
+            m.stopReasons.forEach { (reason, count) ->
+                sb.appendLine("xhrec_room_recordings_stopped_total{roomId=\"$roomId\",reason=\"$reason\"} ${count.get()}")
+            }
         }
 
         // CDN host duration metrics

--- a/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
@@ -3,6 +3,7 @@ package github.rikacelery.v3.components
 import github.rikacelery.v3.core.Actor
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.PipelineMetrics
+import github.rikacelery.v3.core.RoomStateRegistry
 import github.rikacelery.v3.events.*
 import github.rikacelery.v3.utils.CdnSelector
 import github.rikacelery.v3.utils.HttpConnectionStats
@@ -305,6 +306,7 @@ class MetricComponent(
         // Bus, data channel and actor counters are process-wide and live in the objects that own
         // them; they are pulled here rather than pushed as events (see PipelineMetrics).
         PipelineMetrics.appendMetrics(sb)
+        RoomStateRegistry.appendMetrics(sb, now)
 
         return sb.toString()
     }

--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -6,6 +6,7 @@ import github.rikacelery.v3.core.BusMonitor
 import github.rikacelery.v3.core.Diagnosable
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
+import github.rikacelery.v3.core.RoomStateRegistry
 import github.rikacelery.v3.core.diagnose
 import github.rikacelery.v3.data.Hosts
 import github.rikacelery.v3.data.Room
@@ -928,6 +929,7 @@ class SchedulerComponent(
             is WriterFatal -> {
                 logger.error("roomId={} writer fatal: {}", event.roomId, event.error)
                 entries.remove(event.roomId)?.scope?.cancel()
+                RoomStateRegistry.remove(event.roomId)
                 evictRoomClients(event.roomId)
                 // The writer has already closed and deleted the partial file, so a session left
                 // running would keep downloading bytes into nothing. Stop it for the same reason
@@ -939,6 +941,7 @@ class SchedulerComponent(
             // ghost row (see issue #141). Mirrors the DeactivateCmd branch.
             is RoomRemoved -> {
                 entries.remove(event.roomId)?.scope?.cancel()
+                RoomStateRegistry.remove(event.roomId)
                 evictRoomClients(event.roomId)
                 sessionComponent.tell(StopRecording(event.roomId, EndReason.UserStop))
                 logger.info("roomId={} removed, disarmed and recording stopped", event.roomId)
@@ -961,11 +964,32 @@ class SchedulerComponent(
     private suspend fun driveFsm(sig: SchedulerSignal) {
         val e = entries[sig.roomId] ?: return
         e.fsm.driveCatch(sig.event, sig.data)?.let { logger.error("Scheduler FSM drive failed", it) }
+        exportRoomState(sig.roomId, e)
     }
 
     private suspend fun driveFsm(roomId: Long, event: SchedulerEvent, data: SchedulerDriveData?) {
         val e = entries[roomId] ?: return
         e.fsm.driveCatch(event, data)?.let { logger.error("Scheduler FSM drive failed", it) }
+        exportRoomState(roomId, e)
+    }
+
+    /**
+     * Refreshes the exported state of one armed room. Called from **both** `driveFsm` overloads:
+     * they are independent, and the self-scheduled signals (PreconfigDone, BackToArmed, …) only go
+     * through the [SchedulerSignal] one, so instrumenting a single overload left the exported state
+     * stuck wherever an externally-driven transition had left it.
+     *
+     * Identity and arming live here rather than in RoomComponent because the scheduler is the
+     * authority on being armed — a room's `armed` flag never changes when the room list is saved.
+     */
+    private fun exportRoomState(roomId: Long, e: SchedulerEntry) {
+        RoomStateRegistry.update(roomId) {
+            status = e.roomStatus
+            quality = e.configuredQuality.ifBlank { e.settings.quality }
+            armed = true
+            schedulerState = e.fsm.currentState.name
+            hintCode = e.hint()?.code?.wireName
+        }
     }
 
     /**
@@ -1032,6 +1056,7 @@ class SchedulerComponent(
 
             is DeactivateCmd -> {
                 entries.remove(cmd.roomId)?.scope?.cancel()
+                RoomStateRegistry.update(cmd.roomId) { armed = false; schedulerState = ""; hintCode = null }
                 evictRoomClients(cmd.roomId)
                 sessionComponent.tell(StopRecording(cmd.roomId, EndReason.UserStop))
                 logger.info("roomId={} deactivated", cmd.roomId)

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -774,6 +774,7 @@ class SessionComponent(
         RoomStateRegistry.update(sig.roomId) {
             sessionState = e.fsm.currentState.name
             lastProgressAtMs = e.lastProgressAt.toEpochMilli()
+            resumeMarkAhead = e.lastPollMarkAhead
         }
     }
 

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -5,6 +5,7 @@ import github.rikacelery.v3.core.DataChannel
 import github.rikacelery.v3.core.Diagnosable
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.core.RequestBus
+import github.rikacelery.v3.core.RoomStateRegistry
 import github.rikacelery.v3.core.diagnose
 import github.rikacelery.v3.data.RuntimeTuning
 import github.rikacelery.v3.data.StreamStart
@@ -768,6 +769,12 @@ class SessionComponent(
     private fun driveFsm(sig: SessionSignal) {
         val e = entries[sig.roomId] ?: return
         e.fsm.driveCatch(sig.event, sig.data)?.let { logger.error("Session FSM drive failed", it) }
+        // The playlist loop drives this every poll, so the exported progress clock and resume-mark
+        // lag stay fresh without a second timer.
+        RoomStateRegistry.update(sig.roomId) {
+            sessionState = e.fsm.currentState.name
+            lastProgressAtMs = e.lastProgressAt.toEpochMilli()
+        }
     }
 
     private fun onBus(event: Any) {

--- a/src/main/kotlin/github/rikacelery/v3/core/Actor.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/Actor.kt
@@ -21,12 +21,6 @@ abstract class Actor<T : Any>(
 ) : Diagnosable {
     private val mailbox = Channel<T>(capacity = mailboxCapacity)
 
-    /**
-     * Messages accepted but not yet handled. Kept by hand rather than read from the channel so it
-     * needs no experimental API, and it is the cheapest way to tell "this actor is behind" from
-     * "this actor is idle" when a component looks stuck.
-     */
-    private val mailboxDepth = AtomicInteger(0)
     protected val logger = LoggerFactory.getLogger(name)
     internal val scope =
         parentScope + SupervisorJob() + CoroutineName(name) + CoroutineExceptionHandler { context, throwable ->
@@ -76,11 +70,14 @@ abstract class Actor<T : Any>(
             startCompleted.set(true)
             signalSubscriptionsReady()
             for (msg in mailbox) {
+                val stat = PipelineMetrics.actor(name)
+                stat.inFlight.incrementAndGet()
+                val start = System.nanoTime()
                 try {
-                    val start = System.nanoTime()
                     handle(msg)
                     val duration = (System.nanoTime() - start) / 1_000_000
                     if (duration > slowHandlerThresholdMs) {
+                        stat.slow.incrementAndGet()
                         logger.warn(
                             "slow handler: actor={}, msg={}, took={}ms",
                             name, msg::class.simpleName, duration
@@ -89,9 +86,13 @@ abstract class Actor<T : Any>(
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
+                    stat.errors.incrementAndGet()
                     onError(e, msg)
                 } finally {
-                    mailboxDepth.decrementAndGet()
+                    stat.depth.decrementAndGet()
+                    stat.inFlight.decrementAndGet()
+                    stat.messages.incrementAndGet()
+                    stat.handleNanos.addAndGet(System.nanoTime() - start)
                 }
             }
         }
@@ -100,6 +101,7 @@ abstract class Actor<T : Any>(
     open fun stop() {
         started = false
         Diagnostics.unregister(name)
+        PipelineMetrics.forgetActor(name)
         mailbox.close()
         scope.cancel()
     }
@@ -107,16 +109,20 @@ abstract class Actor<T : Any>(
     suspend fun tell(msg: T) = enqueue(msg)
 
     /**
-     * Single funnel for every message entering the mailbox, so [mailboxDepth] stays truthful.
-     * Bus subscriptions enqueue directly rather than through [tell], and counting only one of the
-     * two paths made the depth drift negative.
+     * Single funnel for every message entering the mailbox, so the depth stays truthful. Bus
+     * subscriptions enqueue directly rather than through [tell], and counting only one of the two
+     * paths made the depth drift negative.
+     *
+     * The depth lives in [PipelineMetrics] rather than here so the exporter and `/diagnose` read the
+     * same counter instead of two copies that can disagree.
      */
     private suspend fun enqueue(msg: T) {
-        mailboxDepth.incrementAndGet()
+        val depth = PipelineMetrics.actor(name).depth
+        depth.incrementAndGet()
         try {
             mailbox.send(msg)
         } catch (e: Throwable) {
-            mailboxDepth.decrementAndGet()
+            depth.decrementAndGet()
             throw e
         }
     }
@@ -162,7 +168,7 @@ abstract class Actor<T : Any>(
         put("actor", name)
         put("type", this@Actor::class.simpleName ?: "")
         put("started", started)
-        put("mailboxDepth", mailboxDepth.get())
+        put("mailboxDepth", PipelineMetrics.actor(name).depth.get())
         put("mailboxCapacity", mailboxCapacity)
         extra.forEach { (key, value) -> put(key, value) }
     }

--- a/src/main/kotlin/github/rikacelery/v3/core/DataChannel.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/DataChannel.kt
@@ -33,8 +33,18 @@ class DataChannel(capacity: Int = 256) {
             })
         }
         val result = channel.trySend(msg)
+        val type = msg::class.simpleName ?: "unknown"
         if (result.isFailure) {
-            logger.warn("DataChannel full, dropping {} (roomId={})", msg::class.simpleName, roomOf(msg))
+            // Dropping media here means the finished file is missing data, so it is counted as
+            // well as logged — a log line nobody greps is not an alert.
+            PipelineMetrics.recordChannelDropped(type)
+            logger.warn("DataChannel full, dropping {} (roomId={})", type, roomOf(msg))
+        } else {
+            PipelineMetrics.channelPending.incrementAndGet()
+            PipelineMetrics.recordChannelSent(
+                type,
+                if (msg is github.rikacelery.v3.data.StreamData) msg.data.size else 0
+            )
         }
     }
 
@@ -45,6 +55,13 @@ class DataChannel(capacity: Int = 256) {
         is github.rikacelery.v3.data.StreamEvent -> msg.roomId
     }
 
-    suspend fun receive(): DataChannelMsg = channel.receive()
+    suspend fun receive(): DataChannelMsg {
+        val msg = channel.receive()
+        // Counted after the receive so a cancelled or closed receive does not decrement a message
+        // that was never taken out of the channel.
+        PipelineMetrics.channelPending.decrementAndGet()
+        return msg
+    }
+
     fun close() = channel.close()
 }

--- a/src/main/kotlin/github/rikacelery/v3/core/EventBus.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/EventBus.kt
@@ -42,6 +42,7 @@ class EventBus {
         }
         if (e == null) return
         val published = e
+        PipelineMetrics.recordEventPublished(published::class.simpleName ?: "unknown")
 
         if (BusMonitor.wants(BusMonitor.EVENT)) {
             BusMonitor.record(BusMonitor.EVENT, buildJsonObject {
@@ -61,17 +62,18 @@ class EventBus {
 
     private fun recordBacklog(event: Any) {
         val now = System.currentTimeMillis()
+        val typeName = event::class.simpleName ?: "unknown"
+        PipelineMetrics.recordEventDropped(typeName)
         synchronized(backlogLock) {
             if (backlogStartTime == 0L) {
                 backlogStartTime = now
                 lastBacklogReportTime = now
                 logger.warn(
                     "EventBus buffer full, starting to back up. first event: {}",
-                    event::class.simpleName
+                    typeName
                 )
             }
             backlogTotal++
-            val typeName = event::class.simpleName ?: "unknown"
             backlogByType.merge(typeName, 1L, Long::plus)
 
             val elapsed = now - lastBacklogReportTime

--- a/src/main/kotlin/github/rikacelery/v3/core/PipelineMetrics.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/PipelineMetrics.kt
@@ -1,0 +1,173 @@
+package github.rikacelery.v3.core
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Process-wide counters for the internal transports and the actor mailboxes, rendered by the
+ * Prometheus exporter.
+ *
+ * These are **pulled** at scrape time rather than published as events, for two concrete reasons:
+ *
+ *  - `EventBus` cannot report its own drops through itself. Each report would be another event that
+ *    can be dropped, and counting published events by publishing an event recurses.
+ *  - a per-message `AtomicLong` increment is cheaper than a bus round trip, and the counters that
+ *    matter most here are on the hottest paths in the recorder.
+ *
+ * Everything is keyed by a bounded label (event type, message type, actor name), so cardinality is
+ * a few dozen series in total.
+ */
+object PipelineMetrics {
+
+    // ── Event bus ─────────────────────────────────────────────────────────────
+
+    private val eventsPublished = ConcurrentHashMap<String, AtomicLong>()
+    private val eventsDropped = ConcurrentHashMap<String, AtomicLong>()
+
+    /** True while the bus buffer is saturated and events are being dropped. */
+    @Volatile
+    var eventBusBacklogged: Boolean = false
+        private set
+
+    /** Events dropped since start; monotonic, unlike the per-episode total the logger reports. */
+    val eventBusDroppedTotal = AtomicLong(0)
+
+    fun recordEventPublished(type: String) {
+        eventsPublished.bump(type)
+    }
+
+    /** Records one dropped event and enters the backlogged state. */
+    fun recordEventDropped(type: String) {
+        eventsDropped.bump(type)
+        eventBusDroppedTotal.incrementAndGet()
+        eventBusBacklogged = true
+    }
+
+    fun clearEventBacklog() {
+        eventBusBacklogged = false
+    }
+
+    // ── Data channel (downloader → writer) ────────────────────────────────────
+
+    private val channelSent = ConcurrentHashMap<String, AtomicLong>()
+    private val channelDropped = ConcurrentHashMap<String, AtomicLong>()
+
+    /** Messages accepted but not yet consumed by the writer. */
+    val channelPending = AtomicInteger(0)
+
+    /** Media bytes handed to the channel. */
+    val channelBytes = AtomicLong(0)
+
+    fun recordChannelSent(type: String, bytes: Int) {
+        channelSent.bump(type)
+        channelBytes.addAndGet(bytes.toLong())
+    }
+
+    fun recordChannelDropped(type: String) {
+        channelDropped.bump(type)
+    }
+
+    // ── Actors ────────────────────────────────────────────────────────────────
+
+    class ActorStat {
+        /** Messages accepted but not yet handled. */
+        val depth = AtomicInteger(0)
+
+        /** Messages handled since start. */
+        val messages = AtomicLong(0)
+
+        /** Handlers that exceeded the actor's slow-handler threshold. */
+        val slow = AtomicLong(0)
+
+        /** Handler exceptions, cancellations excluded. */
+        val errors = AtomicLong(0)
+
+        /** Total nanoseconds spent inside handlers, for a mean latency. */
+        val handleNanos = AtomicLong(0)
+
+        /** 1 while a handler is executing, 0 otherwise. */
+        val inFlight = AtomicInteger(0)
+    }
+
+    private val actors = ConcurrentHashMap<String, ActorStat>()
+
+    fun actor(name: String): ActorStat = actors.computeIfAbsent(name) { ActorStat() }
+
+    fun forgetActor(name: String) {
+        actors.remove(name)
+    }
+
+    // ── Prometheus rendering ──────────────────────────────────────────────────
+
+    fun appendMetrics(sb: StringBuilder) {
+        family(sb, "xhrec_eventbus_published_total", "Events published on the internal bus", "counter")
+        eventsPublished.forEach { (type, count) ->
+            sb.appendLine("xhrec_eventbus_published_total{event=\"$type\"} ${count.get()}")
+        }
+
+        family(sb, "xhrec_eventbus_dropped_total", "Events dropped because the bus buffer was full", "counter")
+        eventsDropped.forEach { (type, count) ->
+            sb.appendLine("xhrec_eventbus_dropped_total{event=\"$type\"} ${count.get()}")
+        }
+
+        family(sb, "xhrec_eventbus_backlogged", "The event bus is saturated and dropping (1) or not (0)", "gauge")
+        sb.appendLine("xhrec_eventbus_backlogged ${if (eventBusBacklogged) 1 else 0}")
+
+        family(sb, "xhrec_datachannel_sent_total", "Messages handed to the data channel", "counter")
+        channelSent.forEach { (type, count) ->
+            sb.appendLine("xhrec_datachannel_sent_total{msg=\"$type\"} ${count.get()}")
+        }
+
+        family(sb, "xhrec_datachannel_dropped_total", "Messages dropped because the data channel was full", "counter")
+        channelDropped.forEach { (type, count) ->
+            sb.appendLine("xhrec_datachannel_dropped_total{msg=\"$type\"} ${count.get()}")
+        }
+
+        family(sb, "xhrec_datachannel_pending", "Messages in the data channel, not yet written", "gauge")
+        sb.appendLine("xhrec_datachannel_pending ${channelPending.get()}")
+
+        family(sb, "xhrec_datachannel_bytes_total", "Media bytes handed to the data channel", "counter")
+        sb.appendLine("xhrec_datachannel_bytes_total ${channelBytes.get()}")
+
+        family(sb, "xhrec_actor_mailbox_depth", "Messages accepted by an actor but not yet handled", "gauge")
+        actors.forEach { (actor, stat) ->
+            sb.appendLine("xhrec_actor_mailbox_depth{actor=\"$actor\"} ${stat.depth.get()}")
+        }
+
+        family(sb, "xhrec_actor_messages_total", "Messages handled by an actor", "counter")
+        actors.forEach { (actor, stat) ->
+            sb.appendLine("xhrec_actor_messages_total{actor=\"$actor\"} ${stat.messages.get()}")
+        }
+
+        family(sb, "xhrec_actor_in_flight", "An actor is inside a handler (1) or idle (0)", "gauge")
+        actors.forEach { (actor, stat) ->
+            sb.appendLine("xhrec_actor_in_flight{actor=\"$actor\"} ${if (stat.inFlight.get() > 0) 1 else 0}")
+        }
+
+        family(sb, "xhrec_actor_slow_handlers_total", "Handlers that exceeded the actor's slow threshold", "counter")
+        actors.forEach { (actor, stat) ->
+            sb.appendLine("xhrec_actor_slow_handlers_total{actor=\"$actor\"} ${stat.slow.get()}")
+        }
+
+        family(sb, "xhrec_actor_errors_total", "Handler exceptions, cancellations excluded", "counter")
+        actors.forEach { (actor, stat) ->
+            sb.appendLine("xhrec_actor_errors_total{actor=\"$actor\"} ${stat.errors.get()}")
+        }
+
+        family(sb, "xhrec_actor_handle_seconds_total", "Total time spent inside actor handlers", "counter")
+        actors.forEach { (actor, stat) ->
+            sb.appendLine("xhrec_actor_handle_seconds_total{actor=\"$actor\"} ${stat.handleNanos.get() / 1_000_000_000.0}")
+        }
+    }
+
+    /** One HELP/TYPE pair per family: repeating them inside the loop makes strict scrapers reject. */
+    private fun family(sb: StringBuilder, name: String, help: String, type: String) {
+        sb.appendLine("# HELP $name $help")
+        sb.appendLine("# TYPE $name $type")
+    }
+
+    private fun ConcurrentHashMap<String, AtomicLong>.bump(key: String) {
+        computeIfAbsent(key) { AtomicLong() }.incrementAndGet()
+    }
+}

--- a/src/main/kotlin/github/rikacelery/v3/core/PipelineMetrics.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/PipelineMetrics.kt
@@ -123,6 +123,26 @@ object PipelineMetrics {
         cdnServeFailures.bump(host)
     }
 
+    // ── Live event source ─────────────────────────────────────────────────────
+
+    /** 1 while at least one WebSocket pool is connected. */
+    @Volatile
+    var wsConnected: Boolean = false
+        private set
+
+    val wsConnects = AtomicLong(0)
+    val wsDisconnects = AtomicLong(0)
+
+    fun recordWsConnected() {
+        wsConnected = true
+        wsConnects.incrementAndGet()
+    }
+
+    fun recordWsDisconnected() {
+        wsConnected = false
+        wsDisconnects.incrementAndGet()
+    }
+
     // ── Prometheus rendering ──────────────────────────────────────────────────
 
     fun appendMetrics(sb: StringBuilder) {
@@ -194,6 +214,17 @@ object PipelineMetrics {
         cdnServeFailures.forEach { (host, count) ->
             sb.appendLine("xhrec_cdn_segment_failures_total{host=\"$host\"} ${count.get()}")
         }
+
+        // Losing the WebSocket is not fatal but it is silent: room status changes stop arriving, so
+        // rooms sit armed and unrecorded until the periodic refresh happens to notice.
+        family(sb, "xhrec_ws_connected", "The live event WebSocket is connected (1) or not (0)", "gauge")
+        sb.appendLine("xhrec_ws_connected ${if (wsConnected) 1 else 0}")
+
+        family(sb, "xhrec_ws_connects_total", "Successful WebSocket connects", "counter")
+        sb.appendLine("xhrec_ws_connects_total ${wsConnects.get()}")
+
+        family(sb, "xhrec_ws_disconnects_total", "WebSocket disconnects", "counter")
+        sb.appendLine("xhrec_ws_disconnects_total ${wsDisconnects.get()}")
     }
 
     /** One HELP/TYPE pair per family: repeating them inside the loop makes strict scrapers reject. */

--- a/src/main/kotlin/github/rikacelery/v3/core/PipelineMetrics.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/PipelineMetrics.kt
@@ -98,6 +98,31 @@ object PipelineMetrics {
         actors.remove(name)
     }
 
+    // ── CDN attribution for media traffic ─────────────────────────────────────
+
+    private val cdnServed = ConcurrentHashMap<String, AtomicLong>()
+    private val cdnServeFailures = ConcurrentHashMap<String, AtomicLong>()
+
+    /**
+     * One segment actually fetched from [host] — the host whose rewritten URL served the bytes,
+     * after any failover, not the host the selector first picked.
+     *
+     * Deliberately separate from `CdnSelector`'s `totalSuccesses`: that one also counts master
+     * playlist fetches and skips sub-millisecond downloads, so it cannot answer "which CDN carried
+     * the media traffic".
+     */
+    fun recordCdnServed(host: String) {
+        cdnServed.bump(host)
+    }
+
+    /**
+     * A segment this host failed to deliver (transport error, stall, 5xx). An expired assignment
+     * (404/403) is not attributed to the host, matching the selector's own penalty rule.
+     */
+    fun recordCdnServeFailure(host: String) {
+        cdnServeFailures.bump(host)
+    }
+
     // ── Prometheus rendering ──────────────────────────────────────────────────
 
     fun appendMetrics(sb: StringBuilder) {
@@ -158,6 +183,16 @@ object PipelineMetrics {
         family(sb, "xhrec_actor_handle_seconds_total", "Total time spent inside actor handlers", "counter")
         actors.forEach { (actor, stat) ->
             sb.appendLine("xhrec_actor_handle_seconds_total{actor=\"$actor\"} ${stat.handleNanos.get() / 1_000_000_000.0}")
+        }
+
+        family(sb, "xhrec_cdn_segments_served_total", "Segments actually served by this CDN host", "counter")
+        cdnServed.forEach { (host, count) ->
+            sb.appendLine("xhrec_cdn_segments_served_total{host=\"$host\"} ${count.get()}")
+        }
+
+        family(sb, "xhrec_cdn_segment_failures_total", "Segments this CDN host failed to deliver", "counter")
+        cdnServeFailures.forEach { (host, count) ->
+            sb.appendLine("xhrec_cdn_segment_failures_total{host=\"$host\"} ${count.get()}")
         }
     }
 

--- a/src/main/kotlin/github/rikacelery/v3/core/RoomStateRegistry.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/RoomStateRegistry.kt
@@ -1,0 +1,97 @@
+package github.rikacelery.v3.core
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * The per-room state the exporter renders, pushed by the components that own it.
+ *
+ * Pushed rather than pulled on purpose: `/metrics` must never block. Asking the scheduler and the
+ * sessions over the request bus at scrape time would make exactly the room panels an operator needs
+ * go blank when the process is saturated — the one moment they matter. Each component writes its
+ * own slice, so no component has to know about the others.
+ *
+ * Values are plain strings and numbers: the registry deliberately does not depend on the domain
+ * packages, so components translate their own state (an FSM state, a hint code) before pushing.
+ *
+ * Room **names** are deliberately absent. They are masked in the logs by default
+ * (`maskSensitiveLogs`), and metric labels do not go through that converter, so exporting them
+ * would hand model names to anyone who can read the scrape — and to whatever stores it.
+ */
+object RoomStateRegistry {
+
+    class RoomState {
+        @Volatile var status: String = ""
+        @Volatile var quality: String = ""
+        @Volatile var armed: Boolean = false
+        @Volatile var schedulerState: String = ""
+        @Volatile var hintCode: String? = null
+        @Volatile var sessionState: String = ""
+        @Volatile var lastProgressAtMs: Long = 0L
+    }
+
+    private val rooms = ConcurrentHashMap<Long, RoomState>()
+
+    fun update(roomId: Long, block: RoomState.() -> Unit) {
+        rooms.computeIfAbsent(roomId) { RoomState() }.block()
+    }
+
+    /** Drops every room the caller no longer knows about, so removed rooms stop being exported. */
+    fun retainRooms(roomIds: Collection<Long>) {
+        rooms.keys.retainAll(roomIds.toSet())
+    }
+
+    fun remove(roomId: Long) {
+        rooms.remove(roomId)
+    }
+
+    fun appendMetrics(sb: StringBuilder, nowMs: Long = System.currentTimeMillis()) {
+        if (rooms.isEmpty()) return
+
+        family(sb, "xhrec_room_info", "A tracked room, with its platform status and quality", "gauge")
+        rooms.forEach { (id, room) ->
+            sb.appendLine(
+                "xhrec_room_info{roomId=\"$id\",status=\"${escape(room.status)}\"," +
+                    "quality=\"${escape(room.quality)}\"} 1"
+            )
+        }
+
+        family(sb, "xhrec_room_armed", "The room is armed for recording (1) or not (0)", "gauge")
+        rooms.forEach { (id, room) -> sb.appendLine("xhrec_room_armed{roomId=\"$id\"} ${if (room.armed) 1 else 0}") }
+
+        family(sb, "xhrec_scheduler_state", "Scheduler state machine state, as an info label", "gauge")
+        rooms.forEach { (id, room) ->
+            if (room.schedulerState.isNotEmpty()) {
+                sb.appendLine("xhrec_scheduler_state{roomId=\"$id\",state=\"${escape(room.schedulerState)}\"} 1")
+            }
+        }
+
+        family(sb, "xhrec_session_state", "Recording session state machine state, as an info label", "gauge")
+        rooms.forEach { (id, room) ->
+            if (room.sessionState.isNotEmpty()) {
+                sb.appendLine("xhrec_session_state{roomId=\"$id\",state=\"${escape(room.sessionState)}\"} 1")
+            }
+        }
+
+        family(sb, "xhrec_room_hint", "Why an armed room is not recording, as an info label", "gauge")
+        rooms.forEach { (id, room) ->
+            room.hintCode?.let { sb.appendLine("xhrec_room_hint{roomId=\"$id\",code=\"${escape(it)}\"} 1") }
+        }
+
+        family(sb, "xhrec_room_last_progress_seconds", "Seconds since the session last queued or received data", "gauge")
+        rooms.forEach { (id, room) ->
+            if (room.lastProgressAtMs > 0) {
+                val ageSeconds = (nowMs - room.lastProgressAtMs).coerceAtLeast(0) / 1000.0
+                sb.appendLine("xhrec_room_last_progress_seconds{roomId=\"$id\"} $ageSeconds")
+            }
+        }
+    }
+
+    private fun family(sb: StringBuilder, name: String, help: String, type: String) {
+        sb.appendLine("# HELP $name $help")
+        sb.appendLine("# TYPE $name $type")
+    }
+
+    /** Label values reach Prometheus verbatim, so quotes and backslashes have to be escaped. */
+    private fun escape(value: String): String =
+        value.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", " ")
+}

--- a/src/main/kotlin/github/rikacelery/v3/core/RoomStateRegistry.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/RoomStateRegistry.kt
@@ -27,6 +27,7 @@ object RoomStateRegistry {
         @Volatile var hintCode: String? = null
         @Volatile var sessionState: String = ""
         @Volatile var lastProgressAtMs: Long = 0L
+        @Volatile var resumeMarkAhead: Long = 0L
     }
 
     private val rooms = ConcurrentHashMap<Long, RoomState>()
@@ -84,6 +85,9 @@ object RoomStateRegistry {
                 sb.appendLine("xhrec_room_last_progress_seconds{roomId=\"$id\"} $ageSeconds")
             }
         }
+
+        family(sb, "xhrec_room_resume_mark_ahead", "How far the resume mark leads the newest advertised segment id", "gauge")
+        rooms.forEach { (id, room) -> sb.appendLine("xhrec_room_resume_mark_ahead{roomId=\"$id\"} ${room.resumeMarkAhead}") }
     }
 
     private fun family(sb: StringBuilder, name: String, help: String, type: String) {

--- a/src/test/kotlin/github/rikacelery/v3/integration/PipelineMetricsIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/PipelineMetricsIntegrationTest.kt
@@ -3,6 +3,7 @@ package github.rikacelery.v3.integration
 import io.ktor.client.statement.bodyAsText
 import org.junit.jupiter.api.Test
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -41,7 +42,18 @@ class PipelineMetricsIntegrationTest {
             Regex("""xhrec_actor_mailbox_depth\{actor="SessionComponent"\} \d+""").containsMatchIn(after),
             "per-actor mailbox depth is what makes a lagging component visible"
         )
+
+        // CDN attribution is per actual serving host, so the label value is the mock's host:port
+        // and only the sum is stable enough to assert on.
+        assertTrue(
+            sumOf(after, "xhrec_cdn_segments_served_total") > sumOf(before, "xhrec_cdn_segments_served_total"),
+            "the CDN host that actually served each segment must be counted"
+        )
     }
+
+    private fun sumOf(payload: String, family: String): Long =
+        Regex("""$family\{host="[^"]*"\} (\d+)""").findAll(payload)
+            .sumOf { it.groupValues[1].toLong() }
 
     private fun assertGrew(before: String, after: String, family: String, labels: String) {
         val start = sample(before, family, labels)
@@ -50,6 +62,47 @@ class PipelineMetricsIntegrationTest {
             end > start,
             "$family{$labels} must grow while a room records, went $start -> $end"
         )
+    }
+
+    @Test
+    fun `room identity, arming and both state machines are exported`() = withFixture { fx ->
+        fx.ready()
+        fx.startRecording()
+
+        val metrics = fx.get("/metrics").bodyAsText()
+        for (expected in listOf(
+            """xhrec_room_info{roomId="1001",status="public",quality="720p"} 1""",
+            """xhrec_room_armed{roomId="1001"} 1""",
+            """xhrec_scheduler_state{roomId="1001",state="Recording"} 1""",
+            """xhrec_session_state{roomId="1001",state="Recording"} 1""",
+        )) {
+            assertTrue(expected in metrics, "missing $expected")
+        }
+        assertTrue(
+            Regex("""xhrec_room_last_progress_seconds\{roomId="1001"\} [\d.]+""").containsMatchIn(metrics),
+            "the progress clock is what makes a stalled room alertable without a window function"
+        )
+    }
+
+    @Test
+    fun `why an armed room is not recording is exported as a label`() = withFixture { fx ->
+        fx.ready()
+        fx.mock.addRoom(1001, "model", status = "off")
+        fx.get("/add?name=model&active=false")
+        fx.get("/filter?id=1001&kind=public&v=false")
+        fx.get("/activate?id=1001")
+        fx.mock.startSegments(1001, 30.milliseconds)
+        fx.awaitRoomSubscribed(1001)
+        fx.mock.setRoomStatus(1001, "public")
+
+        // The hint is computed on every scheduler transition, so it lands as soon as the room
+        // status change is driven through the FSM.
+        val hinted = fx.await(10.seconds, "the preconfig hint to be exported") {
+            Regex("""xhrec_room_hint\{roomId="1001",code="public_filter_off"\} 1""")
+                .takeIf { it.containsMatchIn(fx.get("/metrics").bodyAsText()) }
+                ?.let { true }
+        }
+        assertTrue(hinted, "the reason a room cannot record must be an alertable label")
     }
 
     /** Value of `family{labels}` in a Prometheus text payload, or 0 when the series is absent. */

--- a/src/test/kotlin/github/rikacelery/v3/integration/PipelineMetricsIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/PipelineMetricsIntegrationTest.kt
@@ -55,6 +55,29 @@ class PipelineMetricsIntegrationTest {
         Regex("""$family\{host="[^"]*"\} (\d+)""").findAll(payload)
             .sumOf { it.groupValues[1].toLong() }
 
+    @Test
+    fun `websocket health and why a file was cut are exported`() = withFixture { fx ->
+        fx.ready()
+        fx.startRecording()
+
+        val connected = fx.await(10.seconds, "the websocket gauge to report connected") {
+            Regex("""xhrec_ws_connected 1""")
+                .takeIf { it.containsMatchIn(fx.get("/metrics").bodyAsText()) }
+                ?.let { true }
+        }
+        assertTrue(connected, "a connected live event source must be visible: losing it is silent")
+
+        // `/break` cuts the file with a known reason, which must land as a label rather than only
+        // as a log line.
+        fx.get("/break?id=1001")
+        val cut = fx.await(10.seconds, "the cut reason to be counted") {
+            Regex("""xhrec_room_cut_total\{roomId="1001",reason="[A-Za-z]+"\} [1-9]""")
+                .takeIf { it.containsMatchIn(fx.get("/metrics").bodyAsText()) }
+                ?.let { true }
+        }
+        assertTrue(cut, "the reason a file was cut must be an alertable label")
+    }
+
     private fun assertGrew(before: String, after: String, family: String, labels: String) {
         val start = sample(before, family, labels)
         val end = sample(after, family, labels)

--- a/src/test/kotlin/github/rikacelery/v3/integration/PipelineMetricsIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/PipelineMetricsIntegrationTest.kt
@@ -1,0 +1,58 @@
+package github.rikacelery.v3.integration
+
+import io.ktor.client.statement.bodyAsText
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * The bus, the data channel and the actor mailboxes had no exported counters at all: the bus and
+ * the channel silently dropped messages with only a log line, and the mailbox depth existed but was
+ * reachable only through `/diagnose`.
+ *
+ * Every assertion is a **before/after delta**, because the counters are process-wide and a previous
+ * test in the same JVM can already have moved them — an absolute check would pass without this
+ * wiring doing anything.
+ */
+class PipelineMetricsIntegrationTest {
+
+    @Test
+    fun `the bus, the channel and the actors are exported while recording`() = withFixture { fx ->
+        fx.ready()
+        val before = fx.get("/metrics").bodyAsText()
+
+        fx.startRecording()
+
+        val after = fx.get("/metrics").bodyAsText()
+
+        assertGrew(before, after, "xhrec_eventbus_published_total", "event=\"SegmentDownloaded\"")
+        assertGrew(before, after, "xhrec_datachannel_sent_total", "msg=\"StreamData\"")
+        assertGrew(before, after, "xhrec_room_download_bytes_total", "roomId=\"1001\"")
+        // SessionComponent, not WriterComponent: the writer consumes the DataChannel directly from
+        // `onStart` and never goes through its own mailbox, so its actor counters stay at zero.
+        assertGrew(before, after, "xhrec_actor_messages_total", "actor=\"SessionComponent\"")
+
+        // Gauges, so they only have to be present and parse as a number.
+        assertTrue(
+            Regex("""xhrec_datachannel_pending \d+""").containsMatchIn(after),
+            "the data channel backlog must be exported"
+        )
+        assertTrue(
+            Regex("""xhrec_actor_mailbox_depth\{actor="SessionComponent"\} \d+""").containsMatchIn(after),
+            "per-actor mailbox depth is what makes a lagging component visible"
+        )
+    }
+
+    private fun assertGrew(before: String, after: String, family: String, labels: String) {
+        val start = sample(before, family, labels)
+        val end = sample(after, family, labels)
+        assertTrue(
+            end > start,
+            "$family{$labels} must grow while a room records, went $start -> $end"
+        )
+    }
+
+    /** Value of `family{labels}` in a Prometheus text payload, or 0 when the series is absent. */
+    private fun sample(payload: String, family: String, labels: String): Long =
+        Regex("""$family\{$labels\} (\d+)""").find(payload)?.groupValues?.get(1)?.toLong() ?: 0L
+}

--- a/src/test/kotlin/github/rikacelery/v3/integration/PipelineMetricsIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/PipelineMetricsIntegrationTest.kt
@@ -82,6 +82,10 @@ class PipelineMetricsIntegrationTest {
             Regex("""xhrec_room_last_progress_seconds\{roomId="1001"\} [\d.]+""").containsMatchIn(metrics),
             "the progress clock is what makes a stalled room alertable without a window function"
         )
+        assertTrue(
+            Regex("""xhrec_room_resume_mark_ahead\{roomId="1001"\} \d+""").containsMatchIn(metrics),
+            "a continuous gauge for the resume-mark backlog beats alerting on a sparse counter"
+        )
     }
 
     @Test


### PR DESCRIPTION
Implements the P0 and P1 tiers of the metric plan (JVM/memory/threads, tier P0-5, deliberately excluded at the author's request).

## P0 — silent data loss had no counter

`DataChannel` drops a message when the writer falls behind, and `EventBus` drops events when a subscriber stalls. Both only wrote a log line:

- `xhrec_datachannel_dropped_total{msg}`, `xhrec_datachannel_pending`, `xhrec_datachannel_sent_total`, `xhrec_datachannel_bytes_total`
- `xhrec_eventbus_dropped_total{event}`, `xhrec_eventbus_published_total{event}`, `xhrec_eventbus_backlogged`
- `xhrec_actor_mailbox_depth{actor}`, `_messages_total`, `_in_flight`, `_slow_handlers_total`, `_errors_total`, `_handle_seconds_total` — the actor loop already measured handler duration to log a slow-handler warning; it just never reached the exporter.

These live in a new `PipelineMetrics` and are **pulled** at scrape time. The bus cannot report its own drops through itself — each report would be another event that can be dropped, and counting published events by publishing an event recurses — and an `AtomicLong` bump is cheaper than a bus round trip on the hottest paths in the recorder.

Also exports two series whose data already existed: `xhrec_room_download_bytes_total` (the in-memory `lifetimeBytes`, the honest cumulative counterpart to the per-file `xhrec_bytes_write_total`) and `xhrec_cdn_cooldown` (segment-download cooldown; only the playlist one was visible).

## CDN attribution, by the host that actually served the bytes

`xhrec_cdn_total_successes/errors` cannot answer "which CDN carried the media traffic", for two reasons I only found while wiring this:

- `CdnSelector.record` / `recordFailure` are called from the **master playlist fetch** as well as from segment downloads, so those counts mix master traffic in;
- `record` returns early when `durationMs <= 0`, so the fastest segment fetches are dropped from the success count entirely.

`xhrec_cdn_segments_served_total{host}` and `xhrec_cdn_segment_failures_total{host}` are counted at the downloader instead, keyed by the host whose rewritten URL served the bytes — **after any failover, not the selector's first pick**. Expired assignments (404/403) are not attributed to the host, matching the selector's own penalty rule.

Load share, which sums to 100%:

```promql
sum by (host) (rate(xhrec_cdn_segments_served_total{job="xhrec_native"}[5m]))
  / scalar(sum(rate(xhrec_cdn_segments_served_total{job="xhrec_native"}[5m])))
```

## P1 — room state

`xhrec_room_info`, `xhrec_room_armed`, `xhrec_scheduler_state`, `xhrec_session_state`, `xhrec_room_hint`, `xhrec_room_last_progress_seconds` and `xhrec_room_resume_mark_ahead` are pushed into `RoomStateRegistry` and rendered at scrape time. Pushed and not pulled: asking the scheduler and the sessions over the request bus at scrape time would blank exactly the room panels an operator needs whenever the process is saturated.

`xhrec_room_hint` is the one that turns "this room is listening and doing nothing" into an alertable label (`no_free_spy`, `preconfig_failed`, …).

Plus `xhrec_ws_connected` / `_connects_total` / `_disconnects_total` (losing the live event socket is silent — status changes stop arriving and rooms sit armed) and `xhrec_room_cut_total{roomId,reason}` / `xhrec_room_recordings_stopped_total{roomId,reason}`.

## Things this turned up

- The scheduler has **two independent `driveFsm` overloads** and the self-scheduled signals (`PreconfigDone`, `BackToArmed`, …) only go through the `SchedulerSignal` one. Instrumenting a single overload left the exported state stuck wherever an externally-driven transition had put it — the first version reported `Preconfiguring` for a room that was recording.
- **`WriterComponent` bypasses its own mailbox**: it consumes the `DataChannel` directly from `onStart`, so its actor counters stay at zero by construction. The test asserts on `SessionComponent` for that reason.
- A `saveListConf()` hook is *not* a reliable "room state changed" funnel (it is debounced and never fires when a room is armed, because arming is scheduler state), which is why room identity and arming are exported from the scheduler instead.
- Room **names** are deliberately not exported: they are masked in the logs by default and metric labels do not pass through that converter.

## Testing

333 pass, `0` failures; the compile-warnings gate is clean.

Every export assertion is a **before/after delta** — the counters are process-wide, so an absolute check could pass without the wiring doing anything:
bus published, channel sent, room bytes, actor messages, CDN served; WS connected; the `public_filter_off` hint; room/scheduler/session state.
