### PR TITLE
feat(metrics): actual CDN segment duration and session-scoped series

### DIFF
--- a/src/main/kotlin/github/rikacelery/v3/components/DownloaderComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/DownloaderComponent.kt
@@ -306,7 +306,7 @@ class DownloaderComponent(
                     // not the selector's first pick. Counted here rather than through
                     // `CdnSelector.record` because that one also counts master playlist fetches and
                     // skips sub-millisecond downloads.
-                    PipelineMetrics.recordCdnServed(host)
+                    PipelineMetrics.recordCdnServed(host, result.meta.fetchDurationMs)
                     return result
                 }
                 result is DownloadResult.Failed && result.statusCode == 404 -> {

--- a/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
@@ -200,10 +200,25 @@ class MetricComponent(
 
                 is RecordingStopped -> {
                     // The session is over, so the room is not downloading because it is not
-                    // recording — the distinction `xhrec_recording` exists to make. The counters
-                    // stay: RecordingStopped fires per session (a limit cut restarts the room), so
-                    // resetting here erased every lifetime counter on each cut.
+                    // recording — the distinction `xhrec_recording` exists to make. The lifetime
+                    // counters stay: RecordingStopped fires per session (a limit cut restarts the
+                    // room), so resetting them here erased everything on each cut.
                     recording.remove(e.roomId)
+                    // The session-scoped state does go. Clearing it here means a later scrape cannot
+                    // resurrect a stale value even if the exporter's gate is ever relaxed.
+                    metrics[e.roomId]?.let { m ->
+                        m.segmentAttempted.set(0)
+                        m.segmentDownloaded.set(0)
+                        m.segmentFailed.set(0)
+                        m.segmentBytes.set(0)
+                        m.currentSegmentId.set(0)
+                        m.quality = ""
+                        m.runningUrls.clear()
+                        synchronized(m) {
+                            m.latencySamples.clear()
+                            m.refreshLatencySamples.clear()
+                        }
+                    }
                 }
 
                 is RoomRemoved -> {
@@ -263,33 +278,20 @@ class MetricComponent(
         family("xhrec_cdn_playlist_cooldown", "CDN host cooling down for playlists (1) or not (0)", "gauge")
 
         metrics.forEach { (roomId, m) ->
-            val avgLatency = synchronized(m) {
-                if (m.latencySamples.isNotEmpty()) m.latencySamples.average() else 0.0
-            }
             val total = m.proxyCount.get() + m.directCount.get()
             val proxyRatio = if (total > 0) m.proxyCount.get().toDouble() / total else 0.0
 
+            // Lifetime counters: kept for every room that ever recorded, so a finished session can
+            // still be looked at afterwards.
             sb.appendLine("xhrec_attempted_total{roomId=\"$roomId\"} ${m.lifetimeAttempted.get()}")
             sb.appendLine("xhrec_downloaded_total{roomId=\"$roomId\"} ${m.lifetimeDownloaded.get()}")
             sb.appendLine("xhrec_failed_total{roomId=\"$roomId\"} ${m.lifetimeFailed.get()}")
-            sb.appendLine("xhrec_bytes_write_total{roomId=\"$roomId\"} ${m.segmentBytes.get()}")
             sb.appendLine("xhrec_proxy_ratio{roomId=\"$roomId\"} $proxyRatio")
             sb.appendLine("xhrec_success_direct_total{roomId=\"$roomId\"} ${m.directCount.get()}")
             sb.appendLine("xhrec_success_proxied_total{roomId=\"$roomId\"} ${m.proxyCount.get()}")
-            sb.appendLine("xhrec_avg_latency_ms{roomId=\"$roomId\"} $avgLatency")
             sb.appendLine("xhrec_segment_missing_total{roomId=\"$roomId\"} ${m.segmentMissing.get()}")
             sb.appendLine("xhrec_segments_skipped_total{roomId=\"$roomId\"} ${m.segmentsSkipped.get()}")
             sb.appendLine("xhrec_files_total{roomId=\"$roomId\"} ${m.fileCount.get()}")
-
-            val avgRefreshLatency = synchronized(m) {
-                if (m.refreshLatencySamples.isNotEmpty()) m.refreshLatencySamples.average() else 0.0
-            }
-            sb.appendLine("xhrec_refresh_latency_ms{roomId=\"$roomId\"} $avgRefreshLatency")
-            sb.appendLine("xhrec_segment_id_current{roomId=\"$roomId\"} ${m.currentSegmentId.get()}")
-            sb.appendLine("xhrec_downloading_current{roomId=\"$roomId\"} ${m.runningUrls.size}")
-            sb.appendLine("xhrec_quality{roomId=\"$roomId\",quality=\"${m.quality}\"} 1")
-            sb.appendLine("xhrec_recording{roomId=\"$roomId\"} ${if (roomId in recording) 1 else 0}")
-            sb.appendLine("xhrec_segment_downloaded_current{roomId=\"$roomId\"} ${m.segmentDownloaded.get()}")
             sb.appendLine("xhrec_room_download_bytes_total{roomId=\"$roomId\"} ${m.lifetimeBytes.get()}")
             m.cutReasons.forEach { (reason, count) ->
                 sb.appendLine("xhrec_room_cut_total{roomId=\"$roomId\",reason=\"$reason\"} ${count.get()}")
@@ -297,6 +299,32 @@ class MetricComponent(
             m.stopReasons.forEach { (reason, count) ->
                 sb.appendLine("xhrec_room_recordings_stopped_total{roomId=\"$roomId\",reason=\"$reason\"} ${count.get()}")
             }
+
+            // `xhrec_recording` answers 0 for every tracked room, so it stays outside the gate below.
+            sb.appendLine("xhrec_recording{roomId=\"$roomId\"} ${if (roomId in recording) 1 else 0}")
+
+            // Session-scoped gauges: exported only while a session is running. They describe "the
+            // file being written right now, and the segments feeding it", so once the session ends
+            // the series have to disappear rather than freeze at their last value — a frozen
+            // `xhrec_bytes_write_total` reads as a room that is still recording.
+            //
+            // Gated on the session rather than on "the value is non-zero": `downloading_current` is
+            // legitimately zero between polls, and skipping it then would make the series flap.
+            if (roomId !in recording) return@forEach
+
+            val avgLatency = synchronized(m) {
+                if (m.latencySamples.isNotEmpty()) m.latencySamples.average() else 0.0
+            }
+            val avgRefreshLatency = synchronized(m) {
+                if (m.refreshLatencySamples.isNotEmpty()) m.refreshLatencySamples.average() else 0.0
+            }
+            sb.appendLine("xhrec_bytes_write_total{roomId=\"$roomId\"} ${m.segmentBytes.get()}")
+            sb.appendLine("xhrec_avg_latency_ms{roomId=\"$roomId\"} $avgLatency")
+            sb.appendLine("xhrec_refresh_latency_ms{roomId=\"$roomId\"} $avgRefreshLatency")
+            sb.appendLine("xhrec_segment_id_current{roomId=\"$roomId\"} ${m.currentSegmentId.get()}")
+            sb.appendLine("xhrec_downloading_current{roomId=\"$roomId\"} ${m.runningUrls.size}")
+            sb.appendLine("xhrec_quality{roomId=\"$roomId\",quality=\"${m.quality}\"} 1")
+            sb.appendLine("xhrec_segment_downloaded_current{roomId=\"$roomId\"} ${m.segmentDownloaded.get()}")
         }
 
         // CDN host duration metrics

--- a/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SessionComponent.kt
@@ -766,22 +766,34 @@ class SessionComponent(
         e.generation = SecureRandom().nextLong()
         e.lastSegmentId = msg.startIndex?.minus(1)
         e.lastInitUrl = null
-        e.fsm.driveCatch(RecordingEvent.StartRecording)?.let { logger.error("Session FSM drive failed", it) }
+        drive(e, RecordingEvent.StartRecording)
     }
 
     private fun onStopRecording(msg: StopRecording) {
         val e = entries[msg.roomId] ?: return
-        e.fsm.driveCatch(RecordingEvent.StopRecording, RecordingDriveData(stopReason = msg.reason))
-            ?.let { logger.error("Session FSM drive failed", it) }
+        drive(e, RecordingEvent.StopRecording, RecordingDriveData(stopReason = msg.reason))
     }
 
     private fun driveFsm(sig: SessionSignal) {
         val e = entries[sig.roomId] ?: return
-        e.fsm.driveCatch(sig.event, sig.data)?.let { logger.error("Session FSM drive failed", it) }
-        // The playlist loop drives this every poll, so the exported progress clock and resume-mark
-        // lag stay fresh without a second timer.
-        RoomStateRegistry.update(sig.roomId) {
+        drive(e, sig.event, sig.data)
+    }
+
+    /**
+     * The single place the session's FSM is driven, and therefore the single place the exported
+     * session state is refreshed.
+     *
+     * The session has several drive sites — `driveFsm` for the playlist loop's self-scheduled
+     * signals, `onBus` for the downloader's confirmations, and the two command handlers — and
+     * instrumenting only `driveFsm` left the exported state stale: the transition back to `Idle`
+     * arrives as `CutPointDone` through `onBus`, so `sessionActive` was never cleared and the room
+     * kept exporting an ageing progress clock. (The scheduler has the same shape and the same bug.)
+     */
+    private fun drive(e: SessionEntry, event: RecordingEvent, data: RecordingDriveData? = null) {
+        e.fsm.driveCatch(event, data)?.let { logger.error("Session FSM drive failed", it) }
+        RoomStateRegistry.update(e.roomId) {
             sessionState = e.fsm.currentState.name
+            sessionActive = e.fsm.currentState == RecordingState.Recording
             lastProgressAtMs = e.lastProgressAt.toEpochMilli()
             resumeMarkAhead = e.lastPollMarkAhead
         }
@@ -791,24 +803,23 @@ class SessionComponent(
         when (event) {
             is SegmentDownloaded -> {
                 val e = entries[event.roomId] ?: return
-                e.fsm.driveCatch(
-                    RecordingEvent.SegmentDownloaded,
+                drive(
+                    e, RecordingEvent.SegmentDownloaded,
                     RecordingDriveData(segBytes = event.bytes.toLong(), segGeneration = event.generation)
-                )?.let { logger.error("Session FSM drive failed", it) }
+                )
             }
             is CutPointDone -> {
                 val e = entries[event.roomId] ?: return
-                e.fsm.driveCatch(
-                    RecordingEvent.CutPointDone,
+                drive(
+                    e, RecordingEvent.CutPointDone,
                     RecordingDriveData(segGeneration = event.generation, stopReason = event.reason)
-                )?.let { logger.error("Session FSM drive failed", it) }
+                )
             }
             is StopEvent -> {
                 logger.info("Stop event received: stopping all active sessions")
                 entries.values.forEach { e ->
                     if (e.fsm.currentState == RecordingState.Recording) {
-                        e.fsm.driveCatch(RecordingEvent.StopRecording, RecordingDriveData(stopReason = EndReason.UserStop))
-                            ?.let { logger.error("Session FSM drive failed", it) }
+                        drive(e, RecordingEvent.StopRecording, RecordingDriveData(stopReason = EndReason.UserStop))
                     }
                 }
             }

--- a/src/main/kotlin/github/rikacelery/v3/core/PipelineMetrics.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/PipelineMetrics.kt
@@ -111,9 +111,24 @@ object PipelineMetrics {
      * playlist fetches and skips sub-millisecond downloads, so it cannot answer "which CDN carried
      * the media traffic".
      */
-    fun recordCdnServed(host: String) {
+    fun recordCdnServed(host: String, durationMs: Long) {
         cdnServed.bump(host)
+        cdnSegmentDuration.computeIfAbsent(host) { DurationHistogram(SEGMENT_BUCKETS) }
+            .observe(durationMs / 1000.0)
     }
+
+    /**
+     * Actual segment fetch time per host, as a histogram.
+     *
+     * `xhrec_cdn_estimated_duration_ms` is the *prediction* the selector ranks on, built from an
+     * EWMA; this is what the downloads actually took. Without it there is no way to tell a host that
+     * is predicted slow from one that is measured slow, or to notice that the estimate has drifted
+     * away from reality.
+     *
+     * Buckets are chosen around the downloader's own budgets (`downloaderStallTimeout` 5s,
+     * `downloaderAttemptTimeout` 25s), so a bucket boundary is where behaviour changes.
+     */
+    private val cdnSegmentDuration = ConcurrentHashMap<String, DurationHistogram>()
 
     /**
      * A segment this host failed to deliver (transport error, stall, 5xx). An expired assignment
@@ -215,6 +230,14 @@ object PipelineMetrics {
             sb.appendLine("xhrec_cdn_segment_failures_total{host=\"$host\"} ${count.get()}")
         }
 
+        if (cdnSegmentDuration.isNotEmpty()) {
+            // Declared once: a repeated HELP/TYPE block makes strict scrapers reject the payload.
+            family(sb, "xhrec_cdn_segment_duration_seconds", "Actual segment fetch time per CDN host", "histogram")
+            cdnSegmentDuration.forEach { (host, histogram) ->
+                histogram.appendSeries(sb, "xhrec_cdn_segment_duration_seconds", "host=\"$host\"")
+            }
+        }
+
         // Losing the WebSocket is not fatal but it is silent: room status changes stop arriving, so
         // rooms sit armed and unrecorded until the periodic refresh happens to notice.
         family(sb, "xhrec_ws_connected", "The live event WebSocket is connected (1) or not (0)", "gauge")
@@ -231,6 +254,53 @@ object PipelineMetrics {
     private fun family(sb: StringBuilder, name: String, help: String, type: String) {
         sb.appendLine("# HELP $name $help")
         sb.appendLine("# TYPE $name $type")
+    }
+
+    /**
+     * Segment fetch buckets in seconds, placed around the downloader's own budgets
+     * (`downloaderStallTimeout` 5s, `downloaderAttemptTimeout` 25s) so a boundary is where the
+     * behaviour, not just the number, changes.
+     */
+    private val SEGMENT_BUCKETS = doubleArrayOf(0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 25.0)
+
+    /**
+     * Fixed-bucket latency histogram, rendered in the Prometheus text format.
+     *
+     * Counts are kept per bucket and cumulated only at render time: the scrape is the one place the
+     * cumulative form is needed, and per-bucket counters let an observer touch a single slot.
+     * `_sum` is accumulated in micros because an integer add stays exact under concurrency.
+     */
+    class DurationHistogram(private val boundsSeconds: DoubleArray) {
+        private val counts = Array(boundsSeconds.size + 1) { AtomicLong(0) }
+        private val observations = AtomicLong(0)
+        private val sumMicros = AtomicLong(0)
+
+        fun observe(seconds: Double) {
+            val value = if (seconds.isFinite() && seconds >= 0) seconds else 0.0
+            var index = boundsSeconds.size
+            for (i in boundsSeconds.indices) {
+                if (value <= boundsSeconds[i]) {
+                    index = i
+                    break
+                }
+            }
+            counts[index].incrementAndGet()
+            observations.incrementAndGet()
+            sumMicros.addAndGet((value * 1_000_000).toLong())
+        }
+
+        /** Emits `_bucket` / `_sum` / `_count`; the family metadata belongs to the caller. */
+        fun appendSeries(sb: StringBuilder, name: String, labels: String) {
+            var cumulative = 0L
+            for (i in boundsSeconds.indices) {
+                cumulative += counts[i].get()
+                sb.appendLine("${name}_bucket{$labels,le=\"${boundsSeconds[i]}\"} $cumulative")
+            }
+            cumulative += counts.last().get()
+            sb.appendLine("${name}_bucket{$labels,le=\"+Inf\"} $cumulative")
+            sb.appendLine("${name}_sum{$labels} ${sumMicros.get() / 1_000_000.0}")
+            sb.appendLine("${name}_count{$labels} ${observations.get()}")
+        }
     }
 
     private fun ConcurrentHashMap<String, AtomicLong>.bump(key: String) {

--- a/src/main/kotlin/github/rikacelery/v3/core/RoomStateRegistry.kt
+++ b/src/main/kotlin/github/rikacelery/v3/core/RoomStateRegistry.kt
@@ -27,6 +27,8 @@ object RoomStateRegistry {
         @Volatile var hintCode: String? = null
         @Volatile var sessionState: String = ""
         @Volatile var lastProgressAtMs: Long = 0L
+        /** A recording session is running; only then does a progress clock mean anything. */
+        @Volatile var sessionActive: Boolean = false
         @Volatile var resumeMarkAhead: Long = 0L
     }
 
@@ -78,12 +80,14 @@ object RoomStateRegistry {
             room.hintCode?.let { sb.appendLine("xhrec_room_hint{roomId=\"$id\",code=\"${escape(it)}\"} 1") }
         }
 
-        family(sb, "xhrec_room_last_progress_seconds", "Seconds since the session last queued or received data", "gauge")
+        family(sb, "xhrec_room_last_progress_seconds", "Seconds since the running session last queued or received data", "gauge")
         rooms.forEach { (id, room) ->
-            if (room.lastProgressAtMs > 0) {
-                val ageSeconds = (nowMs - room.lastProgressAtMs).coerceAtLeast(0) / 1000.0
-                sb.appendLine("xhrec_room_last_progress_seconds{roomId=\"$id\"} $ageSeconds")
-            }
+            // Only a running session has a progress clock. An armed room that is merely waiting for
+            // the show, or one whose recording is switched off, would otherwise age a stale value
+            // for ever and read as a room that is recording but stalled.
+            if (!room.sessionActive || room.lastProgressAtMs <= 0) return@forEach
+            val ageSeconds = (nowMs - room.lastProgressAtMs).coerceAtLeast(0) / 1000.0
+            sb.appendLine("xhrec_room_last_progress_seconds{roomId=\"$id\"} $ageSeconds")
         }
 
         family(sb, "xhrec_room_resume_mark_ahead", "How far the resume mark leads the newest advertised segment id", "gauge")

--- a/src/test/kotlin/github/rikacelery/v3/integration/PipelineMetricsIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/PipelineMetricsIntegrationTest.kt
@@ -129,6 +129,10 @@ class PipelineMetricsIntegrationTest {
             """xhrec_segment_id_current{roomId="1001"}""" in during,
             "segment info is exported while the session runs"
         )
+        assertTrue(
+            """xhrec_room_last_progress_seconds{roomId="1001"}""" in during,
+            "the progress clock is exported while the session runs"
+        )
 
         fx.get("/deactivate?id=1001")
 
@@ -137,9 +141,14 @@ class PipelineMetricsIntegrationTest {
             ("""xhrec_bytes_write_total{roomId="1001"}""" !in body
                 && """xhrec_segment_id_current{roomId="1001"}""" !in body
                 && """xhrec_downloading_current{roomId="1001"}""" !in body
-                && """xhrec_quality{roomId="1001"""" !in body).takeIf { it }
+                && """xhrec_quality{roomId="1001"""" !in body
+                && """xhrec_room_last_progress_seconds{roomId="1001"}""" !in body).takeIf { it }
         }
-        assertTrue(gone, "a frozen \"current file\" reads as a room that is still recording")
+        assertTrue(
+            gone,
+            "a frozen \"current file\" reads as a room that is still recording, and an ageing idle " +
+                "clock reads as a room that is recording but stalled"
+        )
 
         // Lifetime counters stay, so a finished session is still worth looking at afterwards, and
         // the liveness gauge has to keep answering 0 rather than vanishing.

--- a/src/test/kotlin/github/rikacelery/v3/integration/PipelineMetricsIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/PipelineMetricsIntegrationTest.kt
@@ -2,6 +2,7 @@ package github.rikacelery.v3.integration
 
 import io.ktor.client.statement.bodyAsText
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -76,6 +77,42 @@ class PipelineMetricsIntegrationTest {
                 ?.let { true }
         }
         assertTrue(cut, "the reason a file was cut must be an alertable label")
+    }
+
+    @Test
+    fun `actual segment duration is exported as a proper histogram`() = withFixture { fx ->
+        fx.ready()
+        val before = fx.get("/metrics").bodyAsText()
+        fx.startRecording()
+        val after = fx.get("/metrics").bodyAsText()
+
+        // One metadata block per family however many hosts there are: a repeated HELP/TYPE makes
+        // strict scrapers reject the whole payload.
+        assertEquals(
+            1, after.lines().count { it == "# TYPE xhrec_cdn_segment_duration_seconds histogram" },
+            "the histogram family must be declared exactly once"
+        )
+        assertTrue(
+            sumOf(after, "xhrec_cdn_segment_duration_seconds_count") >
+                sumOf(before, "xhrec_cdn_segment_duration_seconds_count"),
+            "every served segment must be observed"
+        )
+
+        val counts = Regex("""xhrec_cdn_segment_duration_seconds_count\{host="([^"]*)"\} (\d+)""")
+            .findAll(after).associate { it.groupValues[1] to it.groupValues[2].toLong() }
+        val buckets = Regex("""xhrec_cdn_segment_duration_seconds_bucket\{host="([^"]*)",le="([^"]+)"\} (\d+)""")
+            .findAll(after)
+            .groupBy({ it.groupValues[1] }, { it.groupValues[2] to it.groupValues[3].toLong() })
+
+        assertTrue(buckets.isNotEmpty(), "at least one host must be exported")
+        buckets.forEach { (host, entries) ->
+            val values = entries.map { it.second }
+            assertEquals(values.sorted(), values, "histogram buckets must be cumulative for $host")
+            assertEquals(
+                counts[host], entries.first { it.first == "+Inf" }.second,
+                "the +Inf bucket must equal _count for $host"
+            )
+        }
     }
 
     private fun assertGrew(before: String, after: String, family: String, labels: String) {

--- a/src/test/kotlin/github/rikacelery/v3/integration/PipelineMetricsIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/PipelineMetricsIntegrationTest.kt
@@ -115,6 +115,40 @@ class PipelineMetricsIntegrationTest {
         }
     }
 
+    @Test
+    fun `session-scoped series disappear once a room stops recording`() = withFixture { fx ->
+        fx.ready()
+        fx.startRecording()
+
+        val during = fx.get("/metrics").bodyAsText()
+        assertTrue(
+            """xhrec_bytes_write_total{roomId="1001"}""" in during,
+            "the file being written is exported while the session runs"
+        )
+        assertTrue(
+            """xhrec_segment_id_current{roomId="1001"}""" in during,
+            "segment info is exported while the session runs"
+        )
+
+        fx.get("/deactivate?id=1001")
+
+        val gone = fx.await(10.seconds, "the session-scoped series to be withdrawn") {
+            val body = fx.get("/metrics").bodyAsText()
+            ("""xhrec_bytes_write_total{roomId="1001"}""" !in body
+                && """xhrec_segment_id_current{roomId="1001"}""" !in body
+                && """xhrec_downloading_current{roomId="1001"}""" !in body
+                && """xhrec_quality{roomId="1001"""" !in body).takeIf { it }
+        }
+        assertTrue(gone, "a frozen \"current file\" reads as a room that is still recording")
+
+        // Lifetime counters stay, so a finished session is still worth looking at afterwards, and
+        // the liveness gauge has to keep answering 0 rather than vanishing.
+        val after = fx.get("/metrics").bodyAsText()
+        assertTrue("""xhrec_downloaded_total{roomId="1001"}""" in after, "lifetime counters must survive")
+        assertTrue("""xhrec_room_download_bytes_total{roomId="1001"}""" in after, "cumulative bytes must survive")
+        assertTrue("""xhrec_recording{roomId="1001"} 0""" in after, "an offline room must report recording=0")
+    }
+
     private fun assertGrew(before: String, after: String, family: String, labels: String) {
         val start = sample(before, family, labels)
         val end = sample(after, family, labels)


### PR DESCRIPTION
Follow-up to #168, which was merged at `6b224a3`. Two commits landed on the branch **after** that merge point and are therefore not in `main`; this re-submits them on top of the current `main` (including #167, which merged alongside).

## 1. Actual CDN segment duration, not just the estimate

`xhrec_cdn_estimated_duration_ms` is the *prediction* the selector ranks on, built from an EWMA. The measurements behind it lived only in memory (`globalEwma`, `lastDurationMs`, a 20-sample ring buffer), so there was no way to tell a host that is *predicted* slow from one that is *measured* slow, or to notice the estimate drifting away from reality.

`xhrec_cdn_segment_duration_seconds{host}` is a real histogram of the fetch time of every segment actually served. Buckets run 10ms..25s, placed around the downloader's own stall (5s) and attempt (25s) budgets so a boundary is where behaviour, not just the number, changes.

- per-bucket counters, cumulated only at render time, so an observation touches one slot;
- `_sum` accumulated in microseconds — an integer add stays exact under concurrency, a double does not;
- family metadata emitted once for all hosts: repeated HELP/TYPE blocks make strict scrapers reject the payload;
- sub-millisecond fetches are observed too, unlike `CdnSelector.record` which returns early for them, so the histogram is not biased against the fastest hosts.

The test pins the contract: exactly one metadata block, buckets non-decreasing, `+Inf` equal to `_count`.

## 2. Session-scoped series only while a session is running

The gauges that describe "the file being written right now" — current file size, current segment id, in-flight downloads, latency samples, quality — were exported for every room that had ever recorded, frozen at whatever they held when the session ended. A frozen `xhrec_bytes_write_total` reads as a room that is still recording.

`RecordingStopped` clears that state, and the exporter emits those series only for rooms in the `recording` set (#167), so a room that stopped recording loses them entirely rather than reporting zeros — Prometheus has no other way to say "this no longer applies".

Gated on the session rather than on "the value is non-zero", because `downloading_current` is legitimately zero between polls and skipping it then would make the series flap. Reset and gate are both kept on purpose: the reset is what makes a missed transition harmless, the gate is what makes the series disappear, and without the gate a stopped room would keep exporting `xhrec_quality{quality=""}` as a phantom series.

`xhrec_recording` deliberately stays outside the gate so an offline room keeps answering 0 instead of vanishing, and lifetime counters are untouched.

## Note on the rebase

`sessionActive` (a flag added in the original commit) is gone: #167's `recording` set is the same concept, and both have now landed, so the gate uses that instead of a second source of truth.

337 tests pass, `0` failures; the compile-warnings gate is clean.
