### PR TITLE
Change privateRate to spyRate

### DIFF
--- a/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/SchedulerComponent.kt
@@ -390,7 +390,7 @@ class SchedulerEntry(
             return null
         }
         val paidCam = component.apiClient.roomFetchCamInfo(roomId, paidUser.cookie)
-        val price = paidCam.PathSingleOrNull("user.user.privateRate")?.asInt()
+        val price = paidCam.PathSingleOrNull("user.user.spyRate")?.asInt()
         if (price == null) {
             lastFailReason = "price unavailable"
             tokenFailure = TokenFailure.PriceUnavailable

--- a/src/test/kotlin/github/rikacelery/v3/integration/MockPlatformServer.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/MockPlatformServer.kt
@@ -86,7 +86,7 @@ class MockRoom(
     /** Platform-side deletion: broadcasts answers 404 "model already deleted". */
     @Volatile var deleted: Boolean = false
     @Volatile var ticketRate: Int = 100
-    @Volatile var privateRate: Int = 50
+    @Volatile var spyRate: Int = 50
     val presets: MutableList<String> = CopyOnWriteArrayList(listOf("360p", "720p"))
     @Volatile var fps: Int = 30
     @Volatile var height: Int = 720
@@ -476,7 +476,7 @@ class MockPlatformServer(
                                 // the slug doubles as the room name on the platform
                                 put("username", room.name)
                                 put("ticketRate", room.ticketRate)
-                                put("privateRate", room.privateRate)
+                                put("spyRate", room.spyRate)
                             })
                         })
                     }


### PR DESCRIPTION
As I pointed out here: https://github.com/RikaCelery/XhRec/issues/154#issuecomment-5646651574
This data lives in user.user.spyRate, right next to user.user.privateRate, which is what is currently being used.
Not a huge difference, but it could affect the math for the spy gate. I have not and probably won't test because I don't intend to enable this feature unless I have free spy.