### PR TITLE
Add CLI opt to enable/disable TLS, default is still true

### DIFF
--- a/src/main/kotlin/github/rikacelery/v3/Main.kt
+++ b/src/main/kotlin/github/rikacelery/v3/Main.kt
@@ -71,6 +71,7 @@ fun main(vararg args: String) {
         .addOption("o", "output", true, "output directory")
         .addOption("t", "tmp", true, "temp directory")
         .addOption("p", "port", true, "HTTP port")
+        .addOption("s", "tls", true, "Enable TLS/SSL (Default: true)")
         .addOption("u", "users", true, "users.txt path")
         .addOption("post", true, "postprocessor.json path")
     val cli = try {
@@ -95,6 +96,7 @@ fun main(vararg args: String) {
             outputDir = File(cli.getOptionValue("output", "out")),
             tmpDir = File(cli.getOptionValue("tmp", "tmp")),
             port = cli.getOptionValue("port", "8090").toInt(),
+            tls = cli.getOptionValue("tls", "true").toBoolean(),
             proxy = System.getenv("http_proxy"),
             decryptKeys = persisted.decryptKeys,
             streamAuthKey = persisted.pkey,
@@ -189,6 +191,7 @@ fun main(vararg args: String) {
 
         val httpServer = HttpServerComponent(
             config.port,
+            config.tls,
             eventBus,
             requestBus,
             metricComponent,

--- a/src/main/kotlin/github/rikacelery/v3/bootstrap/Bootstrap.kt
+++ b/src/main/kotlin/github/rikacelery/v3/bootstrap/Bootstrap.kt
@@ -48,6 +48,7 @@ class Bootstrap(
         val outputDir: String = "out",
         val tmpDir: String = "tmp",
         val port: Int = 8090,
+        val tls: Boolean = true,
         val usersPath: String = "users.txt",
         val postProcessorPath: String = "postprocessor.json"
     )
@@ -58,6 +59,7 @@ class Bootstrap(
             .addOption("o", "output", true, "output directory")
             .addOption("t", "tmp", true, "temp directory")
             .addOption("p", "port", true, "HTTP port")
+            .addOption("s", "tls", true, "Enable TLS/SSL (Default: true)")
             .addOption("u", "users", true, "users.txt path")
             .addOption("post", true, "postprocessor.json path")
         val cmd = try {
@@ -72,6 +74,7 @@ class Bootstrap(
             outputDir = cmd.getOptionValue("output", "out"),
             tmpDir = cmd.getOptionValue("tmp", "tmp"),
             port = cmd.getOptionValue("port", "8090").toInt(),
+            tls = cmd.getOptionValue("tls", "true").toBoolean(),
             usersPath = cmd.getOptionValue("users", "users.txt"),
             postProcessorPath = cmd.getOptionValue("post", "postprocessor.json")
         )

--- a/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/HttpServerComponent.kt
@@ -42,6 +42,7 @@ import kotlin.time.Duration.Companion.seconds
 
 class HttpServerComponent(
     private val port: Int,
+    private val tls: Boolean,
     private val eventBus: EventBus,
     private val requestBus: RequestBus,
     private val metricComponent: MetricComponent,
@@ -58,40 +59,52 @@ class HttpServerComponent(
     }
 
     fun start(): EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Configuration> {
-        val keyStoreFile = File("xhrec.keystore")
-        if (!keyStoreFile.exists()) {
-            val ks = buildKeyStore {
-                certificate("xhrec") {
-                    password = "changeit"
-                    domains = listOf("127.0.0.1", "0.0.0.0", "localhost")
-                }
-            }
-            ks.saveToFile(keyStoreFile, "changeit")
-            logger.info("Generated self-signed certificate: {}", keyStoreFile.absolutePath)
-        }
-        val keyStore = KeyStore.getInstance(KeyStore.getDefaultType()).apply {
-            keyStoreFile.inputStream().use { load(it, "changeit".toCharArray()) }
-        }
+        val useTls = this@HttpServerComponent.tls
 
         lateinit var engine: EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Configuration>
+
         engine = embeddedServer(Netty, applicationEnvironment {
             log = LoggerFactory.getLogger("ktor.application")
         }, {
-            // engine config: SSL
-            sslConnector(
-                keyStore = keyStore,
-                keyAlias = "xhrec",
-                keyStorePassword = { "changeit".toCharArray() },
-                privateKeyPassword = { "changeit".toCharArray() }
-            ) {
-                port = this@HttpServerComponent.port
-                keyStorePath = keyStoreFile
+            if (useTls) {
+                // TLS / HTTPS Configuration
+                val keyStoreFile = File("xhrec.keystore")
+                if (!keyStoreFile.exists()) {
+                    val ks = buildKeyStore {
+                        certificate("xhrec") {
+                            password = "changeit"
+                            domains = listOf("127.0.0.1", "0.0.0.0", "localhost")
+                        }
+                    }
+                    ks.saveToFile(keyStoreFile, "changeit")
+                    logger.info("Generated self-signed certificate: {}", keyStoreFile.absolutePath)
+                }
+                val keyStore = KeyStore.getInstance(KeyStore.getDefaultType()).apply {
+                    keyStoreFile.inputStream().use { load(it, "changeit".toCharArray()) }
+                }
+
+                sslConnector(
+                    keyStore = keyStore,
+                    keyAlias = "xhrec",
+                    keyStorePassword = { "changeit".toCharArray() },
+                    privateKeyPassword = { "changeit".toCharArray() }
+                ) {
+                    port = this@HttpServerComponent.port
+                    keyStorePath = keyStoreFile
+                }
+            } else {
+                // Standard HTTP Configuration
+                connector {
+                    port = this@HttpServerComponent.port
+                }
             }
         }) {
             installApplication(this, stopEngine = { engine.stop(1000, 5000) })
         }
+
         engine.start(wait = false)
-        logger.info("HTTP server started on port $port")
+        val protocol = if (useTls) "HTTPS" else "HTTP"
+        logger.info("$protocol server started on port $port")
         return engine
     }
 

--- a/src/main/kotlin/github/rikacelery/v3/data/Config.kt
+++ b/src/main/kotlin/github/rikacelery/v3/data/Config.kt
@@ -6,6 +6,7 @@ data class SystemConfig(
     val outputDir: File,
     val tmpDir: File,
     val port: Int,
+    val tls: Boolean = true,
     val proxy: String?,
     val decryptKeys: Map<String, String>,
     val streamAuthKey: String,

--- a/src/test/kotlin/github/rikacelery/v3/components/ConfigComponentTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/ConfigComponentTest.kt
@@ -47,7 +47,7 @@ class ConfigComponentTest {
         val configPath = tempDir.resolve("xhrec.json").toFile()
         val config = SystemConfig(
             outputDir = tempDir.toFile(), tmpDir = tempDir.toFile(),
-            port = 8080, proxy = null,
+            port = 8080, tls = true, proxy = null,
             decryptKeys = mapOf("key1" to "secret1", "key2" to "secret2"),
             streamAuthKey = "auth-secret", 
             hosts = HostsConfig(platformHosts = listOf("ex.com"), webSocketHosts = listOf("ws.ex.com")),
@@ -121,7 +121,7 @@ class ConfigComponentTest {
         val configPath = tempDir.resolve("xhrec2.json").toFile()
         val config = SystemConfig(
             outputDir = tempDir.toFile(), tmpDir = tempDir.toFile(),
-            port = 8080, proxy = null,
+            port = 8080, tls = true, proxy = null,
             decryptKeys = mapOf("k" to "v"), streamAuthKey = "auth",
              hosts = HostsConfig(platformHosts = listOf("ex.com")),
             configPath = configPath.absolutePath
@@ -166,7 +166,7 @@ class ConfigComponentTest {
         configPath.writeText("{\"platformHosts\":[\"mirror.example.com\"],\"webSocketHosts\":[\"ws.mirror.example.com\"],\"hlsHosts\":[\"cdn.mirror.example.com\"],\"hlsMasterHost\":\"master.mirror.example.com\"}")
         val config = SystemConfig(
             outputDir = tempDir.toFile(), tmpDir = tempDir.toFile(),
-            port = 8080, proxy = null,
+            port = 8080, tls = true, proxy = null,
             decryptKeys = mapOf("k" to "v"), streamAuthKey = "auth",
              hosts = HostsConfig(platformHosts = listOf("default.example.com")),
             configPath = configPath.absolutePath
@@ -189,7 +189,7 @@ class ConfigComponentTest {
         val configPath = tempDir.resolve("xhrec-set.json").toFile()
         val config = SystemConfig(
             outputDir = tempDir.toFile(), tmpDir = tempDir.toFile(),
-            port = 8080, proxy = null,
+            port = 8080, tls = true, proxy = null,
             decryptKeys = mapOf("k" to "v"), streamAuthKey = "auth",
              hosts = HostsConfig(platformHosts = listOf("old.example.com")),
             configPath = configPath.absolutePath

--- a/src/test/kotlin/github/rikacelery/v3/components/HttpRoutesTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/HttpRoutesTest.kt
@@ -197,6 +197,7 @@ class HttpRoutesTest {
         )
         val server = HttpServerComponent(
             port = 0,
+            tls = true,
             eventBus = eventBus,
             requestBus = requestBus,
             metricComponent = MetricComponent(eventBus, scope),

--- a/src/test/kotlin/github/rikacelery/v3/integration/XhrecIntegrationFixture.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/XhrecIntegrationFixture.kt
@@ -237,6 +237,7 @@ class XhrecIntegrationFixture(
         postProcessorComponent = PostProcessorComponent(eventBus, scope)
         httpServer = HttpServerComponent(
             port = 0,
+            tls = true,
             eventBus = eventBus,
             requestBus = requestBus,
             metricComponent = metricComponent,


### PR DESCRIPTION
Can launch with -s/-tls/--tls true/false. Default is true because that is the original behavior. I used -s for SSL because -t is used by --tmp.