### PR TITLE
fix(metrics): the room byte counter is per session, not lifetime

### DIFF
--- a/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
+++ b/src/main/kotlin/github/rikacelery/v3/components/MetricComponent.kt
@@ -24,11 +24,15 @@ data class RoomMetrics(
     val segmentDownloaded: AtomicLong = AtomicLong(0),
     val segmentFailed: AtomicLong = AtomicLong(0),
     val segmentBytes: AtomicLong = AtomicLong(0),
+    // Session bytes: reset when a session starts, because a session that is cut and restarted (a
+    // stream change, a cut, an init change) writes a NEW file from zero. Staying cumulative here
+    // hides exactly the restarts an operator needs to see — one room on the live instance restarts
+    // every ~10s, and a lifetime counter let it read as a healthy 600 MiB room the whole time.
+    val sessionBytes: AtomicLong = AtomicLong(0),
     // lifetime counters (never reset)
     val lifetimeAttempted: AtomicLong = AtomicLong(0),
     val lifetimeDownloaded: AtomicLong = AtomicLong(0),
     val lifetimeFailed: AtomicLong = AtomicLong(0),
-    val lifetimeBytes: AtomicLong = AtomicLong(0),
     // unchanged
     val proxyCount: AtomicLong = AtomicLong(0),
     val directCount: AtomicLong = AtomicLong(0),
@@ -103,7 +107,7 @@ class MetricComponent(
                                 "success" to m.segmentDownloaded.get(),
                                 "failed" to m.segmentFailed.get(),
                                 "bytesWrite" to m.segmentBytes.get(),
-                                "lifetimeBytes" to m.lifetimeBytes.get(),
+                                "sessionBytes" to m.sessionBytes.get(),
                                 "lifetimeDownloaded" to m.lifetimeDownloaded.get(),
                                 "running" to m.runningUrls.mapKeys { it.key }
                                     .mapValues { (_, v) ->
@@ -134,7 +138,7 @@ class MetricComponent(
                     m.segmentDownloaded.incrementAndGet()
                     m.segmentBytes.addAndGet(e.bytes.toLong())
                     m.lifetimeDownloaded.incrementAndGet()
-                    m.lifetimeBytes.addAndGet(e.bytes.toLong())
+                    m.sessionBytes.addAndGet(e.bytes.toLong())
                     synchronized(m) {
                         m.latencySamples.addLast(e.durationMs)
                         if (m.latencySamples.size > 10) m.latencySamples.removeFirst()
@@ -194,7 +198,12 @@ class MetricComponent(
                 }
 
                 is RecordingStarted -> {
-                    metrics.getOrPut(e.roomId) { RoomMetrics() }.quality = e.quality
+                    val m = metrics.getOrPut(e.roomId) { RoomMetrics() }
+                    m.quality = e.quality
+                    // A new session writes a new file, so its byte counter starts over. This is what
+                    // makes a restart visible: without it the counter climbs straight through every
+                    // cut and the room looks healthy while it is actually restarting every ~10s.
+                    m.sessionBytes.set(0)
                     recording.add(e.roomId)
                 }
 
@@ -211,6 +220,7 @@ class MetricComponent(
                         m.segmentDownloaded.set(0)
                         m.segmentFailed.set(0)
                         m.segmentBytes.set(0)
+                        m.sessionBytes.set(0)
                         m.currentSegmentId.set(0)
                         m.quality = ""
                         m.runningUrls.clear()
@@ -266,7 +276,11 @@ class MetricComponent(
         family("xhrec_quality", "Recording quality", "gauge")
         family("xhrec_recording", "A recording session is running for this room (1) or not (0)", "gauge")
         family("xhrec_segment_downloaded_current", "Downloaded in current segment", "gauge")
-        family("xhrec_room_download_bytes_total", "Total bytes downloaded for a room", "counter")
+        family(
+            "xhrec_room_download_bytes_total",
+            "Bytes downloaded in the current recording session (resets when a session starts)",
+            "counter"
+        )
         family("xhrec_cdn_cooldown", "CDN host cooling down for segment downloads (1) or not (0)", "gauge")
         family("xhrec_room_cut_total", "File cuts, by reason", "counter")
         family("xhrec_room_recordings_stopped_total", "Recording sessions that ended, by reason", "counter")
@@ -292,7 +306,6 @@ class MetricComponent(
             sb.appendLine("xhrec_segment_missing_total{roomId=\"$roomId\"} ${m.segmentMissing.get()}")
             sb.appendLine("xhrec_segments_skipped_total{roomId=\"$roomId\"} ${m.segmentsSkipped.get()}")
             sb.appendLine("xhrec_files_total{roomId=\"$roomId\"} ${m.fileCount.get()}")
-            sb.appendLine("xhrec_room_download_bytes_total{roomId=\"$roomId\"} ${m.lifetimeBytes.get()}")
             m.cutReasons.forEach { (reason, count) ->
                 sb.appendLine("xhrec_room_cut_total{roomId=\"$roomId\",reason=\"$reason\"} ${count.get()}")
             }
@@ -319,6 +332,7 @@ class MetricComponent(
                 if (m.refreshLatencySamples.isNotEmpty()) m.refreshLatencySamples.average() else 0.0
             }
             sb.appendLine("xhrec_bytes_write_total{roomId=\"$roomId\"} ${m.segmentBytes.get()}")
+            sb.appendLine("xhrec_room_download_bytes_total{roomId=\"$roomId\"} ${m.sessionBytes.get()}")
             sb.appendLine("xhrec_avg_latency_ms{roomId=\"$roomId\"} $avgLatency")
             sb.appendLine("xhrec_refresh_latency_ms{roomId=\"$roomId\"} $avgRefreshLatency")
             sb.appendLine("xhrec_segment_id_current{roomId=\"$roomId\"} ${m.currentSegmentId.get()}")

--- a/src/test/kotlin/github/rikacelery/v3/components/MetricPrometheusTextTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/components/MetricPrometheusTextTest.kt
@@ -3,6 +3,8 @@ package github.rikacelery.v3.components
 import github.rikacelery.v3.core.EventBus
 import github.rikacelery.v3.events.DownloadStarted
 import github.rikacelery.v3.events.RecordingStarted
+import github.rikacelery.v3.events.RecordingStopped
+import github.rikacelery.v3.events.SegmentDownloaded
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runCurrent
@@ -46,4 +48,44 @@ class MetricPrometheusTextTest {
         Regex("^${Regex.escape(prefix)} ${Regex.escape(family)} ", RegexOption.MULTILINE)
             .findAll(text)
             .count()
+
+    /**
+     * A cut ends the session and a new one starts, writing a new file — so the byte counter has to
+     * start over with it. Kept cumulative, a room that is being cut and restarted every ~10s reads
+     * as a healthy multi-hundred-MB room; that is exactly how a restarting room was hiding in the
+     * "Downloaded Bytes by Room" panel.
+     */
+    @Test
+    fun `the session byte counter resets when a session restarts`() = runTest(UnconfinedTestDispatcher()) {
+        val eventBus = EventBus()
+        val metric = MetricComponent(eventBus, this)
+        metric.start()
+        try {
+            assertTrue(metric.awaitSubscribed(), "metric actor must attach before publishing")
+            eventBus.publish(RecordingStarted(7L, "720p"))
+            eventBus.publish(SegmentDownloaded(7L, 0, "u1", 10L, false, 5_000, 1L))
+            runCurrent()
+            assertTrue(
+                """xhrec_room_download_bytes_total{roomId="7"} 5000""" in metric.prometheusText(),
+                "bytes accumulate inside one session"
+            )
+
+            // The session is cut (a stream change, an init change, a size limit) and restarted.
+            eventBus.publish(RecordingStopped(7L))
+            runCurrent()
+            assertTrue(
+                """xhrec_room_download_bytes_total{roomId="7"}""" !in metric.prometheusText(),
+                "a stopped session withdraws its byte counter rather than freezing it"
+            )
+
+            eventBus.publish(RecordingStarted(7L, "720p"))
+            runCurrent()
+            assertTrue(
+                """xhrec_room_download_bytes_total{roomId="7"} 0""" in metric.prometheusText(),
+                "the restarted session starts from zero instead of carrying the previous total"
+            )
+        } finally {
+            metric.stop()
+        }
+    }
 }

--- a/src/test/kotlin/github/rikacelery/v3/integration/PipelineMetricsIntegrationTest.kt
+++ b/src/test/kotlin/github/rikacelery/v3/integration/PipelineMetricsIntegrationTest.kt
@@ -133,6 +133,10 @@ class PipelineMetricsIntegrationTest {
             """xhrec_room_last_progress_seconds{roomId="1001"}""" in during,
             "the progress clock is exported while the session runs"
         )
+        assertTrue(
+            """xhrec_room_download_bytes_total{roomId="1001"}""" in during,
+            "the session byte counter is exported while the session runs"
+        )
 
         fx.get("/deactivate?id=1001")
 
@@ -142,7 +146,8 @@ class PipelineMetricsIntegrationTest {
                 && """xhrec_segment_id_current{roomId="1001"}""" !in body
                 && """xhrec_downloading_current{roomId="1001"}""" !in body
                 && """xhrec_quality{roomId="1001"""" !in body
-                && """xhrec_room_last_progress_seconds{roomId="1001"}""" !in body).takeIf { it }
+                && """xhrec_room_last_progress_seconds{roomId="1001"}""" !in body
+                && """xhrec_room_download_bytes_total{roomId="1001"}""" !in body).takeIf { it }
         }
         assertTrue(
             gone,
@@ -154,7 +159,6 @@ class PipelineMetricsIntegrationTest {
         // the liveness gauge has to keep answering 0 rather than vanishing.
         val after = fx.get("/metrics").bodyAsText()
         assertTrue("""xhrec_downloaded_total{roomId="1001"}""" in after, "lifetime counters must survive")
-        assertTrue("""xhrec_room_download_bytes_total{roomId="1001"}""" in after, "cumulative bytes must survive")
         assertTrue("""xhrec_recording{roomId="1001"} 0""" in after, "an offline room must report recording=0")
     }
 


### PR DESCRIPTION
## 问题

`Downloaded Bytes by Room` 对一个**每 10 秒被切分重启一次**的房间（147835188）显示成一条平滑上升的 600+ MiB 曲线，完全看不出异常。

实测（docker 上跑的这个 build）：

| room | files | NewInit 切分 | segments | segments/文件 |
|---|---|---|---|---|
| **147835188** | **297** | **286** | 1474 | **5.0** |
| 208569547 | 4 | 1 | 786 | 196 |
| 其它 | 0-3 | 0 | — | — |

根因：站点每次刷新 playlist 都换一个随机的 `EXT-X-MAP` uri（`147835188_init_<rand>.mp4`，主机还在 `.net`/`.org` 之间跳），`SessionComponent` 比的是完整 URL 字符串，于是每次刷新都判定"流变了" → 切文件 + 重开 session。

## 改动

1. **计数器按 session 归零**：`RecordingStarted` 时 reset，`RecordingStopped` 时清除。一次切分就是一次新 session、一个新文件，字节数从 0 开始 —— 重启会以"掉回 0"的形式显示出来，而不是被累计值掩盖。
2. **只在录制中导出** `xhrec_room_download_bytes_total`（和 `xhrec_bytes_write_total` 等 session 指标同一道 gate），停录房间自己从面板消失。
3. **面板去掉 `and on(roomId) (xhrec_recording == 1)`**：这个 join 是按 step 求值的，房间每次重启都会把线切断；而且 8 条 series 在 Grafana 里只渲染出 1 条（左轴最大值恰好只够画那一条）。改成源侧 gate + 面板用原本就能正常渲染的 `A > 0` 写法，重启期由 Prometheus 的 5 分钟 lookback 自动抹平。

## 测试

`338 tests / 0 failures`；新增 `the session byte counter resets when a session restarts`（覆盖 reset、停录后撤下 series、重启从 0 开始三个行为）；`session-scoped series disappear once a room stops recording` 相应更新。